### PR TITLE
Add `--description` flag to create type CLI commands

### DIFF
--- a/cmd/incus/cluster_group.go
+++ b/cmd/incus/cluster_group.go
@@ -176,6 +176,8 @@ func (c *cmdClusterGroupAssign) Run(cmd *cobra.Command, args []string) error {
 type cmdClusterGroupCreate struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
+
+	flagDescription string
 }
 
 // Creation of a new cluster group, defining its usage, short and long descriptions, and the RunE method.
@@ -190,6 +192,8 @@ func (c *cmdClusterGroupCreate) Command() *cobra.Command {
 
 incus cluster group create g1 < config.yaml
 	Create a cluster group with configuration from config.yaml`))
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Cluster group description")+"``")
 
 	cmd.RunE = c.Run
 
@@ -243,6 +247,10 @@ func (c *cmdClusterGroupCreate) Run(cmd *cobra.Command, args []string) error {
 	group := api.ClusterGroupsPost{
 		Name:            resource.name,
 		ClusterGroupPut: stdinData,
+	}
+
+	if c.flagDescription != "" {
+		group.Description = c.flagDescription
 	}
 
 	err = resource.server.CreateClusterGroup(group)

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -158,10 +158,11 @@ type cmdConfigTrustAddCertificate struct {
 	config      *cmdConfig
 	configTrust *cmdConfigTrust
 
-	flagProjects   string
-	flagRestricted bool
-	flagName       string
-	flagType       string
+	flagProjects    string
+	flagRestricted  bool
+	flagName        string
+	flagType        string
+	flagDescription string
 }
 
 func (c *cmdConfigTrustAddCertificate) Command() *cobra.Command {
@@ -180,6 +181,7 @@ The following certificate types are supported:
 	cmd.Flags().StringVar(&c.flagProjects, "projects", "", i18n.G("List of projects to restrict the certificate to")+"``")
 	cmd.Flags().StringVar(&c.flagName, "name", "", i18n.G("Alternative certificate name")+"``")
 	cmd.Flags().StringVar(&c.flagType, "type", "client", i18n.G("Type of certificate")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Certificate description")+"``")
 
 	cmd.RunE = c.Run
 
@@ -246,6 +248,7 @@ func (c *cmdConfigTrustAddCertificate) Run(cmd *cobra.Command, args []string) er
 	cert := api.CertificatesPost{}
 	cert.Certificate = base64.StdEncoding.EncodeToString(x509Cert.Raw)
 	cert.Name = name
+	cert.Description = c.flagDescription
 
 	if c.flagType == "client" {
 		cert.Type = api.CertificateTypeClient

--- a/cmd/incus/create.go
+++ b/cmd/incus/create.go
@@ -34,6 +34,7 @@ type cmdCreate struct {
 	flagNoProfiles      bool
 	flagEmpty           bool
 	flagVM              bool
+	flagDescription     string
 }
 
 func (c *cmdCreate) Command() *cobra.Command {
@@ -63,6 +64,7 @@ incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io.bus=nvme
 	cmd.Flags().BoolVar(&c.flagNoProfiles, "no-profiles", false, i18n.G("Create the instance with no profiles applied"))
 	cmd.Flags().BoolVar(&c.flagEmpty, "empty", false, i18n.G("Create an empty instance"))
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Create a virtual machine"))
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Instance description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
@@ -283,7 +285,12 @@ func (c *cmdCreate) create(conf *config.Config, args []string, launch bool) (inc
 
 	req.Config = configMap
 	req.Ephemeral = c.flagEphemeral
-	req.Description = stdinData.Description
+
+	if c.flagDescription != "" {
+		req.Description = c.flagDescription
+	} else {
+		req.Description = stdinData.Description
+	}
 
 	if !c.flagNoProfiles && len(profiles) == 0 {
 		if len(stdinData.Profiles) > 0 {

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -57,6 +57,8 @@ type cmdImageAliasCreate struct {
 	global     *cmdGlobal
 	image      *cmdImage
 	imageAlias *cmdImageAlias
+
+	flagDescription string
 }
 
 func (c *cmdImageAliasCreate) Command() *cobra.Command {
@@ -65,6 +67,8 @@ func (c *cmdImageAliasCreate) Command() *cobra.Command {
 	cmd.Short = i18n.G("Create aliases for existing images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create aliases for existing images`))
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Image alias description")+"``")
 
 	cmd.RunE = c.Run
 
@@ -111,6 +115,7 @@ func (c *cmdImageAliasCreate) Run(cmd *cobra.Command, args []string) error {
 	alias := api.ImageAliasesPost{}
 	alias.Name = resource.name
 	alias.Target = args[1]
+	alias.Description = c.flagDescription
 
 	return resource.server.CreateImageAlias(alias)
 }

--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -632,7 +632,7 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 	}
 
 	fmt.Printf(i18n.G("Name: %s")+"\n", inst.Name)
-
+	fmt.Printf(i18n.G("Description: %s")+"\n", inst.Description)
 	fmt.Printf(i18n.G("Status: %s")+"\n", strings.ToUpper(inst.Status))
 
 	instType := inst.Type

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -328,6 +328,8 @@ func (c *cmdNetworkAttachProfile) Run(cmd *cobra.Command, args []string) error {
 type cmdNetworkCreate struct {
 	global  *cmdGlobal
 	network *cmdNetwork
+
+	flagDescription string
 }
 
 func (c *cmdNetworkCreate) Command() *cobra.Command {
@@ -346,6 +348,7 @@ incus network create bar network=baz --type ovn
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVarP(&c.network.flagType, "type", "t", "", i18n.G("Network type")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Network description")+"``")
 
 	cmd.RunE = c.Run
 
@@ -398,6 +401,10 @@ func (c *cmdNetworkCreate) Run(cmd *cobra.Command, args []string) error {
 
 	network.Name = resource.name
 	network.Type = c.network.flagType
+
+	if c.flagDescription != "" {
+		network.Description = c.flagDescription
+	}
 
 	if network.Config == nil {
 		network.Config = map[string]string{}

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -371,6 +371,8 @@ func (c *cmdNetworkACLGet) Run(cmd *cobra.Command, args []string) error {
 type cmdNetworkACLCreate struct {
 	global     *cmdGlobal
 	networkACL *cmdNetworkACL
+
+	flagDescription string
 }
 
 func (c *cmdNetworkACLCreate) Command() *cobra.Command {
@@ -382,6 +384,8 @@ func (c *cmdNetworkACLCreate) Command() *cobra.Command {
 
 incus network acl create a1 < config.yaml
     Create network acl with configuration from config.yaml`))
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Network ACL description")+"``")
 
 	cmd.RunE = c.Run
 
@@ -435,6 +439,10 @@ func (c *cmdNetworkACLCreate) Run(cmd *cobra.Command, args []string) error {
 			Name: resource.name,
 		},
 		NetworkACLPut: aclPut,
+	}
+
+	if c.flagDescription != "" {
+		acl.Description = c.flagDescription
 	}
 
 	if acl.Config == nil {
@@ -852,6 +860,7 @@ type cmdNetworkACLRule struct {
 	global          *cmdGlobal
 	networkACL      *cmdNetworkACL
 	flagRemoveForce bool
+	flagDescription string
 }
 
 func (c *cmdNetworkACLRule) Command() *cobra.Command {
@@ -874,6 +883,9 @@ func (c *cmdNetworkACLRule) CommandAdd() *cobra.Command {
 	cmd.Use = usage("add", i18n.G("[<remote>:]<ACL> <direction> <key>=<value>..."))
 	cmd.Short = i18n.G("Add rules to an ACL")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add rules to an ACL"))
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Rule description")+"``")
+
 	cmd.RunE = c.RunAdd
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -985,6 +997,10 @@ func (c *cmdNetworkACLRule) RunAdd(cmd *cobra.Command, args []string) error {
 	rule, err := c.parseConfigToRule(keys)
 	if err != nil {
 		return err
+	}
+
+	if c.flagDescription != "" {
+		rule.Description = c.flagDescription
 	}
 
 	rule.Normalise() // Strip space.

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -315,6 +315,8 @@ func (c *cmdNetworkForwardShow) Run(cmd *cobra.Command, args []string) error {
 type cmdNetworkForwardCreate struct {
 	global         *cmdGlobal
 	networkForward *cmdNetworkForward
+
+	flagDescription string
 }
 
 func (c *cmdNetworkForwardCreate) Command() *cobra.Command {
@@ -330,6 +332,7 @@ incus network forward create n1 127.0.0.1 < config.yaml
 	cmd.RunE = c.Run
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Network forward description")+"``")
 
 	return cmd
 }
@@ -389,6 +392,10 @@ func (c *cmdNetworkForwardCreate) Run(cmd *cobra.Command, args []string) error {
 	forward := api.NetworkForwardsPost{
 		ListenAddress:     args[1],
 		NetworkForwardPut: forwardPut,
+	}
+
+	if c.flagDescription != "" {
+		forward.Description = c.flagDescription
 	}
 
 	forward.Normalise()
@@ -888,6 +895,7 @@ type cmdNetworkForwardPort struct {
 	global          *cmdGlobal
 	networkForward  *cmdNetworkForward
 	flagRemoveForce bool
+	flagDescription string
 }
 
 func (c *cmdNetworkForwardPort) Command() *cobra.Command {
@@ -913,6 +921,7 @@ func (c *cmdNetworkForwardPort) CommandAdd() *cobra.Command {
 	cmd.RunE = c.RunAdd
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Port description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -973,6 +982,7 @@ func (c *cmdNetworkForwardPort) RunAdd(cmd *cobra.Command, args []string) error 
 		Protocol:      args[2],
 		ListenPort:    args[3],
 		TargetAddress: args[4],
+		Description:   c.flagDescription,
 	}
 
 	if len(args) > 5 {

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -319,6 +319,7 @@ func (c *cmdNetworkLoadBalancerShow) Run(cmd *cobra.Command, args []string) erro
 type cmdNetworkLoadBalancerCreate struct {
 	global              *cmdGlobal
 	networkLoadBalancer *cmdNetworkLoadBalancer
+	flagDescription     string
 }
 
 func (c *cmdNetworkLoadBalancerCreate) Command() *cobra.Command {
@@ -334,6 +335,7 @@ incus network load-balancer create n1 127.0.0.1 < config.yaml
 	cmd.RunE = c.Run
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Load balancer description")+"``")
 
 	return cmd
 }
@@ -393,6 +395,10 @@ func (c *cmdNetworkLoadBalancerCreate) Run(cmd *cobra.Command, args []string) er
 	loadBalancer := api.NetworkLoadBalancersPost{
 		ListenAddress:          args[1],
 		NetworkLoadBalancerPut: loadBalancerPut,
+	}
+
+	if c.flagDescription != "" {
+		loadBalancer.Description = c.flagDescription
 	}
 
 	loadBalancer.Normalise()
@@ -868,6 +874,7 @@ func (c *cmdNetworkLoadBalancerDelete) Run(cmd *cobra.Command, args []string) er
 type cmdNetworkLoadBalancerBackend struct {
 	global              *cmdGlobal
 	networkLoadBalancer *cmdNetworkLoadBalancer
+	flagDescription     string
 }
 
 func (c *cmdNetworkLoadBalancerBackend) Command() *cobra.Command {
@@ -893,6 +900,7 @@ func (c *cmdNetworkLoadBalancerBackend) CommandAdd() *cobra.Command {
 	cmd.RunE = c.RunAdd
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Backend description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -948,6 +956,7 @@ func (c *cmdNetworkLoadBalancerBackend) RunAdd(cmd *cobra.Command, args []string
 	backend := api.NetworkLoadBalancerBackend{
 		Name:          args[2],
 		TargetAddress: args[3],
+		Description:   c.flagDescription,
 	}
 
 	if len(args) >= 5 {
@@ -1057,6 +1066,7 @@ type cmdNetworkLoadBalancerPort struct {
 	global              *cmdGlobal
 	networkLoadBalancer *cmdNetworkLoadBalancer
 	flagRemoveForce     bool
+	flagDescription     string
 }
 
 func (c *cmdNetworkLoadBalancerPort) Command() *cobra.Command {
@@ -1082,6 +1092,7 @@ func (c *cmdNetworkLoadBalancerPort) CommandAdd() *cobra.Command {
 	cmd.RunE = c.RunAdd
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Port description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -1138,6 +1149,7 @@ func (c *cmdNetworkLoadBalancerPort) RunAdd(cmd *cobra.Command, args []string) e
 		Protocol:      args[2],
 		ListenPort:    args[3],
 		TargetBackend: util.SplitNTrimSpace(args[4], ",", -1, false),
+		Description:   c.flagDescription,
 	}
 
 	loadBalancer.Ports = append(loadBalancer.Ports, port)

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -310,7 +310,8 @@ type cmdNetworkPeerCreate struct {
 	global      *cmdGlobal
 	networkPeer *cmdNetworkPeer
 
-	flagType string
+	flagType        string
+	flagDescription string
 }
 
 func (c *cmdNetworkPeerCreate) Command() *cobra.Command {
@@ -331,6 +332,7 @@ incus network peer create default peer3 web/default < config.yaml
 	cmd.RunE = c.Run
 
 	cmd.Flags().StringVar(&c.flagType, "type", "local", i18n.G("Type of peer (local or remote)")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Peer description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -424,6 +426,10 @@ func (c *cmdNetworkPeerCreate) Run(cmd *cobra.Command, args []string) error {
 		peer.TargetNetwork = target
 	} else if c.flagType == "remote" {
 		peer.TargetIntegration = target
+	}
+
+	if c.flagDescription != "" {
+		peer.Description = c.flagDescription
 	}
 
 	client := resource.server

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -381,6 +381,8 @@ func (c *cmdNetworkZoneGet) Run(cmd *cobra.Command, args []string) error {
 type cmdNetworkZoneCreate struct {
 	global      *cmdGlobal
 	networkZone *cmdNetworkZone
+
+	flagDescription string
 }
 
 func (c *cmdNetworkZoneCreate) Command() *cobra.Command {
@@ -394,6 +396,8 @@ incus network zone create z1 < config.yaml
     Create network zone z1 with configuration from config.yaml`))
 
 	cmd.RunE = c.Run
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Zone description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -447,6 +451,10 @@ func (c *cmdNetworkZoneCreate) Run(cmd *cobra.Command, args []string) error {
 
 	if zone.Config == nil {
 		zone.Config = map[string]string{}
+	}
+
+	if c.flagDescription != "" {
+		zone.Description = c.flagDescription
 	}
 
 	for i := 1; i < len(args); i++ {
@@ -1065,6 +1073,8 @@ func (c *cmdNetworkZoneRecordGet) Run(cmd *cobra.Command, args []string) error {
 type cmdNetworkZoneRecordCreate struct {
 	global            *cmdGlobal
 	networkZoneRecord *cmdNetworkZoneRecord
+
+	flagDescription string
 }
 
 func (c *cmdNetworkZoneRecordCreate) Command() *cobra.Command {
@@ -1078,6 +1088,8 @@ incus network zone record create z1 r1 < config.yaml
     Create record r1 for zone z1 with configuration from config.yaml`))
 
 	cmd.RunE = c.Run
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Record description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -1134,6 +1146,10 @@ func (c *cmdNetworkZoneRecordCreate) Run(cmd *cobra.Command, args []string) erro
 
 	if record.Config == nil {
 		record.Config = map[string]string{}
+	}
+
+	if c.flagDescription != "" {
+		record.Description = c.flagDescription
 	}
 
 	for i := 2; i < len(args); i++ {

--- a/cmd/incus/profile.go
+++ b/cmd/incus/profile.go
@@ -348,6 +348,8 @@ func (c *cmdProfileCopy) Run(cmd *cobra.Command, args []string) error {
 type cmdProfileCreate struct {
 	global  *cmdGlobal
 	profile *cmdProfile
+
+	flagDescription string
 }
 
 func (c *cmdProfileCreate) Command() *cobra.Command {
@@ -363,6 +365,8 @@ incus profile create p1 < config.yaml
     Create a profile named p1 with configuration from config.yaml`))
 
 	cmd.RunE = c.Run
+
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Profile description")+"``")
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -413,6 +417,10 @@ func (c *cmdProfileCreate) Run(cmd *cobra.Command, args []string) error {
 	profile := api.ProfilesPost{}
 	profile.Name = resource.name
 	profile.ProfilePut = stdinData
+
+	if c.flagDescription != "" {
+		profile.Description = c.flagDescription
+	}
 
 	err = resource.server.CreateProfile(profile)
 	if err != nil {

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -92,9 +92,10 @@ func (c *cmdProject) Command() *cobra.Command {
 
 // Create.
 type cmdProjectCreate struct {
-	global     *cmdGlobal
-	project    *cmdProject
-	flagConfig []string
+	global          *cmdGlobal
+	project         *cmdProject
+	flagConfig      []string
+	flagDescription string
 }
 
 func (c *cmdProjectCreate) Command() *cobra.Command {
@@ -110,6 +111,7 @@ incus project create p1 < config.yaml
     Create a project named p1 with configuration from config.yaml`))
 
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new project")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Project description")+"``")
 
 	cmd.RunE = c.Run
 
@@ -173,6 +175,10 @@ func (c *cmdProjectCreate) Run(cmd *cobra.Command, args []string) error {
 
 			project.Config[key] = value
 		}
+	}
+
+	if c.flagDescription != "" {
+		project.Description = c.flagDescription
 	}
 
 	err = resource.server.CreateProject(project)

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -87,6 +87,8 @@ func (c *cmdStorageBucket) Command() *cobra.Command {
 type cmdStorageBucketCreate struct {
 	global        *cmdGlobal
 	storageBucket *cmdStorageBucket
+
+	flagDescription string
 }
 
 func (c *cmdStorageBucketCreate) Command() *cobra.Command {
@@ -101,6 +103,8 @@ incus storage bucket create p1 b01 < config.yaml
 	Create a new storage bucket named b01 in storage pool p1 using the content of config.yaml`))
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Bucket description")+"``")
+
 	cmd.RunE = c.Run
 
 	return cmd
@@ -161,6 +165,10 @@ func (c *cmdStorageBucketCreate) Run(cmd *cobra.Command, args []string) error {
 	bucket := api.StorageBucketsPost{
 		Name:             args[1],
 		StorageBucketPut: bucketPut,
+	}
+
+	if c.flagDescription != "" {
+		bucket.Description = c.flagDescription
 	}
 
 	client := resource.server
@@ -1018,6 +1026,7 @@ type cmdStorageBucketKeyCreate struct {
 	flagRole         string
 	flagAccessKey    string
 	flagSecretKey    string
+	flagDescription  string
 }
 
 func (c *cmdStorageBucketKeyCreate) Command() *cobra.Command {
@@ -1037,6 +1046,7 @@ incus storage bucket key create p1 b01 k1 < config.yaml
 	cmd.Flags().StringVar(&c.flagRole, "role", "read-only", i18n.G("Role (admin or read-only)")+"``")
 	cmd.Flags().StringVar(&c.flagAccessKey, "access-key", "", i18n.G("Access key (auto-generated if empty)")+"``")
 	cmd.Flags().StringVar(&c.flagSecretKey, "secret-key", "", i18n.G("Secret key (auto-generated if empty)")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Key description")+"``")
 
 	return cmd
 }
@@ -1104,6 +1114,10 @@ func (c *cmdStorageBucketKeyCreate) RunAdd(cmd *cobra.Command, args []string) er
 
 	if c.flagSecretKey != "" {
 		req.SecretKey = c.flagSecretKey
+	}
+
+	if c.flagDescription != "" {
+		req.Description = c.flagDescription
 	}
 
 	key, err := client.CreateStoragePoolBucketKey(resource.name, args[1], req)

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -570,6 +570,7 @@ type cmdStorageVolumeCreate struct {
 	storage         *cmdStorage
 	storageVolume   *cmdStorageVolume
 	flagContentType string
+	flagDescription string
 }
 
 func (c *cmdStorageVolumeCreate) Command() *cobra.Command {
@@ -586,6 +587,8 @@ incus storage volume create default foo < config.yaml
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagContentType, "type", "filesystem", i18n.G("Content type, block or filesystem")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Volume description")+"``")
+
 	cmd.RunE = c.Run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -655,6 +658,10 @@ func (c *cmdStorageVolumeCreate) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		vol.Config[entry[0]] = entry[1]
+	}
+
+	if c.flagDescription != "" {
+		vol.Description = c.flagDescription
 	}
 
 	// If a target was specified, create the volume on the given member.
@@ -2314,8 +2321,9 @@ type cmdStorageVolumeSnapshotCreate struct {
 	storageVolume         *cmdStorageVolume
 	storageVolumeSnapshot *cmdStorageVolumeSnapshot
 
-	flagNoExpiry bool
-	flagReuse    bool
+	flagNoExpiry    bool
+	flagReuse       bool
+	flagDescription string
 }
 
 func (c *cmdStorageVolumeSnapshotCreate) Command() *cobra.Command {
@@ -2333,6 +2341,8 @@ incus storage volume snapshot create default vol1 snap0 < config.yaml
 	cmd.Flags().BoolVar(&c.flagNoExpiry, "no-expiry", false, i18n.G("Ignore any configured auto-expiry for the storage volume"))
 	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the snapshot name already exists, delete and create a new one"))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Snapshot description")+"``")
+
 	cmd.RunE = c.Run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -31,7 +31,7 @@ msgstr "  Firmware:"
 msgid "  Motherboard:"
 msgstr "  Mainboard:"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -56,7 +56,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -87,7 +87,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -113,7 +113,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -126,7 +126,7 @@ msgstr ""
 "### Beachten Sie, dass der Fingerabdruck angezeigt wird, aber nicht geändert "
 "werden kann."
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -233,7 +233,7 @@ msgstr ""
 "###       template: template.tpl\n"
 "###       properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -279,7 +279,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -334,7 +334,7 @@ msgstr ""
 "### Beachten Sie, dass der Name angezeigt wird, aber nicht geändert werden "
 "kann."
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -386,7 +386,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -416,7 +416,7 @@ msgstr ""
 "### Beachten Sie, dass die Felder name, target_project, target_network und "
 "status nicht geändert werden können."
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -442,7 +442,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -468,7 +468,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -506,7 +506,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -545,7 +545,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern."
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -671,7 +671,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty kann nicht mit einem image namen kombiniert werden"
 
@@ -790,7 +790,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -815,12 +815,12 @@ msgstr "Authentifizierungstyp"
 msgid "Accept certificate"
 msgstr "Akzeptiere das Zertifikat"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 "Zugangsschlüssel (wird automatisch generiert, wenn nichts angegeben wird)"
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr "Zugangsschlüssel: %s"
@@ -843,25 +843,25 @@ msgstr "Aktion %q wird von diesem Programm nicht unterstützt"
 msgid "Action (defaults to GET)"
 msgstr "Aktion (Standard ist: GET)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Cluster Mitglied zu einer Cluster Gruppe hinzufügen:"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Füge einen Netzwerk Zonen Eintrag hinzu"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr "Backend zu einem Load Balancer hinzufügen"
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr "Backends zu einem load balancer hinzufügen"
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr "Einträge zu einem Netzwerkzonen-Datensatz hinzufügen"
 
@@ -869,7 +869,7 @@ msgstr "Einträge zu einem Netzwerkzonen-Datensatz hinzufügen"
 msgid "Add instance devices"
 msgstr "Füge Devices zu einer Instanz hinzu"
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr "Mitglied zu einer Gruppe hinzufügen"
 
@@ -906,12 +906,12 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr "Vertrauenswürdigen Client hinzufügen"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -937,12 +937,12 @@ msgstr ""
 "Dies stellt einen Trust-Token aus, der vom Client verwendet wird, um sich "
 "selbst zum Trust Store hinzuzufügen.\"\n"
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr "Ports zu einem Network Forward hinzufügen"
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr "Ports zu einem Load Balancer hinzufügen"
 
@@ -954,7 +954,7 @@ msgstr "Profile zu Instanzen hinzufügen"
 msgid "Add roles to a cluster member"
 msgstr "Rollen einem Cluster Mitglied hinzufügen"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr "Regeln zu einer Zugangskontrollliste (ACL) hinzufügen"
 
@@ -984,12 +984,12 @@ msgstr "Adresse: %s"
 msgid "Address: %v"
 msgstr "Adresse: %v"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Administrator Zugangsschlüssel: %s"
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Administrator Geheimer Schlüssel: %s"
@@ -1004,8 +1004,8 @@ msgstr "Alias %s existiert bereits"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s existiert nicht"
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr "Aliasbezeichnung fehlt"
 
@@ -1029,7 +1029,7 @@ msgstr ""
 "Alle existierenden Dateien sind verloren, wenn sie dem Cluster beitreten, "
 "Vorgang fortsetzen?"
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr "Alle Projekte"
 
@@ -1037,7 +1037,7 @@ msgstr "Alle Projekte"
 msgid "All server addresses are unavailable"
 msgstr "Alle Server Adressen sind nicht erreichbar"
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Alternativer Zertifikatsbezeichnung"
@@ -1070,7 +1070,7 @@ msgstr ""
 "Da keines der genannten Programme gefunden werden konnte, finden Sie hier "
 "den SPICE Socket zum manuellen verbinden:"
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 #, fuzzy
 msgid "Asked for a VM but image is of type container"
 msgstr ""
@@ -1164,7 +1164,11 @@ msgstr "Durchschnitt: %.2f %.2f %.2f"
 msgid "BASE IMAGE"
 msgstr "BASIS ABBILD"
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr "Backend Status:"
 
@@ -1173,22 +1177,22 @@ msgstr "Backend Status:"
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr "Backup erfolgreich exportiert!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr "Sicherungen:"
 
@@ -1199,22 +1203,22 @@ msgstr ""
 "Ungültige Gerätüberschreibungs-Syntax, erwartet wird <Gerät>,"
 "<Schlüssel>=<Wert>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ungültiges key/value Paar: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ungültiges key=value Paar: %s"
@@ -1224,7 +1228,7 @@ msgstr "Ungültiges key=value Paar: %s"
 msgid "Bad property: %s"
 msgstr "Ungültige Eigenschaft: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr "Link-Bündelung:"
 
@@ -1237,20 +1241,25 @@ msgstr "Sowohl --all als auch ein Instanzname angegeben"
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr "Netzwerk-Brücke:"
+
+#: cmd/incus/storage_bucket.go:106
+#, fuzzy
+msgid "Bucket description"
+msgstr "Fingerabdruck: %s\n"
 
 #: cmd/incus/info.go:365
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Bus Adresse: %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1258,11 +1267,11 @@ msgstr "Bytes gesendet"
 msgid "CANCELABLE"
 msgstr "ABBRECHBAR"
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "ALLGEMEINER NAME"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr "INHALTS-TYP"
 
@@ -1354,7 +1363,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr "\"Kann --fast nicht zusammen mit --columns angeben.\""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr "Kann --project nicht zusammen mit --all-projects angeben"
 
@@ -1362,7 +1371,7 @@ msgstr "Kann --project nicht zusammen mit --all-projects angeben"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1401,7 +1410,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr "Kann kein Image mit --empty verwenden"
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1425,7 +1434,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Kann --volume-only nicht setzen, wenn ein Snapshot kopiert wird"
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "Kann Schlüssel nicht setzen: %s"
@@ -1444,10 +1453,15 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "\"Zertifikat-Token für %s gelöscht\""
+
+#: cmd/incus/config_trust.go:184
+#, fuzzy
+msgid "Certificate description"
+msgstr "Fingerprint des Zertifikats: %s"
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1466,7 +1480,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerprint des Zertifikats: %s"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1494,25 +1508,30 @@ msgstr "Client-Zertifikat wird nun vom Server als vertrauenswürdig behandelt:"
 msgid "Client version: %s\n"
 msgstr "Client Version: %s\n"
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr "Cluster-Gruppe %s erstellt"
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "Cluster-Gruppe %s gelöscht\""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "Cluster-Gruppe %s erstellt"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1524,57 +1543,57 @@ msgstr "\"Join-Token für Cluster %s:%s gelöscht\""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "%s als Mitglied zu den Cluster-Gruppen %s hinzugefügt"
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr "Cluster-Mitgliedsname"
 
@@ -1583,17 +1602,17 @@ msgid "Clustering enabled"
 msgstr "Clustering aktiviert"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Spalten"
@@ -1629,7 +1648,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1639,7 +1658,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new network integration"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1653,16 +1672,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1685,11 +1704,11 @@ msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1831,7 +1850,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1840,7 +1859,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1849,16 +1868,16 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1895,12 +1914,12 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 #, fuzzy
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1910,12 +1929,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create network integrations"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1925,67 +1944,67 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
@@ -1995,7 +2014,7 @@ msgstr "Erstelle %s"
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2009,16 +2028,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -2030,7 +2049,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr ""
 
@@ -2053,11 +2072,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2069,7 +2088,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -2077,7 +2096,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2087,7 +2106,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2110,16 +2129,16 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Delete instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2128,49 +2147,49 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2193,12 +2212,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2213,11 +2232,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2225,31 +2244,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2257,45 +2276,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2303,64 +2322,64 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Storage Volumes zu Profilen hinzufügen"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2430,7 +2449,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr ""
@@ -2493,7 +2512,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2502,7 +2521,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2553,7 +2572,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2586,7 +2605,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2599,13 +2618,13 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
@@ -2615,7 +2634,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2648,16 +2667,16 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2667,53 +2686,53 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network integration configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 #, fuzzy
 msgid ""
 "Edit storage volume configurations as YAML\n"
@@ -2723,23 +2742,23 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2775,7 +2794,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 #, fuzzy
 msgid "Entry TTL"
 msgstr "Eingangs TTL"
@@ -2785,7 +2804,7 @@ msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 "Festzulegende Umgebungsvariable (Environment variable) (z.B. HOME=/home/foo)"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Kurzlebiger Container"
@@ -2810,15 +2829,15 @@ msgstr "Fehler beim Dekodieren der Datei(en): %v"
 msgid "Error retrieving aliases: %w"
 msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim Festlegen der Parameter: %v"
@@ -2833,14 +2852,14 @@ msgstr "Fehler beim setzen der Größe des Terminals/der Konsole %s"
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim Löschen der Parameter: %v"
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Fehler beim Löschen des Parameters: %v"
@@ -2981,8 +3000,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 #, fuzzy
 msgid "Expires at"
 msgstr "Wird gelöscht am"
@@ -3013,7 +3032,7 @@ msgstr ""
 "angegeben wird, wird die resultierende Datei im derzeit aktiven Ordner/Pfad "
 "gespeichert."
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr "Storage Volume exportieren"
 
@@ -3026,25 +3045,25 @@ msgstr "Backups einer Instanz exportieren"
 msgid "Export instances as backup tarballs."
 msgstr "Instanzen als Backup Dateien (.tar) exportieren."
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr "Storage Buckets exportieren"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Storage Buckets als Dateien (.tar) exportieren."
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr "Storage Volume ohne Snapshots exportieren"
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup des Storage Bucket %s wird exportiert"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Backup %s wird exportiert"
@@ -3062,8 +3081,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 #, fuzzy
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -3147,7 +3166,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed getting existing storage pools: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3157,17 +3176,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3256,7 +3275,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Akzeptiere Zertifikat"
@@ -3266,7 +3285,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3276,12 +3295,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3428,7 +3447,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -3449,7 +3468,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3513,19 +3532,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3542,7 +3561,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3593,16 +3612,16 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3611,11 +3630,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3628,7 +3647,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3638,17 +3657,17 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3657,30 +3676,30 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3689,7 +3708,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3714,11 +3733,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3728,13 +3747,13 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3744,34 +3763,34 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 #, fuzzy
 msgid ""
 "Get values for storage volume configuration keys\n"
@@ -3793,7 +3812,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3831,7 +3850,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3845,7 +3864,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3858,7 +3877,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3867,30 +3886,30 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3902,7 +3921,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3916,7 +3935,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3928,6 +3947,10 @@ msgstr ""
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
+msgstr ""
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -3972,17 +3995,17 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4003,29 +4026,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4035,7 +4058,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -4059,6 +4082,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "Entferntes Administrator Passwort"
+
 #: cmd/incus/file.go:1473
 #, fuzzy
 msgid "Instance disconnected"
@@ -4073,7 +4101,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4092,7 +4120,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -4101,8 +4129,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
@@ -4122,8 +4150,8 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid arguments"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -4133,7 +4161,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 #, fuzzy
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
@@ -4213,7 +4241,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -4223,7 +4251,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Ungültiges Ziel %s"
@@ -4233,9 +4261,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -4286,6 +4314,11 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+#, fuzzy
+msgid "Key description"
+msgstr "Fingerabdruck: %s\n"
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -4294,7 +4327,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -4302,10 +4335,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4323,12 +4356,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4343,11 +4376,11 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4376,12 +4409,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4430,12 +4463,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4580,7 +4613,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4612,11 +4645,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4637,11 +4670,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4696,11 +4729,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4943,12 +4976,12 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4957,11 +4990,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4977,11 +5010,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -5002,12 +5035,12 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -5029,12 +5062,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5057,12 +5090,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5076,12 +5109,12 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -5130,11 +5163,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5190,11 +5223,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5207,7 +5244,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -5228,17 +5265,17 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 #, fuzzy
 msgid "Lower device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 #, fuzzy
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5247,7 +5284,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -5261,11 +5298,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5286,11 +5323,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5298,7 +5335,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5401,7 +5438,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5410,7 +5447,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5425,14 +5462,14 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5447,12 +5484,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5472,12 +5509,12 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5497,7 +5534,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5606,30 +5643,30 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -5639,32 +5676,32 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 #, fuzzy
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5678,10 +5715,10 @@ msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5694,87 +5731,87 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing network integration name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5788,12 +5825,12 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5802,12 +5839,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5833,8 +5870,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5848,7 +5885,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5879,7 +5916,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5888,11 +5925,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5906,15 +5943,15 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5922,11 +5959,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5943,9 +5980,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5969,8 +6006,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -6034,8 +6071,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -6045,60 +6082,75 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/network_zone.go:475
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/network_forward.go:416
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/network_integration.go:160
 #, fuzzy, c-format
@@ -6115,57 +6167,57 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network integration %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -6178,7 +6230,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6188,7 +6240,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -6198,29 +6250,29 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -6228,11 +6280,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6273,7 +6325,7 @@ msgstr ""
 msgid "OS Version"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -6281,11 +6333,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6297,11 +6349,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6325,7 +6377,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6373,19 +6425,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6397,11 +6449,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -6433,6 +6485,11 @@ msgstr ""
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: cmd/incus/network_peer.go:335
+#, fuzzy
+msgid "Peer description"
+msgstr "Fingerabdruck: %s\n"
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6458,6 +6515,11 @@ msgstr ""
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
 msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+#, fuzzy
+msgid "Port description"
+msgstr "Fingerabdruck: %s\n"
 
 #: cmd/incus/admin_init_interactive.go:816
 msgid "Port to bind to"
@@ -6497,17 +6559,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6562,37 +6624,42 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: cmd/incus/profile.go:369
+#, fuzzy
+msgid "Profile description"
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/image.go:161
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6617,20 +6684,25 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: cmd/incus/project.go:114
+#, fuzzy
+msgid "Project description"
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/remote.go:124
 msgid "Project to use for the remote"
@@ -6650,7 +6722,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6706,15 +6778,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6736,6 +6808,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#: cmd/incus/network_zone.go:1092
+#, fuzzy
+msgid "Record description"
+msgstr "Fingerabdruck: %s\n"
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6783,7 +6860,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -6822,14 +6899,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6838,7 +6915,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -6848,25 +6925,25 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6876,22 +6953,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6905,7 +6982,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6915,11 +6992,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6927,12 +7004,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6947,7 +7024,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Rename instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6956,16 +7033,16 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -6974,17 +7051,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
@@ -7028,7 +7105,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -7038,7 +7115,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -7052,12 +7129,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7067,7 +7144,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -7075,6 +7152,11 @@ msgstr ""
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
+
+#: cmd/incus/network_acl.go:887
+#, fuzzy
+msgid "Rule description"
+msgstr "Fingerabdruck: %s\n"
 
 #: cmd/incus/remote_unix.go:36
 msgid "Run a local API proxy"
@@ -7114,7 +7196,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -7142,9 +7224,9 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STARTED AT"
 msgstr "ERSTELLT AM"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -7160,7 +7242,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -7168,11 +7250,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -7180,11 +7262,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
@@ -7227,7 +7309,7 @@ msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -7249,7 +7331,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7304,12 +7386,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7318,11 +7400,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7331,12 +7413,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7360,12 +7442,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7374,12 +7456,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7388,12 +7470,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7402,16 +7484,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7420,12 +7502,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7434,12 +7516,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7448,12 +7530,12 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7462,12 +7544,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -7513,7 +7595,7 @@ msgstr "Setzt die uid der Datei beim Übertragen"
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7522,11 +7604,11 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7536,49 +7618,49 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7607,7 +7689,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
@@ -7676,7 +7758,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7706,44 +7788,44 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 #, fuzzy
 msgid ""
 "Show storage volume configurations\n"
@@ -7756,22 +7838,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 #, fuzzy
 msgid ""
 "Show storage volume state information\n"
@@ -7781,7 +7863,7 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7793,7 +7875,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
@@ -7807,15 +7889,15 @@ msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Profil %s erstellt\n"
@@ -7829,7 +7911,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7851,16 +7933,20 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7912,7 +7998,7 @@ msgstr ""
 msgid "State"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
@@ -7949,22 +8035,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Profil %s erstellt\n"
@@ -7983,22 +8069,27 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool %q of type %q"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 #, fuzzy
 msgid "Storage pool name"
@@ -8009,12 +8100,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Storage pool to use or create"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -8029,7 +8120,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s gelöscht\n"
@@ -8062,7 +8153,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -8078,7 +8169,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8086,20 +8177,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -8174,7 +8265,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -8196,7 +8287,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -8204,7 +8295,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8233,7 +8324,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8253,12 +8344,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8268,7 +8359,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8278,7 +8369,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8288,37 +8379,37 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8369,13 +8460,13 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -8429,11 +8520,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -8449,7 +8540,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8457,7 +8548,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -8473,7 +8564,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8503,7 +8594,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8521,7 +8612,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
@@ -8532,18 +8623,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8555,7 +8646,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8569,11 +8660,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -8601,7 +8692,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, fuzzy, c-format
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8612,17 +8703,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8638,7 +8729,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, fuzzy, c-format
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8648,7 +8739,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -8677,21 +8768,21 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8701,60 +8792,60 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 #, fuzzy
 msgid ""
 "Unset storage volume configuration keys\n"
@@ -8764,7 +8855,7 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -8773,11 +8864,11 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8787,50 +8878,50 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8844,7 +8935,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8873,17 +8964,17 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 #, fuzzy
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8907,7 +8998,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8922,15 +9013,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8974,9 +9065,14 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+#, fuzzy
+msgid "Volume description"
+msgstr "Fingerabdruck: %s\n"
 
 #: cmd/incus/info.go:307
 #, c-format
@@ -9132,9 +9228,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -9167,7 +9263,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+#, fuzzy
+msgid "Zone description"
+msgstr "Fingerabdruck: %s\n"
+
+#: cmd/incus/storage_volume.go:865
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9184,12 +9285,12 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9214,7 +9315,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr ""
@@ -9223,7 +9324,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -9240,7 +9341,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -9250,7 +9351,7 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -9258,7 +9359,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -9266,7 +9367,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -9274,7 +9375,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -9282,7 +9383,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9290,7 +9391,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -9307,8 +9408,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -9316,7 +9417,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -9324,7 +9425,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9332,7 +9433,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9340,7 +9441,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9349,7 +9450,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -9358,7 +9459,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9366,8 +9467,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -9376,8 +9477,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -9385,7 +9486,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr ""
@@ -9393,7 +9494,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
@@ -9401,7 +9502,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -9451,7 +9552,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9544,7 +9645,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9698,8 +9799,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -9792,8 +9893,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
@@ -9803,7 +9904,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -9819,7 +9920,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -9827,7 +9928,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -9835,11 +9936,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -9847,7 +9948,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -9855,7 +9956,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -9865,9 +9966,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -9875,7 +9976,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -9883,7 +9984,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -9893,13 +9994,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9907,7 +10008,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -9915,7 +10016,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -9931,7 +10032,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -9939,7 +10040,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -9949,7 +10050,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -9957,7 +10058,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -9965,7 +10066,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -9981,7 +10082,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -9997,8 +10098,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10006,7 +10107,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -10014,7 +10115,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10022,8 +10123,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -10031,9 +10132,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -10041,7 +10142,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -10049,7 +10150,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -10058,7 +10159,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -10066,7 +10167,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -10074,7 +10175,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -10082,7 +10183,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -10090,7 +10191,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10098,7 +10199,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10106,7 +10207,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10122,7 +10223,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10131,7 +10232,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10140,7 +10241,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10149,7 +10250,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10158,7 +10259,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10166,7 +10267,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10175,7 +10276,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10183,8 +10284,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10192,7 +10293,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10200,7 +10301,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10208,7 +10309,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10217,7 +10318,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10234,8 +10335,8 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10267,7 +10368,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10275,7 +10376,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10291,7 +10392,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10307,8 +10408,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10316,7 +10417,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10324,7 +10425,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10332,7 +10433,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10358,7 +10459,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -10366,8 +10467,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -10375,7 +10476,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -10383,7 +10484,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -10391,7 +10492,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -10399,7 +10500,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -10463,11 +10564,11 @@ msgstr ""
 msgid "application"
 msgstr "Eigenschaften:\n"
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -10475,7 +10576,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -10532,7 +10633,7 @@ msgstr ""
 "    Setzt die Gruppen des Clustermitglied zurück und weist nur die Gruppe "
 "\"default\" zu."
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10574,7 +10675,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -10586,7 +10687,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -10725,7 +10826,7 @@ msgstr ""
 "\n"
 "lxc move <Quelle> <Ziel>\n"
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -10733,7 +10834,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -10745,7 +10846,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -10770,7 +10871,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -10779,7 +10880,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -10795,7 +10896,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -10803,7 +10904,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10841,7 +10942,7 @@ msgstr ""
 "incus profile assign foo ''\n"
 "    Die Profile der Instanz \"foo\" zurücksetzen und kein Profil zuweisen."
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 #, fuzzy
 msgid ""
 "incus profile create p1\n"
@@ -10876,7 +10977,7 @@ msgstr ""
 "   Mounted das Storage Volume \"some-volume\" im Storage pool \"some-pool\" "
 "in den Dateipfad \"/opt\" innerhalb der Instanz."
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -10885,7 +10986,7 @@ msgstr ""
 "   Automatisches Editieren eines Profils mithilfe der Konfigurationsdatei "
 "\"profile.yaml\""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 #, fuzzy
 msgid ""
 "incus project create p1\n"
@@ -10901,7 +11002,7 @@ msgstr ""
 "    Erstellt ein Projekt namens \"p1\" mit der Konfigurationsdatei \"config."
 "yaml\""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10946,7 +11047,7 @@ msgstr ""
 "incus snapshot restore u1 snap0\n"
 "Stellt den Zustand vom snapshot \"snap0\" für die Instanz \"u1\" wieder her."
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid ""
 "incus storage bucket create p1 b01\n"
@@ -10964,7 +11065,7 @@ msgstr ""
 "\tErstellt einen neuen storage bucket genannt \"b01\" im storage pool \"p1\" "
 "unter Nutzung der Konfigurationsdatei \"config.yaml\""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
@@ -10973,7 +11074,7 @@ msgstr ""
 "    Automatisches Editieren eines storage bucket mithilfe der "
 "Konfigurationsdetails aus der Datei \"bucket.yaml\"."
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
@@ -10982,7 +11083,7 @@ msgstr ""
 "    Automatisches Editieren eines storage bucket Schlüssels mithilfe der "
 "Konfigurationsdetails aus der Datei \"key.yaml\"."
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy
 msgid ""
 "incus storage bucket export default b1\n"
@@ -10992,7 +11093,7 @@ msgstr ""
 "    Erstellen einer Sicherungsdatei (backup) vom storage bucket namens "
 "\"b1\" im pool \"default\"."
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
@@ -11000,7 +11101,7 @@ msgstr ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tErstellt einen neuen storage bucket aus der Datei \"backup0.tar.gz\"."
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -11018,7 +11119,7 @@ msgstr ""
 "pool \"p1\" unter Nutzung der Konfigurationsdetails aus der Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
@@ -11028,7 +11129,7 @@ msgstr ""
 "        Zeigt die Eigenschaften eines storage bucket Schlüssels genannt "
 "\"foo\" für einen storage bucket namens \"data\" im pool \"default\"."
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -11038,7 +11139,7 @@ msgstr ""
 "    Zeigt die Eigenschaften eines storage bucket namens \"data\" im pool "
 "\"default\"."
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -11047,7 +11148,7 @@ msgstr ""
 "    Automatisches Editieren der Konfiguration des storage pool mit den "
 "Konfigurationsdetails aus der Datei \"pool.yaml\"."
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 #, fuzzy
 msgid ""
 "incus storage volume create default foo\n"
@@ -11066,7 +11167,7 @@ msgstr ""
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 #, fuzzy
 msgid ""
 "incus storage volume edit default container/c1\n"
@@ -11085,7 +11186,7 @@ msgstr ""
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11095,7 +11196,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11105,7 +11206,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11115,7 +11216,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11125,7 +11226,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11139,7 +11240,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 #, fuzzy
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
@@ -11158,7 +11259,7 @@ msgstr ""
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -11168,7 +11269,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr "Info"
 
@@ -11176,11 +11277,11 @@ msgstr "Info"
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr "Name"
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr "nein"
@@ -11194,7 +11295,7 @@ msgstr "ok (j/n/[fingerprint])?"
 msgid "please use `incus profile`"
 msgstr "bitte nutzen Sie ìncus profile`"
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr "Speicherplatz in Benutzung"
 
@@ -11213,7 +11314,7 @@ msgstr ""
 "sshfs wurde nicht gefunden. Versuchen Sie stattdessen SSH SFTP Modus mit dem "
 "\"--listen\" Argument"
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr "Gesamter Speicherplatz"
 
@@ -11221,7 +11322,7 @@ msgstr "Gesamter Speicherplatz"
 msgid "unreachable"
 msgstr "nicht erreichbar"
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr "wird benutzt von"
 
@@ -11229,9 +11330,9 @@ msgstr "wird benutzt von"
 msgid "y"
 msgstr "j"
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -59,7 +59,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -91,7 +91,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -120,7 +120,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -241,7 +241,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -284,7 +284,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -336,7 +336,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -385,7 +385,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -417,7 +417,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -446,7 +446,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -475,7 +475,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -510,7 +510,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -546,7 +546,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -666,7 +666,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -778,7 +778,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expira: %s"
@@ -828,25 +828,25 @@ msgstr "El filtrado no está soportado aún"
 msgid "Action (defaults to GET)"
 msgstr "Accion (predeterminados a GET)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -883,12 +883,12 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -905,12 +905,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -950,12 +950,12 @@ msgstr "Expira: %s"
 msgid "Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
@@ -970,8 +970,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1113,7 +1113,12 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+#, fuzzy
+msgid "Backend description"
+msgstr "Descripción"
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -1122,22 +1127,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -1146,22 +1151,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1171,7 +1176,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -1185,20 +1190,25 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+#, fuzzy
+msgid "Bucket description"
+msgstr "Descripción"
 
 #: cmd/incus/info.go:365
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1206,11 +1216,11 @@ msgstr "Bytes enviados"
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1304,7 +1314,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr "No se puede especificar --fast con --columns"
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1313,7 +1323,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1347,7 +1357,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1366,7 +1376,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1381,10 +1391,15 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
+
+#: cmd/incus/config_trust.go:184
+#, fuzzy
+msgid "Certificate description"
+msgstr "Certificado de la huella digital: %s"
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1403,7 +1418,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1432,25 +1447,30 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "Perfil %s creado"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1462,57 +1482,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1521,17 +1541,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Columnas"
@@ -1560,7 +1580,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1570,7 +1590,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config key/value to apply to the new network integration"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1583,16 +1603,16 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1614,11 +1634,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1758,7 +1778,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1767,7 +1787,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1776,16 +1796,16 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
@@ -1821,11 +1841,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1834,12 +1854,12 @@ msgstr ""
 msgid "Create network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1847,60 +1867,60 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
@@ -1910,7 +1930,7 @@ msgstr "Creando %s"
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1924,16 +1944,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1945,7 +1965,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
@@ -1968,11 +1988,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1984,7 +2004,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1992,7 +2012,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2001,7 +2021,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
@@ -2023,15 +2043,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Delete instances"
 msgstr "Eliminar imágenes"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2040,48 +2060,48 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2104,12 +2124,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2124,11 +2144,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2136,31 +2156,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2168,45 +2188,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2214,63 +2234,63 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descripción"
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2332,7 +2352,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2394,7 +2414,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2403,7 +2423,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2454,7 +2474,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2483,7 +2503,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2496,13 +2516,13 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
@@ -2512,7 +2532,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2540,15 +2560,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2557,53 +2577,53 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2612,22 +2632,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2661,7 +2681,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2669,7 +2689,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2693,15 +2713,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2716,14 +2736,14 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2814,8 +2834,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2840,7 +2860,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2854,26 +2874,26 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2891,8 +2911,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -2974,7 +2994,7 @@ msgstr "Acepta certificado"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2984,17 +3004,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
@@ -3083,7 +3103,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Acepta certificado"
@@ -3093,7 +3113,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
@@ -3103,12 +3123,12 @@ msgstr "Acepta certificado"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
@@ -3255,7 +3275,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -3273,7 +3293,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3337,19 +3357,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3366,7 +3386,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3416,16 +3436,16 @@ msgstr "Acepta certificado"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Perfil %s creado"
@@ -3434,11 +3454,11 @@ msgstr "Perfil %s creado"
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Perfil %s creado"
@@ -3451,7 +3471,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -3461,17 +3481,17 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3480,29 +3500,29 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3510,7 +3530,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Perfil %s creado"
@@ -3532,11 +3552,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
@@ -3546,13 +3566,13 @@ msgstr "Perfil %s creado"
 msgid "Get values for network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
@@ -3562,33 +3582,33 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3609,7 +3629,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3647,7 +3667,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3661,7 +3681,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3674,7 +3694,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3683,30 +3703,30 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "Expira: %s"
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "Expira: %s"
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3718,7 +3738,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3732,7 +3752,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3742,6 +3762,10 @@ msgstr ""
 
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
+msgstr ""
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
 msgstr ""
 
 #: cmd/incus/image.go:1482
@@ -3786,16 +3810,16 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Perfil %s creado"
@@ -3816,29 +3840,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3848,7 +3872,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3874,6 +3898,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "Descripción"
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3888,7 +3917,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3907,7 +3936,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3916,8 +3945,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
@@ -3937,8 +3966,8 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid arguments"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3948,7 +3977,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -4026,7 +4055,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4035,7 +4064,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Nombre del contenedor es: %s"
@@ -4045,9 +4074,9 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -4094,6 +4123,11 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+#, fuzzy
+msgid "Key description"
+msgstr "Descripción"
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -4102,7 +4136,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -4110,10 +4144,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4131,12 +4165,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
@@ -4151,11 +4185,11 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4184,12 +4218,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4238,12 +4272,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4388,7 +4422,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
@@ -4420,11 +4454,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4445,11 +4479,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4504,11 +4538,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4749,12 +4783,12 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4763,11 +4797,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4783,11 +4817,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4808,11 +4842,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4834,12 +4868,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4862,12 +4896,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4881,11 +4915,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4934,11 +4968,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4994,11 +5028,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5011,7 +5049,7 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -5032,15 +5070,15 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5049,7 +5087,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expira: %s"
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -5059,11 +5097,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5084,11 +5122,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5096,7 +5134,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5189,7 +5227,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -5197,7 +5235,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -5210,14 +5248,14 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
@@ -5231,12 +5269,12 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
@@ -5254,12 +5292,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -5277,7 +5315,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Nombre del contenedor es: %s"
@@ -5384,30 +5422,30 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -5417,32 +5455,32 @@ msgstr "Nombre del Miembro del Cluster"
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -5455,10 +5493,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
@@ -5471,86 +5509,86 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing network integration name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -5564,11 +5602,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -5578,12 +5616,12 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5608,8 +5646,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5622,7 +5660,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Aliases:"
@@ -5651,7 +5689,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5660,11 +5698,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5677,15 +5715,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5693,11 +5731,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5714,9 +5752,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5740,8 +5778,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5801,8 +5839,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5812,60 +5850,75 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr "Perfil %s creado"
+
+#: cmd/incus/network_zone.go:475
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr "Descripción"
+
+#: cmd/incus/network_forward.go:416
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
+msgstr "Perfil %s creado"
 
 #: cmd/incus/network_integration.go:160
 #, fuzzy, c-format
@@ -5882,55 +5935,55 @@ msgstr "Perfil %s eliminado"
 msgid "Network integration %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5943,7 +5996,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5952,7 +6005,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5962,27 +6015,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5990,11 +6043,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6035,7 +6088,7 @@ msgstr ""
 msgid "OS Version"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -6043,11 +6096,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6059,11 +6112,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6086,7 +6139,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6132,19 +6185,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6156,11 +6209,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -6191,6 +6244,11 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+#, fuzzy
+msgid "Peer description"
+msgstr "Descripción"
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6215,6 +6273,11 @@ msgstr ""
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
 msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+#, fuzzy
+msgid "Port description"
+msgstr "Descripción"
 
 #: cmd/incus/admin_init_interactive.go:816
 msgid "Port to bind to"
@@ -6254,17 +6317,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6319,37 +6382,42 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
+
+#: cmd/incus/profile.go:369
+#, fuzzy
+msgid "Profile description"
+msgstr "Descripción"
 
 #: cmd/incus/image.go:161
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -6373,20 +6441,25 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/project.go:114
+#, fuzzy
+msgid "Project description"
+msgstr "Descripción"
 
 #: cmd/incus/remote.go:124
 msgid "Project to use for the remote"
@@ -6405,7 +6478,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -6458,15 +6531,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6488,6 +6561,11 @@ msgstr "Creando el contenedor"
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Aliases:"
+
+#: cmd/incus/network_zone.go:1092
+#, fuzzy
+msgid "Record description"
+msgstr "Descripción"
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6534,7 +6612,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6573,14 +6651,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
@@ -6589,7 +6667,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
@@ -6598,25 +6676,25 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6624,21 +6702,21 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6651,7 +6729,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6660,11 +6738,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6672,12 +6750,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6692,7 +6770,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Rename instances"
 msgstr "Aliases:"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6701,15 +6779,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6717,17 +6795,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6771,7 +6849,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6780,7 +6858,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6793,12 +6871,12 @@ msgstr "Aliases:"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
@@ -6808,7 +6886,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6816,6 +6894,11 @@ msgstr ""
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
+
+#: cmd/incus/network_acl.go:887
+#, fuzzy
+msgid "Rule description"
+msgstr "Descripción"
 
 #: cmd/incus/remote_unix.go:36
 msgid "Run a local API proxy"
@@ -6855,7 +6938,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6883,9 +6966,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr "CREADO EN"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6901,7 +6984,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6909,11 +6992,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6921,11 +7004,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Creado: %s"
@@ -6962,7 +7045,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6980,7 +7063,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Perfil %s creado"
@@ -7033,11 +7116,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7046,11 +7129,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7059,12 +7142,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7088,12 +7171,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7102,12 +7185,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7116,12 +7199,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7130,16 +7213,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7148,11 +7231,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7161,12 +7244,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7175,11 +7258,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7188,11 +7271,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7234,7 +7317,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Nombre del contenedor es: %s"
@@ -7243,11 +7326,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -7257,48 +7340,48 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7326,7 +7409,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
@@ -7389,7 +7472,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7418,43 +7501,43 @@ msgstr "Perfil %s creado"
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7466,21 +7549,21 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7489,7 +7572,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7501,7 +7584,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Copiando la imagen: %s"
@@ -7514,15 +7597,15 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr ""
 
@@ -7535,7 +7618,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7557,15 +7640,20 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+#, fuzzy
+msgid "Snapshot description"
+msgstr "Descripción"
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7616,7 +7704,7 @@ msgstr ""
 msgid "State"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
@@ -7651,22 +7739,22 @@ msgstr "Copiando la imagen: %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Perfil %s creado"
@@ -7685,22 +7773,27 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr "Perfil %s creado"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7710,12 +7803,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7728,7 +7821,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Perfil %s eliminado"
@@ -7760,7 +7853,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7776,7 +7869,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7784,20 +7877,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7870,7 +7963,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7892,7 +7985,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7900,7 +7993,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Nombre del Miembro del Cluster"
@@ -7928,7 +8021,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7948,12 +8041,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7963,7 +8056,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7973,7 +8066,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7983,37 +8076,37 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8064,12 +8157,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -8120,11 +8213,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -8140,7 +8233,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8148,7 +8241,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -8164,7 +8257,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8194,7 +8287,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8213,7 +8306,7 @@ msgstr ""
 msgid "Type"
 msgstr "Expira: %s"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Acepta certificado"
@@ -8224,18 +8317,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8247,7 +8340,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8259,11 +8352,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -8290,7 +8383,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -8301,17 +8394,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8327,7 +8420,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8337,7 +8430,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Perfil %s creado"
@@ -8363,20 +8456,20 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
@@ -8386,58 +8479,58 @@ msgstr "Perfil %s creado"
 msgid "Unset network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8446,7 +8539,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Perfil %s creado"
@@ -8455,11 +8548,11 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -8469,49 +8562,49 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8524,7 +8617,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8553,16 +8646,16 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8586,7 +8679,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8601,15 +8694,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8649,9 +8742,14 @@ msgstr "Versión de CUDA: %v"
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+#, fuzzy
+msgid "Volume description"
+msgstr "Descripción"
 
 #: cmd/incus/info.go:307
 #, c-format
@@ -8801,9 +8899,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8832,7 +8930,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+#, fuzzy
+msgid "Zone description"
+msgstr "Descripción"
+
+#: cmd/incus/storage_volume.go:865
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8843,12 +8946,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -8864,12 +8967,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8879,38 +8982,38 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8920,65 +9023,65 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9008,7 +9111,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9066,7 +9169,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9155,8 +9258,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9212,15 +9315,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9230,73 +9333,73 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9306,29 +9409,29 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <peer name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9338,7 +9441,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9348,76 +9451,76 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9427,63 +9530,63 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9494,8 +9597,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9515,12 +9618,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9530,7 +9633,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9540,23 +9643,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9571,33 +9674,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9636,11 +9739,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9648,7 +9751,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9698,7 +9801,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9740,7 +9843,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9752,7 +9855,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9887,7 +9990,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9895,7 +9998,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9907,7 +10010,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9932,7 +10035,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9941,7 +10044,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9957,7 +10060,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9965,7 +10068,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9991,7 +10094,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10011,13 +10114,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10026,7 +10129,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10054,7 +10157,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10064,31 +10167,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10098,27 +10201,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10128,7 +10231,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10138,7 +10241,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10148,7 +10251,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10158,7 +10261,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10168,7 +10271,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10178,7 +10281,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10192,7 +10295,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10202,7 +10305,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10212,7 +10315,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -10220,11 +10323,11 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
@@ -10237,7 +10340,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -10254,7 +10357,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -10262,7 +10365,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -10270,9 +10373,9 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -30,7 +30,7 @@ msgstr "  Firmware :"
 msgid "  Motherboard:"
 msgstr "  Carte mère :"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -53,7 +53,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -110,7 +110,7 @@ msgstr ""
 "### config:\n"
 "###      size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -123,7 +123,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -229,7 +229,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -283,7 +283,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -341,7 +341,7 @@ msgstr ""
 "###\n"
 "### Prenez note que le nom est affiché mais ne peut pas être modifié"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -399,7 +399,7 @@ msgstr ""
 "### Notez que l'adresse d'écoute (listen_address) et la localisation "
 "(lacation) ne peuvent pas être changées."
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -428,7 +428,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié."
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -452,7 +452,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -476,7 +476,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,7 +512,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -676,7 +676,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -782,7 +782,7 @@ msgstr "Vous devez fournir le nom d'un membre appartenant à un cluster"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -806,11 +806,11 @@ msgstr "TYPE D'AUTHENTIFICATION"
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr "Clé d'accès (auto-généré si vide)"
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr "Clé d'accès: %s"
@@ -832,23 +832,23 @@ msgstr "L'action '%q' n'est pas supporté par le serveur"
 msgid "Action (defaults to GET)"
 msgstr "Action (GET par défaut)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr "Ajoutez un membre d'un cluster à un groupe de cluster"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr "Ajoutez un enregistrement d'une zone réseau"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr "Ajoutez un backend à un équilibreur de charge"
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr "Ajoutez des backends à un équilibreur de charge"
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr "Ajoutez des entrées à la zone d'enregistrement réseau"
 
@@ -856,7 +856,7 @@ msgstr "Ajoutez des entrées à la zone d'enregistrement réseau"
 msgid "Add instance devices"
 msgstr "Ajoutez des périphériques à l'instance"
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr "Ajoutez des membres à un groupe"
 
@@ -893,11 +893,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -923,12 +923,12 @@ msgstr ""
 "Cela va générer un jeton de confiance a utiliser par le client pour "
 "s'ajouter au dépôt de confiance.\n"
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr "Ajoutez des ports à la redirection"
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr "Ajoutez des ports à l'équilibreur de charge"
 
@@ -940,7 +940,7 @@ msgstr "Ajouter des profils aux instances"
 msgid "Add roles to a cluster member"
 msgstr "Ajoutez des roles à un membre d'un cluster"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr "Ajoutez des règles à une liste de contrôle d'accès (ACL)"
 
@@ -969,12 +969,12 @@ msgstr "Addresse : %s"
 msgid "Address: %v"
 msgstr "Addresse : %v"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Clef d'accès administrateur : %s"
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Clef d'accès secrète administrateur : %s"
@@ -989,8 +989,8 @@ msgstr "L'alias %s existe déjà"
 msgid "Alias %s doesn't exist"
 msgstr "L'alias %s n'existe pas"
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr "Nom d'alias manquant"
 
@@ -1014,7 +1014,7 @@ msgstr ""
 "Toutes les données seront perdues après avoir rejoint le cluster, voulez-"
 "vous continuer ?"
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr "Tous les projets"
 
@@ -1022,7 +1022,7 @@ msgstr "Tous les projets"
 msgid "All server addresses are unavailable"
 msgstr "Toutes les adresses serveurs sont indisponibles"
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
@@ -1051,7 +1051,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "Aucun n'a pu être trouvé, la socket SPICE peut être trouvé à:"
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "Machine virtuelle a été demandé mais l'image est de type conteneur"
 
@@ -1137,7 +1137,12 @@ msgstr "Moyenne : %.2f %.2f %.2f"
 msgid "BASE IMAGE"
 msgstr "Image de base"
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+#, fuzzy
+msgid "Backend description"
+msgstr "Description"
+
+#: cmd/incus/network_load_balancer.go:1332
 #, fuzzy
 msgid "Backend health:"
 msgstr "État du backend :"
@@ -1147,22 +1152,22 @@ msgstr "État du backend :"
 msgid "Backing up instance: %s"
 msgstr "Sauvegarder l'instance : %s"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Sauvegarder le bucket de stockage : %s"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1173,22 +1178,22 @@ msgstr ""
 "Mauvais appareil remplacez la syntaxe, syntaxe attendue <appareil>,"
 "<clé>=<valeur>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Mauvaise association clef=valeur: %q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Mauvaise paire clé=valeur: %s"
@@ -1198,7 +1203,7 @@ msgstr "Mauvaise paire clé=valeur: %s"
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr "Liaison:"
 
@@ -1211,20 +1216,25 @@ msgstr "À la fois--all et le nom d'instance on été donné"
 msgid "Brand: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr "Pont:"
+
+#: cmd/incus/storage_bucket.go:106
+#, fuzzy
+msgid "Bucket description"
+msgstr "Description"
 
 #: cmd/incus/info.go:365
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Adresse du bus : %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1232,11 +1242,11 @@ msgstr "Octets émis"
 msgid "CANCELABLE"
 msgstr "ANNULABLE"
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "NOM COMMUN"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr "Type de contenu"
 
@@ -1329,7 +1339,7 @@ msgstr "Impossible de supprimer le serveur distant par défaut"
 msgid "Can't specify --fast with --columns"
 msgstr "Impossible de spécifier --fast avec --columns"
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr "Impossible de spécifier --project avec --all-projects"
 
@@ -1337,7 +1347,7 @@ msgstr "Impossible de spécifier --project avec --all-projects"
 msgid "Can't specify a different remote for rename"
 msgstr "Impossible de spécifier un autre serveur distant pour un renommage"
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1374,7 +1384,7 @@ msgstr "Impossible d'utiliser --minimal et --preseed ensemble"
 msgid "Can't use an image with --empty"
 msgstr "Impossible d'utiliser une image avec --empty"
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1399,7 +1409,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
@@ -1414,10 +1424,15 @@ msgstr "Cartes %d:"
 msgid "Card: %s (%s)"
 msgstr "Cartes : %s (%s)"
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Jeton d'ajout du certificat pour %s supprimé"
+
+#: cmd/incus/config_trust.go:184
+#, fuzzy
+msgid "Certificate description"
+msgstr "Empreinte du certificat : %s"
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1439,7 +1454,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr "Châssis"
 
@@ -1467,25 +1482,30 @@ msgstr "Certificat client approuvé par le serveur :"
 msgid "Client version: %s\n"
 msgstr "Version du client : %s\n"
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr "Groupe de serveurs %s créé"
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "Groupe de serveurs %s supprimé"
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Le groupe de serveurs %s n'est pas actuellement appliqué à %s"
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Groupe de serveurs %s renommée en %s"
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "Groupe de serveurs %s créé"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1497,57 +1517,57 @@ msgstr "Jeton de connexion de cluster pour %s:%s supprimé"
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "Membre de cluster %s ajouté aux groupes %s"
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Membre du cluster %s ajouté au groupe %s"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Le membre du cluster %s est déjà dans le groupe %s"
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Le membre du cluster %s est supprimé du groupe %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr "Nom du membre du cluster"
 
@@ -1556,17 +1576,17 @@ msgid "Clustering enabled"
 msgstr "Clustering activé"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Colonnes"
@@ -1603,7 +1623,7 @@ msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuration clé/valeur à associer à la nouvelle instance"
 
@@ -1612,7 +1632,7 @@ msgstr "Configuration clé/valeur à associer à la nouvelle instance"
 msgid "Config key/value to apply to the new network integration"
 msgstr "Configuration clé/valeur à associer à la nouvelle intégration réseau"
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr "Configuration clef/valeur à associer au nouveau projet"
 
@@ -1624,16 +1644,16 @@ msgstr "Configuration clef/valeur à associer pour l'instance cible"
 msgid "Config option should be in the format KEY=VALUE"
 msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1656,11 +1676,11 @@ msgstr "Configurer le démon"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "Connexion au démon (tentative %d)"
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr "Type de contenu, bloc ou système de fichier"
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr "Type de contenu : %s"
@@ -1817,7 +1837,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible d'écrire le fichier de certificat serveur %q: %w"
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr "Impossible de trouver une entrée correspondante"
 
@@ -1826,7 +1846,7 @@ msgstr "Impossible de trouver une entrée correspondante"
 msgid "Couldn't statfs %s: %w"
 msgstr "Impossible de statfs %s: %w"
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr "Créer un groupe de serveurs"
 
@@ -1835,15 +1855,15 @@ msgstr "Créer un groupe de serveurs"
 msgid "Create a new %s pool?"
 msgstr "Créer un nouvel agrégat de stockage %s ?"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr "Créer une nouvelle machine virtuelle"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr "Crée des alias pour les images existantes"
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr "Créer une instance vide"
 
@@ -1898,12 +1918,12 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Création d'instances à partir d'images"
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Création d'une clef pour un stockage de type bucket"
@@ -1913,12 +1933,12 @@ msgstr "Création d'une clef pour un stockage de type bucket"
 msgid "Create network integrations"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1928,68 +1948,68 @@ msgstr "Copie de l'image : %s"
 msgid "Create new instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr "Créer de nouvelles ACL réseau"
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 #, fuzzy
 msgid "Create new networks"
 msgstr "Créer de nouveaux réseaux"
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
@@ -1999,7 +2019,7 @@ msgstr "Création de %s"
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -2013,16 +2033,16 @@ msgstr "Nombre actuel de VFs: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "ADRESSE CIBLE PAR DÉFAUT"
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2034,7 +2054,7 @@ msgstr "DISQUE"
 msgid "DISK USAGE"
 msgstr "UTILISATION DISQUE"
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr "PILOTE"
 
@@ -2057,11 +2077,11 @@ msgstr "Le démon continue de fonctionner après %ds d'attente"
 msgid "Date: %s"
 msgstr "État : %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr "ID VLAN par défaut"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2074,7 +2094,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "Supprimer une opération en tâche de fond (essayera d'annuler)"
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr "Supprime un groupe de serveurs"
 
@@ -2083,7 +2103,7 @@ msgstr "Supprime un groupe de serveurs"
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2093,7 +2113,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 #, fuzzy
 msgid "Delete image aliases"
 msgstr "Supprimer les alias d'image"
@@ -2118,16 +2138,16 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Delete instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr "Supprimer les ACLs réseau"
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr "Supprime les redirections réseaux"
 
@@ -2136,50 +2156,50 @@ msgstr "Supprime les redirections réseaux"
 msgid "Delete network integrations"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr "Supprime les réseaux"
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr "Supprime les profiles"
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr "Supprime les pool de stockage"
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2203,12 +2223,12 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2223,11 +2243,11 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2235,31 +2255,31 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2267,45 +2287,45 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2313,63 +2333,63 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Description"
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr "Détacher les interfaces réseaux des instances"
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr "Détacher les interfaces réseau des profils"
 
@@ -2436,7 +2456,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2499,7 +2519,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2508,7 +2528,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display resource usage info per instance"
 msgstr "Afficher l'utilisation des ressources par instance"
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2560,7 +2580,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Don't show progress information"
 msgstr "Ne pas afficher les informations sur l'état d'avancement"
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr "ENTRÉES"
 
@@ -2602,13 +2622,13 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "EXISTANT: %q (principal=%q, source=%q)"
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
@@ -2621,7 +2641,7 @@ msgstr ""
 "en peux pas être annulé (annuler deux fois supplémentaires pour forcer "
 "l'action)"
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr "Modifier un groupe de serveurs"
 
@@ -2654,16 +2674,16 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr "Modifier les configurations réseau au format YAML"
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2673,54 +2693,54 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network integration configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr "Modifier les configurations de profil au format YAML"
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr "Modifier la clé du bucket de stockage au format YAML"
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr "Modifier les configurations du pool de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr "Modifier les configurations de volume de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2729,23 +2749,23 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2795,7 +2815,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr "Entrée TTL"
 
@@ -2803,7 +2823,7 @@ msgstr "Entrée TTL"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
@@ -2828,15 +2848,15 @@ msgstr "Erreur lors du décodage des données: %v"
 msgid "Error retrieving aliases: %w"
 msgstr "Erreur lors de la récupération des alias : %w"
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "Erreur lors du paramétrages des propriétés: %v"
@@ -2851,14 +2871,14 @@ msgstr "Récupération de l'image : %s"
 msgid "Error unsetting properties: %v"
 msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
@@ -3004,8 +3024,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -3036,7 +3056,7 @@ msgstr ""
 "La cible de sortie est facultative et par défaut dans le répertoire de "
 "travail."
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -3051,27 +3071,27 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -3090,8 +3110,8 @@ msgstr "DOMAINE D'ÉCHEC"
 msgid "FILENAME"
 msgstr "NOM"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -3179,7 +3199,7 @@ msgstr "Échec de la génération du certificat de confiance : %w"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Échec de l'obtention des pools de stockage existants : %w"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "Échec de la récupération du status du pair : %w"
@@ -3189,18 +3209,18 @@ msgstr "Échec de la récupération du status du pair : %w"
 msgid "Failed import request: %w"
 msgstr "Échec de la demande d'importation : %w"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Échec du chargement du réseau %q : %w"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 "Échec du chargement du profil %q pour la modification du périphérique : %w"
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec du chargement du pool de stockage %q : %w"
@@ -3290,7 +3310,7 @@ msgstr "Échec de la création de %q : %w"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec de la création de l'alias %s : %w"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr "Échec de la création de la sauvegarde : %v"
@@ -3300,7 +3320,7 @@ msgstr "Échec de la création de la sauvegarde : %v"
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
@@ -3311,12 +3331,12 @@ msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 "Échec de la suppression de l'instance originale après l'avoir copiée : %w"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Échec de la récupération de la sauvegarde de l'unité de stockage : %w"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3468,7 +3488,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Fetch instance backup file: %w"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr "Le filtrage n'est pas encore pris en charge"
@@ -3487,7 +3507,7 @@ msgstr "Forcer une action d'évacuation particulière"
 msgid "Force creating files or directories"
 msgstr "Forcer la création de fichiers ou de répertoires"
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 #, fuzzy
 msgid "Force delete the project and everything it contains."
 msgstr "Suppression forcée du projet et de toutes les données associées"
@@ -3575,19 +3595,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 #, fuzzy
 msgid "Format (csv|json|table|yaml|compact)"
@@ -3608,7 +3628,7 @@ msgstr "Format (man|md|rest|yaml)"
 msgid "Format (table|compact)"
 msgstr "Format (csv|json|table|yaml|compact)"
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3659,16 +3679,16 @@ msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr "Obtenir un résumé de l'allocation des ressources"
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Nom du réseau"
@@ -3677,12 +3697,12 @@ msgstr "Nom du réseau"
 msgid "Get image properties"
 msgstr "Obtenir les propriétés de l'image"
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 #, fuzzy
 msgid "Get runtime information on networks"
 msgstr "Obtenir les informations opérationnelles des réseaux"
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
@@ -3695,7 +3715,7 @@ msgstr "Obtenir la clé en tant que propriété du cluster"
 msgid "Get the key as a network ACL property"
 msgstr "Obtenir la clé en tant que propriété ACL du réseau"
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
@@ -3705,17 +3725,17 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr "Obtenir la clé en tant que propriété du réseau"
 
@@ -3724,30 +3744,30 @@ msgstr "Obtenir la clé en tant que propriété du réseau"
 msgid "Get the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr "Obtenir la clé en tant que propriété du profil"
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr "Obtenir la clé en tant que propriété du projet"
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3756,7 +3776,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as an instance property"
 msgstr "Obtenir la clé en tant que propriété d'instance"
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3781,12 +3801,12 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3796,13 +3816,13 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3812,35 +3832,35 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du pool de stockage"
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du volume de stockage"
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3864,7 +3884,7 @@ msgstr ""
 "ID du groupe avec lequel la commande doit être exécutée (valeur par défaut : "
 "0)"
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -3903,7 +3923,7 @@ msgstr "La copie d'E/S de l'instance vers sshfs a échoué : %v"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "La copie d'E/S de sshfs vers l'instance a échoué : %v"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 #, fuzzy
 msgid "ID"
 msgstr "PID"
@@ -3918,7 +3938,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr "ID : %s"
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -3931,7 +3951,7 @@ msgstr "NOM DE L'INSTANCE"
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
@@ -3940,30 +3960,30 @@ msgstr "ADRESSE IP"
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr "IPv4"
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr "IPv6"
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "Expire : %s"
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "Expire : %s"
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
@@ -3978,7 +3998,7 @@ msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "Si l'alias de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
@@ -3996,7 +4016,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "Ignorer toute expiration automatique configurée pour l'instance"
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 "Ignorer toute expiration automatique configurée pour le volume de stockage"
@@ -4009,6 +4029,10 @@ msgstr "Ignorer les erreurs de copie pour les fichiers non permanents"
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
+msgstr ""
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -4055,17 +4079,17 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Import backups of instances including their snapshots."
 msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Copie de l'image : %s"
@@ -4091,30 +4115,30 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr "Le type d'importation doit être \"backup\" ou \"iso\""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 #, fuzzy
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "Type d'importation : \"backup\" ou \"iso\" (par défaut \"backup\")"
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -4124,7 +4148,7 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 #, fuzzy
 msgid "Include environment variables from file"
 msgstr "Inclure les variables environnements à partir d'un fichier"
@@ -4151,6 +4175,11 @@ msgstr "Données d'entrée"
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "Mot de passe de l'administrateur distant"
+
 #: cmd/incus/file.go:1473
 #, fuzzy
 msgid "Instance disconnected"
@@ -4166,7 +4195,7 @@ msgstr "Instance déconnectée pour le client %q"
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -4188,7 +4217,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr "Type d'instance"
 
@@ -4197,8 +4226,8 @@ msgstr "Type d'instance"
 msgid "Invalid IP address or DNS name"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
@@ -4218,8 +4247,8 @@ msgstr "Cible invalide %s"
 msgid "Invalid arguments"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, fuzzy, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
@@ -4229,7 +4258,7 @@ msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
 msgid "Invalid boolean value: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
@@ -4314,7 +4343,7 @@ msgstr ""
 "Nom invalide dans \"%s\", la chaîne vide n'est autorisée que lorsque "
 "maxWidth est défini."
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -4324,7 +4353,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Cible invalide %s"
@@ -4334,9 +4363,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -4383,6 +4412,11 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "Kernel Version"
 msgstr "Version du noyau"
 
+#: cmd/incus/storage_bucket.go:1049
+#, fuzzy
+msgid "Key description"
+msgstr "Description"
+
 #: cmd/incus/warning.go:213
 #, fuzzy
 msgid "LAST SEEN"
@@ -4392,7 +4426,7 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr "LIMITE"
 
@@ -4400,10 +4434,10 @@ msgstr "LIMITE"
 msgid "LISTEN ADDRESS"
 msgstr "ADRESSE D’ÉCOUTE"
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
@@ -4421,12 +4455,12 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
@@ -4441,11 +4475,11 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "Vitesse de la liaison : %dMbit/s (%s duplex)"
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr "Liste des baux DHCP"
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4474,12 +4508,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias :"
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4528,12 +4562,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4678,7 +4712,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nom du réseau"
@@ -4710,11 +4744,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4735,11 +4769,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4794,11 +4828,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5101,12 +5135,12 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -5115,11 +5149,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -5135,11 +5169,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -5160,12 +5194,12 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -5187,12 +5221,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5215,12 +5249,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5234,12 +5268,12 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -5288,11 +5322,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5348,11 +5382,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5365,7 +5403,7 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal :"
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -5386,17 +5424,17 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 #, fuzzy
 msgid "Lower device"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 #, fuzzy
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5405,7 +5443,7 @@ msgstr ""
 msgid "MAC address"
 msgstr "Expire : %s"
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -5415,11 +5453,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5440,11 +5478,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5452,7 +5490,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5553,7 +5591,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage instance snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
@@ -5563,7 +5601,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
@@ -5578,14 +5616,14 @@ msgstr "Nom du réseau"
 msgid "Manage network integrations"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
@@ -5600,12 +5638,12 @@ msgstr "Nom du réseau"
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
@@ -5624,12 +5662,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Copie de l'image : %s"
@@ -5649,7 +5687,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Copie de l'image : %s"
@@ -5758,30 +5796,30 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -5791,32 +5829,32 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 #, fuzzy
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5830,10 +5868,10 @@ msgid "Missing name"
 msgstr "Résumé manquant."
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
@@ -5846,88 +5884,88 @@ msgstr "Nom du réseau"
 msgid "Missing network integration name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5941,12 +5979,12 @@ msgstr "Résumé manquant."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5956,12 +5994,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 #, fuzzy
 msgid "Mode"
 msgstr "Publié : %s"
@@ -5988,8 +6026,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -6004,7 +6042,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -6035,7 +6073,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -6044,11 +6082,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -6062,15 +6100,15 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr "NOM"
 
@@ -6078,11 +6116,11 @@ msgstr "NOM"
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -6099,9 +6137,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr "NON"
@@ -6125,8 +6163,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -6191,8 +6229,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -6202,60 +6240,75 @@ msgstr "Nom : %s"
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr "Le réseau %s a été créé"
+
+#: cmd/incus/network_zone.go:475
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr "Description"
+
+#: cmd/incus/network_forward.go:416
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
+msgstr "Le réseau %s a été créé"
 
 #: cmd/incus/network_integration.go:160
 #, fuzzy, c-format
@@ -6272,56 +6325,56 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network integration %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -6335,7 +6388,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -6345,7 +6398,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -6355,28 +6408,28 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -6384,11 +6437,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6429,7 +6482,7 @@ msgstr ""
 msgid "OS Version"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -6439,13 +6492,13 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -6461,13 +6514,13 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -6492,7 +6545,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6541,19 +6594,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6565,11 +6618,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -6602,6 +6655,11 @@ msgstr ""
 msgid "Pause instances"
 msgstr "Création du conteneur"
 
+#: cmd/incus/network_peer.go:335
+#, fuzzy
+msgid "Peer description"
+msgstr "Description"
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6626,6 +6684,11 @@ msgstr "Veuillez entrer 'o', 'n' ou l'empreinte :"
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
 msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+#, fuzzy
+msgid "Port description"
+msgstr "Description"
 
 #: cmd/incus/admin_init_interactive.go:816
 msgid "Port to bind to"
@@ -6665,17 +6728,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -6731,37 +6794,42 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
+
+#: cmd/incus/profile.go:369
+#, fuzzy
+msgid "Profile description"
+msgstr "Description"
 
 #: cmd/incus/image.go:161
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -6786,20 +6854,25 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
+
+#: cmd/incus/project.go:114
+#, fuzzy
+msgid "Project description"
+msgstr "Description"
 
 #: cmd/incus/remote.go:124
 msgid "Project to use for the remote"
@@ -6818,7 +6891,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6874,16 +6947,16 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6905,6 +6978,11 @@ msgstr "Création du conteneur"
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
+
+#: cmd/incus/network_zone.go:1092
+#, fuzzy
+msgid "Record description"
+msgstr "Description"
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6954,7 +7032,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -6994,14 +7072,14 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -7010,7 +7088,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
@@ -7020,25 +7098,25 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
@@ -7048,22 +7126,22 @@ msgstr "Création du conteneur"
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -7077,7 +7155,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
@@ -7087,12 +7165,12 @@ msgstr "Création du conteneur"
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -7100,12 +7178,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -7120,7 +7198,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Rename instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -7129,15 +7207,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -7146,17 +7224,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7216,7 +7294,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7226,7 +7304,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -7240,12 +7318,12 @@ msgstr "Création du conteneur"
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -7255,7 +7333,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -7263,6 +7341,11 @@ msgstr ""
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
+
+#: cmd/incus/network_acl.go:887
+#, fuzzy
+msgid "Rule description"
+msgstr "Description"
 
 #: cmd/incus/remote_unix.go:36
 msgid "Run a local API proxy"
@@ -7302,7 +7385,7 @@ msgstr "Publié : %s"
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -7330,9 +7413,9 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STARTED AT"
 msgstr "CRÉÉ À"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -7350,7 +7433,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -7359,12 +7442,12 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -7372,11 +7455,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Créé : %s"
@@ -7415,7 +7498,7 @@ msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -7434,7 +7517,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7489,12 +7572,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7503,12 +7586,12 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7517,12 +7600,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7546,12 +7629,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7560,12 +7643,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7574,12 +7657,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7588,17 +7671,17 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7607,12 +7690,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7621,12 +7704,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7635,12 +7718,12 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7649,12 +7732,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7699,7 +7782,7 @@ msgstr "Définir l'uid du fichier lors de l'envoi"
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
@@ -7708,11 +7791,11 @@ msgstr "Obtenir la clé en tant que propriété du cluster"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
@@ -7722,49 +7805,49 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7793,7 +7876,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
@@ -7864,7 +7947,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
@@ -7895,46 +7978,46 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7946,22 +8029,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7970,7 +8053,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 #, fuzzy
 msgid "Show the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -7984,7 +8067,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
@@ -7998,15 +8081,15 @@ msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Afficher la configuration étendue"
@@ -8020,7 +8103,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -8042,16 +8125,21 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+#, fuzzy
+msgid "Snapshot description"
+msgstr "Description"
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -8103,7 +8191,7 @@ msgstr ""
 msgid "State"
 msgstr "État : %s"
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
@@ -8141,22 +8229,22 @@ msgstr "L'arrêt de l'instance a échoué : %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Profil %s créé"
@@ -8175,22 +8263,27 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool %q of type %q"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr "Le réseau %s a été créé"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -8200,12 +8293,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Storage pool to use or create"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
@@ -8220,7 +8313,7 @@ msgstr "Image copiée avec succès !"
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s supprimé"
@@ -8253,7 +8346,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -8271,7 +8364,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8279,20 +8372,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -8367,7 +8460,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -8394,7 +8487,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -8404,7 +8497,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8433,7 +8526,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8453,12 +8546,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8468,7 +8561,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8478,7 +8571,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8488,37 +8581,37 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8572,12 +8665,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
@@ -8629,12 +8722,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
@@ -8653,7 +8746,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8661,7 +8754,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -8677,7 +8770,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8707,7 +8800,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8726,7 +8819,7 @@ msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 msgid "Type"
 msgstr "Expire : %s"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
@@ -8737,18 +8830,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8760,7 +8853,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8774,11 +8867,11 @@ msgstr "Création du conteneur"
 msgid "USB devices:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -8806,7 +8899,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -8817,17 +8910,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8843,7 +8936,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8853,7 +8946,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8882,22 +8975,22 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
@@ -8907,62 +9000,62 @@ msgstr "Nom du réseau"
 msgid "Unset network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8971,7 +9064,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
@@ -8980,11 +9073,11 @@ msgstr "Obtenir la clé en tant que propriété du cluster"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
@@ -8994,50 +9087,50 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -9051,7 +9144,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -9080,17 +9173,17 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 #, fuzzy
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9114,7 +9207,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 #, fuzzy
 msgid "User aborted delete operation"
@@ -9130,15 +9223,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -9178,9 +9271,14 @@ msgstr "Version CUDA : %v"
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+#, fuzzy
+msgid "Volume description"
+msgstr "Description"
 
 #: cmd/incus/info.go:307
 #, fuzzy, c-format
@@ -9336,9 +9434,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr "OUI"
@@ -9370,7 +9468,12 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom d'image ou utilisez --empty"
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+#, fuzzy
+msgid "Zone description"
+msgstr "Description"
+
+#: cmd/incus/storage_volume.go:865
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9387,12 +9490,12 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<serveur distant>:]"
@@ -9413,11 +9516,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid "[<remote>:] <cert>"
 msgstr "[<serveur distant>:] <certificat>"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr "[<serveur distant>:] <nom>"
 
@@ -9425,28 +9528,28 @@ msgstr "[<serveur distant>:] <nom>"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<serveur distant>:] [<filtre>...]"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<serveur distant>:] [<filtres>...]"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr "[<serveur distant>:]<ACL>"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<serveur distant>:]<ACL> <direction> <clé=valeur>..."
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<serveur distant>:] <ACL> <clé>"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<serveur distant>:]<ACL> <clé>=<valeur>"
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9454,7 +9557,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -9474,8 +9577,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -9483,7 +9586,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -9491,7 +9594,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9499,7 +9602,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9507,7 +9610,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9519,7 +9622,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -9531,7 +9634,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9539,8 +9642,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -9552,8 +9655,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -9561,7 +9664,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr ""
@@ -9569,7 +9672,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
@@ -9577,7 +9680,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -9633,7 +9736,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9732,7 +9835,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9922,8 +10025,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -10028,8 +10131,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
@@ -10039,7 +10142,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -10055,7 +10158,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -10063,7 +10166,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -10071,11 +10174,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -10083,7 +10186,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -10091,7 +10194,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -10101,9 +10204,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -10111,7 +10214,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -10119,7 +10222,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -10129,13 +10232,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -10143,7 +10246,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -10151,7 +10254,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -10167,7 +10270,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -10175,7 +10278,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -10185,7 +10288,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -10193,7 +10296,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -10201,7 +10304,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -10217,7 +10320,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -10233,8 +10336,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10242,7 +10345,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -10250,7 +10353,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10258,8 +10361,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -10267,9 +10370,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -10277,7 +10380,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -10285,7 +10388,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -10297,7 +10400,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -10305,7 +10408,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -10313,7 +10416,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -10321,7 +10424,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -10329,7 +10432,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10337,7 +10440,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10345,7 +10448,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10361,7 +10464,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10373,7 +10476,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10385,7 +10488,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10397,7 +10500,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10409,7 +10512,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10417,7 +10520,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10429,7 +10532,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10437,8 +10540,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10446,7 +10549,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10454,7 +10557,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10462,7 +10565,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10474,7 +10577,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10491,8 +10594,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10524,7 +10627,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10532,7 +10635,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10548,7 +10651,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10564,8 +10667,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10573,7 +10676,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10581,7 +10684,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10589,7 +10692,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10621,7 +10724,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -10629,8 +10732,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -10638,7 +10741,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -10646,7 +10749,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -10654,7 +10757,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -10662,7 +10765,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -10735,12 +10838,12 @@ msgstr ""
 msgid "application"
 msgstr "Propriétés :"
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -10748,7 +10851,7 @@ msgstr ""
 msgid "disabled"
 msgstr "désactivé"
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -10799,7 +10902,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10841,7 +10944,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -10853,7 +10956,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -11010,7 +11113,7 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -11018,7 +11121,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -11030,7 +11133,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -11055,7 +11158,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -11064,7 +11167,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -11080,7 +11183,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -11088,7 +11191,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -11114,7 +11217,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -11134,13 +11237,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -11149,7 +11252,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -11177,7 +11280,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -11187,31 +11290,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -11221,27 +11324,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -11251,7 +11354,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -11261,7 +11364,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11271,7 +11374,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11281,7 +11384,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11291,7 +11394,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11301,7 +11404,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11315,7 +11418,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -11325,7 +11428,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -11335,7 +11438,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -11344,11 +11447,11 @@ msgstr ""
 msgid "n"
 msgstr "non"
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr "non"
@@ -11361,7 +11464,7 @@ msgstr "ok (o/n/[empreinte]) ?"
 msgid "please use `incus profile`"
 msgstr "veuillez utiliser `incus profile`"
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr "espace utilisé"
 
@@ -11379,7 +11482,7 @@ msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs non trouvé. Essayez le mode SSH SFTP en utilisant l'option --listen"
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr "espace total"
 
@@ -11387,7 +11490,7 @@ msgstr "espace total"
 msgid "unreachable"
 msgstr "inaccessible"
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr "utilisé par"
 
@@ -11395,9 +11498,9 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "oui"
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -31,7 +31,7 @@ msgstr "  Firmware:"
 msgid "  Motherboard:"
 msgstr "  Motherboard:"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -44,7 +44,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -75,7 +75,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -83,7 +83,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -144,7 +144,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -172,7 +172,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -204,7 +204,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -238,7 +238,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -269,7 +269,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -283,7 +283,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -303,7 +303,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -324,7 +324,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,7 +427,7 @@ msgstr "--console tidak bisa dipakai dengan --allx"
 msgid "--console only works with a single instance"
 msgstr "--console hanya bekerja dengan satu instansi"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty tidak bisa dikombinasikan dengan nama image"
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr "ALAMAT"
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -555,11 +555,11 @@ msgstr "TIPE AUTH"
 msgid "Accept certificate"
 msgstr "Terima sertifikat"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,23 +581,23 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -633,11 +633,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -654,12 +654,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -698,12 +698,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -718,8 +718,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr "Alias:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr "Semua proyek"
 
@@ -749,7 +749,7 @@ msgstr "Semua proyek"
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -857,7 +857,12 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+#, fuzzy
+msgid "Backend description"
+msgstr "deskripsi"
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -866,22 +871,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr "Cadangan:"
 
@@ -890,22 +895,22 @@ msgstr "Cadangan:"
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -915,7 +920,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr "Bond:"
 
@@ -928,20 +933,25 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Merek: %v"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr "Bridge:"
+
+#: cmd/incus/storage_bucket.go:106
+#, fuzzy
+msgid "Bucket description"
+msgstr "deskripsi"
 
 #: cmd/incus/info.go:365
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Alamat Bus: %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Byte diterima"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Byte dikirim"
 
@@ -949,11 +959,11 @@ msgstr "Byte dikirim"
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "NAMA UMUM"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1043,7 +1053,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1051,7 +1061,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1085,7 +1095,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1104,7 +1114,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1119,10 +1129,15 @@ msgstr "Kartu %d:"
 msgid "Card: %s (%s)"
 msgstr "Kartu: %s (%s)"
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
+
+#: cmd/incus/config_trust.go:184
+#, fuzzy
+msgid "Certificate description"
+msgstr "deskripsi"
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1141,7 +1156,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1169,25 +1184,30 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "deskripsi"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1199,57 +1219,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1258,17 +1278,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Kolom"
@@ -1296,7 +1316,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1304,7 +1324,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1316,16 +1336,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1347,11 +1367,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1488,7 +1508,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1497,7 +1517,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1506,15 +1526,15 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1547,11 +1567,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1559,11 +1579,11 @@ msgstr ""
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1571,58 +1591,58 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr "Buat profil"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr "Buat proyek"
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr "Buat pool penyimpanan"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr "Dibuat: %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "Membuat %s"
@@ -1632,7 +1652,7 @@ msgstr "Membuat %s"
 msgid "Creating %s: %%s"
 msgstr "Membuat %s: %%s"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid "Creating the instance"
 msgstr "Membuat instansi"
 
@@ -1645,16 +1665,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr "DESKRIPSI"
 
@@ -1666,7 +1686,7 @@ msgstr "DISK"
 msgid "DISK USAGE"
 msgstr "PENGGUNAAN DISK"
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1689,11 +1709,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Tanggal: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr "ID VLAN baku"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1705,7 +1725,7 @@ msgstr "Tundaan:"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1713,7 +1733,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1721,7 +1741,7 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr "Hapus berkas dalam instansi"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr "Hapus alias image"
 
@@ -1741,15 +1761,15 @@ msgstr "Hapus snapshot instansi"
 msgid "Delete instances"
 msgstr "Hapus instansi"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr "Hapus kunci dari suatu bucket penyimpanan"
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr "Hapus ACL jaringan"
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr "Hapus penerusan jaringan"
 
@@ -1757,44 +1777,44 @@ msgstr "Hapus penerusan jaringan"
 msgid "Delete network integrations"
 msgstr "Hapus integrasi jaringan"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 msgid "Delete network load balancers"
 msgstr "Hapus load balancer jaringan"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr "Hapus peering jaringan"
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid "Delete network zone record"
 msgstr "Hapus record zona jaringan"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr "Hapus zona jaringan"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr "Hapus jaringan"
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr "Hapus profil"
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid "Delete storage buckets"
 msgstr "Hapus bucket penyimpanan"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr "Hapus pool penyimpanan"
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1816,12 +1836,12 @@ msgstr "Hapus peringatan"
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -1836,11 +1856,11 @@ msgstr "Hapus peringatan"
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -1848,31 +1868,31 @@ msgstr "Hapus peringatan"
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -1880,45 +1900,45 @@ msgstr "Hapus peringatan"
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -1926,60 +1946,60 @@ msgstr "Hapus peringatan"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Deskripsi"
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr "Deskripsi: %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2040,7 +2060,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Perangkat: %s"
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2097,7 +2117,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2105,7 +2125,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2155,7 +2175,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2184,7 +2204,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr "ENTRI"
 
@@ -2197,12 +2217,12 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr "KEDALUWARSA PADA"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "TANGGAL KEDALUWARSA"
 
@@ -2212,7 +2232,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2240,15 +2260,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2256,48 +2276,48 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2306,22 +2326,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2355,7 +2375,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2363,7 +2383,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2387,15 +2407,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2410,14 +2430,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2507,8 +2527,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr "Kedaluwarsa pada"
 
@@ -2532,7 +2552,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2544,24 +2564,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2579,8 +2599,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NAMA_BERKAS"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr "SIDIKJARI"
 
@@ -2662,7 +2682,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2672,17 +2692,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2771,7 +2791,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2781,7 +2801,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2791,12 +2811,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2943,7 +2963,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2961,7 +2981,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3024,19 +3044,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3053,7 +3073,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3102,15 +3122,15 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 msgid "Get current load-balacner status"
 msgstr ""
 
@@ -3118,11 +3138,11 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 msgid "Get the key as a cluster group property"
 msgstr ""
 
@@ -3134,7 +3154,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3142,15 +3162,15 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3158,27 +3178,27 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3186,7 +3206,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
@@ -3206,11 +3226,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -3218,12 +3238,12 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3231,31 +3251,31 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3276,7 +3296,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3312,7 +3332,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3326,7 +3346,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3339,7 +3359,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3347,27 +3367,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3379,7 +3399,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3393,7 +3413,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3404,6 +3424,11 @@ msgstr ""
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
 msgstr ""
+
+#: cmd/incus/image_alias.go:71
+#, fuzzy
+msgid "Image alias description"
+msgstr "deskripsi"
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -3447,15 +3472,15 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3474,28 +3499,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3505,7 +3530,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3529,6 +3554,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "deskripsi"
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3542,7 +3572,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3561,7 +3591,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3569,8 +3599,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3589,8 +3619,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3600,7 +3630,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -3678,7 +3708,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3687,7 +3717,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 msgid "Invalid peer type"
 msgstr ""
 
@@ -3696,9 +3726,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3742,6 +3772,11 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+#, fuzzy
+msgid "Key description"
+msgstr "deskripsi"
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -3750,7 +3785,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -3758,10 +3793,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3779,12 +3814,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 msgid "Launching the instance"
 msgstr ""
 
@@ -3798,11 +3833,11 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3830,11 +3865,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3882,11 +3917,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4029,7 +4064,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid "List available network zone records"
 msgstr ""
 
@@ -4060,11 +4095,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4085,11 +4120,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4144,11 +4179,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4385,11 +4420,11 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4397,11 +4432,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4417,11 +4452,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4442,11 +4477,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4468,11 +4503,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4495,11 +4530,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4513,11 +4548,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4566,11 +4601,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4625,11 +4660,16 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+#, fuzzy
+msgid "Load balancer description"
+msgstr "deskripsi"
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4642,7 +4682,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -4663,15 +4703,15 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4679,7 +4719,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4689,11 +4729,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -4714,11 +4754,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -4726,7 +4766,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4816,7 +4856,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4824,7 +4864,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4836,13 +4876,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4854,11 +4894,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4874,11 +4914,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4894,7 +4934,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -4999,27 +5039,27 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid "Missing cluster group name"
 msgstr ""
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -5028,30 +5068,30 @@ msgstr ""
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 msgid "Missing listen address"
 msgstr ""
 
@@ -5063,10 +5103,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5077,83 +5117,83 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr ""
 
@@ -5165,11 +5205,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5177,11 +5217,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5206,8 +5246,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5219,7 +5259,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5247,7 +5287,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5256,11 +5296,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5273,15 +5313,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5289,11 +5329,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5310,9 +5350,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5336,8 +5376,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5397,8 +5437,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5408,60 +5448,75 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr "deskripsi"
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr "deskripsi"
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
+msgstr "Hapus penerusan jaringan"
 
 #: cmd/incus/network_integration.go:160
 #, c-format
@@ -5478,55 +5533,55 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5539,7 +5594,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5548,7 +5603,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5558,27 +5613,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5586,11 +5641,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5630,7 +5685,7 @@ msgstr ""
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -5638,11 +5693,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5654,11 +5709,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5680,7 +5735,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5726,19 +5781,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -5750,11 +5805,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -5785,6 +5840,11 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+#, fuzzy
+msgid "Peer description"
+msgstr "deskripsi"
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -5808,6 +5868,11 @@ msgstr ""
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
 msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+#, fuzzy
+msgid "Port description"
+msgstr "deskripsi"
 
 #: cmd/incus/admin_init_interactive.go:816
 msgid "Port to bind to"
@@ -5847,17 +5912,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5912,36 +5977,41 @@ msgstr "Produk: %v (%v)"
 msgid "Profile %s added to %s"
 msgstr "Profil %s ditambahkan ke %s"
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s dibuat"
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s dihapus"
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s saat ini tidak diterapkan ke %s"
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s dihapus dari %s"
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s diganti nama menjadi %s"
+
+#: cmd/incus/profile.go:369
+#, fuzzy
+msgid "Profile description"
+msgstr "deskripsi"
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr "Profil yang akan diterapkan ke image baru"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr "Profil yang akan diterapkan ke instansi baru"
 
@@ -5962,20 +6032,25 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr "Proyek %s dibuat"
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/project.go:114
+#, fuzzy
+msgid "Project description"
+msgstr "deskripsi"
 
 #: cmd/incus/remote.go:124
 msgid "Project to use for the remote"
@@ -5994,7 +6069,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
@@ -6047,15 +6122,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6075,6 +6150,11 @@ msgstr ""
 #: cmd/incus/rebuild.go:26
 msgid "Rebuild instances"
 msgstr ""
+
+#: cmd/incus/network_zone.go:1092
+#, fuzzy
+msgid "Record description"
+msgstr "deskripsi"
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6121,7 +6201,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6160,14 +6240,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -6175,7 +6255,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6183,23 +6263,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6207,20 +6287,20 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6232,7 +6312,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6241,11 +6321,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6253,12 +6333,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6270,7 +6350,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6278,15 +6358,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6294,16 +6374,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6344,7 +6424,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6353,7 +6433,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6365,12 +6445,12 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -6378,7 +6458,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6386,6 +6466,11 @@ msgstr ""
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
+
+#: cmd/incus/network_acl.go:887
+#, fuzzy
+msgid "Rule description"
+msgstr "deskripsi"
 
 #: cmd/incus/remote_unix.go:36
 msgid "Run a local API proxy"
@@ -6424,7 +6509,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6451,9 +6536,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6469,7 +6554,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6477,11 +6562,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6489,11 +6574,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6530,7 +6615,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6548,7 +6633,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
@@ -6599,11 +6684,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6612,11 +6697,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6625,11 +6710,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6652,11 +6737,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6665,11 +6750,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6678,11 +6763,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6691,15 +6776,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6708,11 +6793,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6721,11 +6806,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6734,11 +6819,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6747,11 +6832,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6793,7 +6878,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 msgid "Set the key as a cluster group property"
 msgstr ""
 
@@ -6801,11 +6886,11 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -6813,43 +6898,43 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6877,7 +6962,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -6937,7 +7022,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -6962,39 +7047,39 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7006,19 +7091,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7027,7 +7112,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr "Tampilkan proyek saat ini"
 
@@ -7039,7 +7124,7 @@ msgstr "Tampilkan remote baku"
 msgid "Show the expanded configuration"
 msgstr "Tampilkan konfigurasi yang diperluas"
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 msgid "Show the instance's access list"
 msgstr "Tampilkan daftar akses instansi"
 
@@ -7051,15 +7136,15 @@ msgstr "Tampilkan entri log terkini instansi"
 msgid "Show the resources available to the server"
 msgstr "Tampilkan sumber daya yang tersedia ke server"
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr "Tampilkan sumber daya yang tersedia ke pool penyimpanan"
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr "Tampilkan ruang terpakai dan bebas dalam byte"
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr "Tampilkan konfigurasi trust"
 
@@ -7071,7 +7156,7 @@ msgstr "Tampilkan informasi yang berguna tentang suatu anggota klaster"
 msgid "Show useful information about images"
 msgstr "Tampilkan informasi yang berguna tentang image"
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr "Tampilkan informasi yang berguna tentang pool penyimpanan"
 
@@ -7093,15 +7178,20 @@ msgstr "Ukuran: %.2fMiB"
 msgid "Size: %s"
 msgstr "Ukuran: %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+#, fuzzy
+msgid "Snapshot description"
+msgstr "deskripsi"
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr "Volume penyimpanan snapshot"
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "Snapshot itu hanya-baca dan tidak bisa diubah konfigurasinya"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr "Snapshot:"
 
@@ -7151,7 +7241,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -7186,22 +7276,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7220,22 +7310,27 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr "deskripsi"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7244,12 +7339,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7262,7 +7357,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7293,7 +7388,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7309,7 +7404,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7317,20 +7412,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7403,7 +7498,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7425,7 +7520,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7433,7 +7528,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
@@ -7461,7 +7556,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
@@ -7481,12 +7576,12 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -7496,7 +7591,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7506,7 +7601,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7516,37 +7611,37 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7597,12 +7692,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -7652,11 +7747,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7672,7 +7767,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -7680,7 +7775,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7696,7 +7791,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7726,7 +7821,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -7744,7 +7839,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid "Type of certificate"
 msgstr ""
 
@@ -7754,18 +7849,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7777,7 +7872,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -7789,11 +7884,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -7819,7 +7914,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -7830,17 +7925,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7856,7 +7951,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7866,7 +7961,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
@@ -7890,19 +7985,19 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7910,51 +8005,51 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -7963,7 +8058,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
@@ -7971,11 +8066,11 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -7983,43 +8078,43 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8032,7 +8127,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8060,16 +8155,16 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8092,7 +8187,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8107,15 +8202,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr "VF: %d"
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr "ID VLAN"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr "Pemfilteran VLAN"
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr "VLAN:"
 
@@ -8155,9 +8250,14 @@ msgstr "Versi: %s"
 msgid "Version: %v"
 msgstr "Versi: %v"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
 msgstr "Hanya Volume"
+
+#: cmd/incus/storage_volume.go:590
+#, fuzzy
+msgid "Volume description"
+msgstr "deskripsi"
 
 #: cmd/incus/info.go:307
 #, c-format
@@ -8306,9 +8406,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8337,7 +8437,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+#, fuzzy
+msgid "Zone description"
+msgstr "deskripsi"
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>]"
 
@@ -8346,12 +8451,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>] [<path>]"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -8364,11 +8469,11 @@ msgstr "[<remote>:] <berkas cadangan> [<nama instansi>]"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.kunci>"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid "[<remote>:] <cert>"
 msgstr "[<remote>:] <cert>"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <nama>"
 
@@ -8376,32 +8481,32 @@ msgstr "[<remote>:] <nama>"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filter>...]"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <arah> <kunci>=<nilai>..."
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <kunci>"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <kunci>=<nilai>..."
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <nama-baru>"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [kunci=nilai...]"
 
@@ -8409,54 +8514,54 @@ msgstr "[<remote>:]<ACL> [kunci=nilai...]"
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<path API>"
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zona>"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zona> <kunci>"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <kunci>=<nilai>..."
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zona> [kunci=nilai...]"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <sidikjari>"
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <nama-baru>"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<sidikjari>"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<grup>"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 msgid "[<remote>:]<group> <key>"
 msgstr "[<remote>:]<grup> <kunci>"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -8480,7 +8585,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<nama>]"
 
@@ -8527,7 +8632,7 @@ msgstr "[<remote>:]<instansi> <nama>..."
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "[<remote>:]<instansi> <nama snapshot lama> <nama snapshot baru>"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instansi> <profil>"
 
@@ -8600,8 +8705,8 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -8646,14 +8751,14 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -8661,63 +8766,63 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -8725,25 +8830,25 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
@@ -8751,7 +8856,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<jaringan> <profil> [<nama perangkat>] [<nama antar muka>]"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<jaringan> [kunci=nilai...]"
 
@@ -8759,63 +8864,63 @@ msgstr "[<remote>:]<jaringan> [kunci=nilai...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operasi>"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <berkas cadangan> [<bucket>]"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <berkas cadangan> [<volume nama>]"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <kunci>"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <kunci>=<nilai>..."
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "[<remote>:]<pool> <bucket> [<path>]"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [kunci=nilai...]"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [kunci=nilai...]"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <kunci>"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <kunci> <nilai>"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <nama lama> <nama baru>"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>]"
 
@@ -8823,52 +8928,52 @@ msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot lama> <snapshot baru>"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8877,8 +8982,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -8894,11 +8999,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -8906,7 +9011,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
@@ -8914,20 +9019,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -8939,28 +9044,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -8992,11 +9097,11 @@ msgstr ""
 msgid "application"
 msgstr "aplikasi"
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr "deskripsi"
 
@@ -9004,7 +9109,7 @@ msgstr "deskripsi"
 msgid "disabled"
 msgstr "dinonaktifkan"
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr "driver"
 
@@ -9054,7 +9159,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9096,7 +9201,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9108,7 +9213,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9243,7 +9348,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9251,7 +9356,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9263,7 +9368,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9288,7 +9393,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9297,7 +9402,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9313,7 +9418,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9321,7 +9426,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9347,7 +9452,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9367,13 +9472,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9382,7 +9487,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9410,7 +9515,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9420,31 +9525,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9454,27 +9559,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9484,7 +9589,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9494,7 +9599,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9504,7 +9609,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9514,7 +9619,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9524,7 +9629,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9534,7 +9639,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9548,7 +9653,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9558,7 +9663,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9568,7 +9673,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -9576,11 +9681,11 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
@@ -9593,7 +9698,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -9610,7 +9715,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -9618,7 +9723,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -9626,8 +9731,8 @@ msgstr ""
 msgid "y"
 msgstr "y"
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ya"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-12-17 00:47-0500\n"
+        "POT-Creation-Date: 2024-12-17 02:23-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr  ""
 msgid   "  Motherboard:"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid   "### This is a YAML representation of a storage bucket.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -40,7 +40,7 @@ msgid   "### This is a YAML representation of a storage bucket.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid   "### This is a YAML representation of a storage pool.\n"
         "### Any line starting with a '#' will be ignored.\n"
         "###\n"
@@ -56,7 +56,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -69,14 +69,14 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid   "### This is a YAML representation of the certificate.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### Note that the fingerprint is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -133,7 +133,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid   "### This is a YAML representation of the network ACL.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -159,7 +159,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -188,7 +188,7 @@ msgid   "### This is a YAML representation of the network integration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -220,7 +220,7 @@ msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid   "### This is a YAML representation of the network peer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -235,7 +235,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -248,7 +248,7 @@ msgid   "### This is a YAML representation of the network zone record.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid   "### This is a YAML representation of the network zone.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -261,7 +261,7 @@ msgid   "### This is a YAML representation of the network zone.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -280,7 +280,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -300,7 +300,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -401,7 +401,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -502,7 +502,7 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid   "ALIAS"
 msgstr  ""
 
@@ -526,11 +526,11 @@ msgstr  ""
 msgid   "Accept certificate"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid   "Access key (auto-generated if empty)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid   "Access key: %s"
 msgstr  ""
@@ -552,23 +552,23 @@ msgstr  ""
 msgid   "Action (defaults to GET)"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid   "Add a network zone record entry"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
@@ -576,7 +576,7 @@ msgstr  ""
 msgid   "Add instance devices"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid   "Add member to group"
 msgstr  ""
 
@@ -601,11 +601,11 @@ msgstr  ""
 msgid   "Add new trusted client"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid   "Add new trusted client certificate"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid   "Add new trusted client certificate\n"
         "\n"
         "The following certificate types are supported:\n"
@@ -619,11 +619,11 @@ msgid   "Add new trusted client\n"
         "This will issue a trust token to be used by the client to add itself to the trust store.\n"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090 cmd/incus/network_load_balancer.go:1091
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
@@ -635,7 +635,7 @@ msgstr  ""
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid   "Add rules to an ACL"
 msgstr  ""
 
@@ -661,12 +661,12 @@ msgstr  ""
 msgid   "Address: %v"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid   "Admin secret key: %s"
 msgstr  ""
@@ -681,7 +681,7 @@ msgstr  ""
 msgid   "Alias %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162 cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167 cmd/incus/image_alias.go:405
 msgid   "Alias name missing"
 msgstr  ""
 
@@ -703,7 +703,7 @@ msgstr  ""
 msgid   "All existing data is lost when joining a cluster, continue?"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid   "All projects"
 msgstr  ""
 
@@ -711,7 +711,7 @@ msgstr  ""
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid   "Alternative certificate name"
 msgstr  ""
 
@@ -738,7 +738,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -817,7 +817,11 @@ msgstr  ""
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid   "Backend description"
+msgstr  ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid   "Backend health:"
 msgstr  ""
 
@@ -826,21 +830,21 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, c-format
 msgid   "Backing up storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539 cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553 cmd/incus/storage_volume.go:3123
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid   "Backups:"
 msgstr  ""
 
@@ -849,17 +853,17 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386 cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455 cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455 cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388 cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463 cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169 cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179 cmd/incus/storage_volume.go:657
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -869,7 +873,7 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid   "Bond:"
 msgstr  ""
 
@@ -882,8 +886,12 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid   "Bridge:"
+msgstr  ""
+
+#: cmd/incus/storage_bucket.go:106
+msgid   "Bucket description"
 msgstr  ""
 
 #: cmd/incus/info.go:365
@@ -891,11 +899,11 @@ msgstr  ""
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -903,11 +911,11 @@ msgstr  ""
 msgid   "CANCELABLE"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -996,7 +1004,7 @@ msgstr  ""
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
@@ -1004,7 +1012,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686 cmd/incus/warning.go:226
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -1037,7 +1045,7 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
@@ -1054,7 +1062,7 @@ msgstr  ""
 msgid   "Cannot set --volume-only when copying a snapshot"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid   "Cannot set key: %s"
 msgstr  ""
@@ -1069,9 +1077,13 @@ msgstr  ""
 msgid   "Card: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid   "Certificate add token for %s deleted"
+msgstr  ""
+
+#: cmd/incus/config_trust.go:184
+msgid   "Certificate description"
 msgstr  ""
 
 #: cmd/incus/remote.go:237
@@ -1089,7 +1101,7 @@ msgstr  ""
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid   "Chassis"
 msgstr  ""
 
@@ -1117,24 +1129,28 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid   "Cluster group %s created"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid   "Cluster group %s deleted"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid   "Cluster group %s isn't currently applied to %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid   "Cluster group %s renamed to %s"
+msgstr  ""
+
+#: cmd/incus/cluster_group.go:196
+msgid   "Cluster group description"
 msgstr  ""
 
 #: cmd/incus/cluster.go:1304
@@ -1147,22 +1163,22 @@ msgstr  ""
 msgid   "Cluster member %s added to cluster groups %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid   "Cluster member %s added to group %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid   "Cluster member %s is already in group %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61 cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1479 cmd/incus/network.go:1572 cmd/incus/network.go:1644 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520 cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826 cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997 cmd/incus/network_load_balancer.go:255 cmd/incus/network_load_balancer.go:336 cmd/incus/network_load_balancer.go:507 cmd/incus/network_load_balancer.go:642 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:895 cmd/incus/network_load_balancer.go:971 cmd/incus/network_load_balancer.go:1084 cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738 cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337 cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560 cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587 cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969 cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328 cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873 cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129 cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335 cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713 cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879 cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61 cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64 cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1486 cmd/incus/network.go:1579 cmd/incus/network.go:1651 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527 cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007 cmd/incus/network_load_balancer.go:255 cmd/incus/network_load_balancer.go:337 cmd/incus/network_load_balancer.go:513 cmd/incus/network_load_balancer.go:648 cmd/incus/network_load_balancer.go:813 cmd/incus/network_load_balancer.go:902 cmd/incus/network_load_balancer.go:980 cmd/incus/network_load_balancer.go:1094 cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110 cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839 cmd/incus/storage.go:941 cmd/incus/storage.go:1034 cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746 cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911 cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150 cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351 cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574 cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976 cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335 cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136 cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723 cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889 cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1170,7 +1186,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080 cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:139 cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551 cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424 cmd/incus/config_trust.go:613 cmd/incus/image.go:1093 cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087 cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:694 cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912 cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid   "Columns"
 msgstr  ""
 
@@ -1195,7 +1211,7 @@ msgstr  ""
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
@@ -1203,7 +1219,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new network integration"
 msgstr  ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
@@ -1215,7 +1231,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804 cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405 cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356 cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722 cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810 cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421 cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375 cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314 cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1237,11 +1253,11 @@ msgstr  ""
 msgid   "Connecting to the daemon (attempt %d)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1371,7 +1387,7 @@ msgstr  ""
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
@@ -1380,7 +1396,7 @@ msgstr  ""
 msgid   "Couldn't statfs %s: %w"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid   "Create a cluster group"
 msgstr  ""
 
@@ -1389,15 +1405,15 @@ msgstr  ""
 msgid   "Create a new %s pool?"
 msgstr  ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid   "Create a virtual machine"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid   "Create an empty instance"
 msgstr  ""
 
@@ -1429,11 +1445,11 @@ msgid   "Create instance snapshots\n"
         "running state, including process memory state, TCP connections, ..."
 msgstr  ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid   "Create instances from images"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid   "Create key for a storage bucket"
 msgstr  ""
 
@@ -1441,11 +1457,11 @@ msgstr  ""
 msgid   "Create network integrations"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1453,56 +1469,56 @@ msgstr  ""
 msgid   "Create new instance file templates"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:327 cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:329
 msgid   "Create new network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid   "Create new network peering"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid   "Create new network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid   "Create new network zones"
 msgstr  ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid   "Create new networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid   "Create profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid   "Create projects"
 msgstr  ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid   "Create storage pools"
 msgstr  ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664 cmd/incus/storage_volume.go:1446
+#: cmd/incus/image.go:999 cmd/incus/info.go:664 cmd/incus/storage_volume.go:1453
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
@@ -1512,7 +1528,7 @@ msgstr  ""
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1525,7 +1541,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:152 cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1675
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:438 cmd/incus/image.go:1115 cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:925 cmd/incus/operation.go:152 cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717 cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924 cmd/incus/storage_volume.go:1682
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1537,7 +1553,7 @@ msgstr  ""
 msgid   "DISK USAGE"
 msgstr  ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid   "DRIVER"
 msgstr  ""
 
@@ -1560,11 +1576,11 @@ msgstr  ""
 msgid   "Date: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1576,7 +1592,7 @@ msgstr  ""
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid   "Delete a cluster group"
 msgstr  ""
 
@@ -1584,7 +1600,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 msgid   "Delete custom storage volumes"
 msgstr  ""
 
@@ -1592,7 +1608,7 @@ msgstr  ""
 msgid   "Delete files in instances"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid   "Delete image aliases"
 msgstr  ""
 
@@ -1612,15 +1628,15 @@ msgstr  ""
 msgid   "Delete instances"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid   "Delete network forwards"
 msgstr  ""
 
@@ -1628,43 +1644,43 @@ msgstr  ""
 msgid   "Delete network integrations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:803 cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809 cmd/incus/network_load_balancer.go:810
 msgid   "Delete network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid   "Delete network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid   "Delete network zones"
 msgstr  ""
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid   "Delete networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid   "Delete profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid   "Delete projects"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid   "Delete storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid   "Delete storage volume snapshots"
 msgstr  ""
 
@@ -1672,32 +1688,32 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:169 cmd/incus/alias.go:224 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491 cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66 cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184 cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259 cmd/incus/network.go:1413 cmd/incus/network.go:1473 cmd/incus/network.go:1569 cmd/incus/network.go:1641 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30 cmd/incus/operation.go:63 cmd/incus/operation.go:114 cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762 cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957 cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317 cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562 cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797 cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964 cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264 cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:169 cmd/incus/alias.go:224 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617 cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758 cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896 cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593 cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792 cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491 cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266 cmd/incus/network.go:1420 cmd/incus/network.go:1480 cmd/incus/network.go:1576 cmd/incus/network.go:1648 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382 cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573 cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870 cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029 cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434 cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629 cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830 cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920 cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:329 cmd/incus/network_load_balancer.go:437 cmd/incus/network_load_balancer.go:505 cmd/incus/network_load_balancer.go:615 cmd/incus/network_load_balancer.go:645 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:884 cmd/incus/network_load_balancer.go:899 cmd/incus/network_load_balancer.go:977 cmd/incus/network_load_balancer.go:1076 cmd/incus/network_load_balancer.go:1091 cmd/incus/network_load_balancer.go:1166 cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472 cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659 cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493 cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624 cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807 cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084 cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277 cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454 cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530 cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30 cmd/incus/operation.go:63 cmd/incus/operation.go:114 cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359 cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642 cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964 cmd/incus/profile.go:1024 cmd/incus/profile.go:1113 cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105 cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443 cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798 cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991 cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833 cmd/incus/storage.go:937 cmd/incus/storage.go:1031 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741 cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844 cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211 cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418 cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580 cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769 cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964 cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324 cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569 cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877 cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120 cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283 cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468 cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563 cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807 cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974 cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264 cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 msgid   "Detach custom storage volumes from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 msgid   "Detach custom storage volumes from profiles"
 msgstr  ""
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
@@ -1752,7 +1768,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid   "Didn't get name of new instance from the server"
 msgstr  ""
 
@@ -1809,7 +1825,7 @@ msgstr  ""
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 msgid   "Display profiles from all projects"
 msgstr  ""
 
@@ -1817,7 +1833,7 @@ msgstr  ""
 msgid   "Display resource usage info per instance"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 msgid   "Display storage pool buckets from all projects"
 msgstr  ""
 
@@ -1866,7 +1882,7 @@ msgstr  ""
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid   "Down delay"
 msgstr  ""
 
@@ -1892,7 +1908,7 @@ msgstr  ""
 msgid   "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid   "ENTRIES"
 msgstr  ""
 
@@ -1905,11 +1921,11 @@ msgstr  ""
 msgid   "EXISTING: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623 cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626 cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid   "EXPIRES AT"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid   "EXPIRY DATE"
 msgstr  ""
 
@@ -1917,7 +1933,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid   "Edit a cluster group"
 msgstr  ""
 
@@ -1945,15 +1961,15 @@ msgstr  ""
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
@@ -1961,58 +1977,58 @@ msgstr  ""
 msgid   "Edit network integration configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:638 cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644 cmd/incus/network_load_balancer.go:645
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid   "Edit storage bucket configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid   "Edit storage bucket key as YAML"
 msgstr  ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid   "Edit storage volume configurations as YAML\n"
         "\n"
         "If the type is not specified, incus assumes the type is \"custom\".\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121 cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:167 cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661 cmd/incus/top.go:90 cmd/incus/warning.go:237
+#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450 cmd/incus/config_trust.go:634 cmd/incus/image.go:1133 cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128 cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:167 cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:729 cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933 cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671 cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2040,7 +2056,7 @@ msgstr  ""
 msgid   "Enter new delay in seconds:"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid   "Entry TTL"
 msgstr  ""
 
@@ -2048,7 +2064,7 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid   "Ephemeral instance"
 msgstr  ""
 
@@ -2072,7 +2088,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548 cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083 cmd/incus/project.go:855 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041 cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554 cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588 cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556 cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091 cmd/incus/project.go:861 cmd/incus/storage.go:903 cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048 cmd/incus/storage_volume.go:2091
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2087,7 +2103,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013 cmd/incus/network.go:1541 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622 cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230 cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035 cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021 cmd/incus/network.go:1548 cmd/incus/network_acl.go:542 cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246 cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897 cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042 cmd/incus/storage_volume.go:2085
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2173,7 +2189,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479 cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486 cmd/incus/storage_volume.go:1536
 msgid   "Expires at"
 msgstr  ""
 
@@ -2196,7 +2212,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -2208,24 +2224,24 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid   "Export storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid   "Export storage buckets as tarball."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, c-format
 msgid   "Exporting backup of storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2243,7 +2259,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117 cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117 cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2325,7 +2341,7 @@ msgstr  ""
 msgid   "Failed getting existing storage pools: %w"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
@@ -2335,17 +2351,17 @@ msgstr  ""
 msgid   "Failed import request: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid   "Failed loading network %q: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
@@ -2434,7 +2450,7 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid   "Failed to create backup: %v"
 msgstr  ""
@@ -2444,7 +2460,7 @@ msgstr  ""
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
@@ -2454,12 +2470,12 @@ msgstr  ""
 msgid   "Failed to delete original instance after copying it: %w"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid   "Failed to fetch storage bucket backup: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
@@ -2603,7 +2619,7 @@ msgstr  ""
 msgid   "Fetch instance backup file: %w"
 msgstr  ""
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133 cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133 cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2620,7 +2636,7 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid   "Force delete the project and everything it contains."
 msgstr  ""
 
@@ -2675,7 +2691,7 @@ msgstr  ""
 msgid   "Forces a connection to the console, even if there is already an active session"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081 cmd/incus/network.go:1280 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:137 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:612 cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088 cmd/incus/network.go:1287 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:867 cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910 cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574 cmd/incus/warning.go:95
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2691,7 +2707,7 @@ msgstr  ""
 msgid   "Format (table|compact)"
 msgstr  ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid   "Forward delay"
 msgstr  ""
 
@@ -2739,15 +2755,15 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 msgid   "Get current load balancer status"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 msgid   "Get current load-balacner status"
 msgstr  ""
 
@@ -2755,11 +2771,11 @@ msgstr  ""
 msgid   "Get image properties"
 msgstr  ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 msgid   "Get the key as a cluster group property"
 msgstr  ""
 
@@ -2771,7 +2787,7 @@ msgstr  ""
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
@@ -2779,15 +2795,15 @@ msgstr  ""
 msgid   "Get the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid   "Get the key as a network peer property"
 msgstr  ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid   "Get the key as a network property"
 msgstr  ""
 
@@ -2795,27 +2811,27 @@ msgstr  ""
 msgid   "Get the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid   "Get the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 msgid   "Get the key as a storage bucket property"
 msgstr  ""
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2823,7 +2839,7 @@ msgstr  ""
 msgid   "Get the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 msgid   "Get values for cluster group configuration keys"
 msgstr  ""
 
@@ -2843,11 +2859,11 @@ msgstr  ""
 msgid   "Get values for network ACL configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
@@ -2855,11 +2871,11 @@ msgstr  ""
 msgid   "Get values for network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:430 cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436 cmd/incus/network_load_balancer.go:437
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
@@ -2867,31 +2883,31 @@ msgstr  ""
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid   "Get values for storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid   "Get values for storage volume configuration keys\n"
         "\n"
         "If the type is not specified, incus assumes the type is \"custom\".\n"
@@ -2909,7 +2925,7 @@ msgstr  ""
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -2945,7 +2961,7 @@ msgstr  ""
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid   "ID"
 msgstr  ""
 
@@ -2959,7 +2975,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid   "IMAGES"
 msgstr  ""
 
@@ -2972,7 +2988,7 @@ msgstr  ""
 msgid   "IOMMU group: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid   "IP ADDRESS"
 msgstr  ""
 
@@ -2980,27 +2996,27 @@ msgstr  ""
 msgid   "IP addresses"
 msgstr  ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid   "IP addresses:"
 msgstr  ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid   "IPV4"
 msgstr  ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid   "IPV6"
 msgstr  ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid   "IPv4 uplink address"
 msgstr  ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid   "IPv6 uplink address"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid   "ISSUE DATE"
 msgstr  ""
 
@@ -3012,7 +3028,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -3024,7 +3040,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -3034,6 +3050,10 @@ msgstr  ""
 
 #: cmd/incus/action.go:166
 msgid   "Ignore the instance state"
+msgstr  ""
+
+#: cmd/incus/image_alias.go:71
+msgid   "Image alias description"
 msgstr  ""
 
 #: cmd/incus/image.go:1482
@@ -3078,15 +3098,15 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 msgid   "Import backups of storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 msgid   "Import custom storage volumes."
 msgstr  ""
 
@@ -3104,28 +3124,28 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 msgid   "Import storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid   "Import type needs to be \"backup\" or \"iso\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid   "Importing ISO images requires a volume name to be set"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, c-format
 msgid   "Importing bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -3135,7 +3155,7 @@ msgstr  ""
 msgid   "Importing instance: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid   "Include environment variables from file"
 msgstr  ""
 
@@ -3159,6 +3179,10 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
+#: cmd/incus/create.go:67
+msgid   "Instance description"
+msgstr  ""
+
 #: cmd/incus/file.go:1473
 msgid   "Instance disconnected"
 msgstr  ""
@@ -3172,7 +3196,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -3191,7 +3215,7 @@ msgstr  ""
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid   "Instance type"
 msgstr  ""
 
@@ -3199,7 +3223,7 @@ msgstr  ""
 msgid   "Invalid IP address or DNS name"
 msgstr  ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490 cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504 cmd/incus/storage_volume.go:3074
 #, c-format
 msgid   "Invalid URL %q: %w"
 msgstr  ""
@@ -3218,7 +3242,7 @@ msgstr  ""
 msgid   "Invalid arguments"
 msgstr  ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495 cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509 cmd/incus/storage_volume.go:3079
 #, c-format
 msgid   "Invalid backup name segment in path %q: %w"
 msgstr  ""
@@ -3228,7 +3252,7 @@ msgstr  ""
 msgid   "Invalid boolean value: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid   "Invalid certificate"
 msgstr  ""
 
@@ -3305,7 +3329,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -3314,7 +3338,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 msgid   "Invalid peer type"
 msgstr  ""
 
@@ -3323,7 +3347,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245 cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018 cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252 cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2934
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -3367,6 +3391,10 @@ msgstr  ""
 msgid   "Kernel Version"
 msgstr  ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid   "Key description"
+msgstr  ""
+
 #: cmd/incus/warning.go:213
 msgid   "LAST SEEN"
 msgstr  ""
@@ -3375,7 +3403,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid   "LIMIT"
 msgstr  ""
 
@@ -3383,7 +3411,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304 cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143 cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516 cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311 cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143 cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524 cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3401,12 +3429,12 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 msgid   "Launching the instance"
 msgstr  ""
 
@@ -3420,11 +3448,11 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid   "List DHCP leases"
 msgstr  ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid   "List DHCP leases\n"
         "\n"
         "Default column layout: hmitL\n"
@@ -3451,11 +3479,11 @@ msgstr  ""
 msgid   "List aliases"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid   "List all active certificate add tokens\n"
         "\n"
         "Default column layout: ntE\n"
@@ -3501,11 +3529,11 @@ msgid   "List all active cluster member join tokens\n"
         "  E - Expires At"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid   "List all the cluster groups\n"
         "\n"
         "Default column layout: ndm\n"
@@ -3643,7 +3671,7 @@ msgid   "List available network peers\n"
         "  s - State"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid   "List available network zone records"
 msgstr  ""
 
@@ -3673,11 +3701,11 @@ msgid   "List available network zone\n"
         "  u - Used by"
 msgstr  ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid   "List available networks"
 msgstr  ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid   "List available networks\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3697,11 +3725,11 @@ msgid   "List available networks\n"
         "u - Used by (count)"
 msgstr  ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid   "List available storage pools"
 msgstr  ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid   "List available storage pools\n"
         "\n"
         "Default column layout: nDSdus\n"
@@ -3754,11 +3782,11 @@ msgid   "List background operations\n"
         "  L - Location of the operation (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid   "List image aliases"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid   "List image aliases\n"
         "\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
@@ -3982,11 +4010,11 @@ msgid   "List network integrations\n"
         "	u - Used by"
 msgstr  ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 msgid   "List networks in all projects"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid   "List of projects to restrict the certificate to"
 msgstr  ""
 
@@ -3994,11 +4022,11 @@ msgstr  ""
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid   "List profiles"
 msgstr  ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid   "List profiles\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4013,11 +4041,11 @@ msgid   "List profiles\n"
         "u - Used By"
 msgstr  ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid   "List projects"
 msgstr  ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid   "List projects\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4037,11 +4065,11 @@ msgid   "List projects\n"
         "u - Used By"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid   "List storage bucket keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid   "List storage bucket keys\n"
         "\n"
         "Default column layout: ndr\n"
@@ -4062,11 +4090,11 @@ msgid   "List storage bucket keys\n"
         "  r - Role"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid   "List storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid   "List storage buckets\n"
         "\n"
         "Default column layout: ndL\n"
@@ -4088,11 +4116,11 @@ msgid   "List storage buckets\n"
         "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 msgid   "List storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid   "List storage volume snapshots\n"
         "\n"
         "	The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4105,11 +4133,11 @@ msgid   "List storage volume snapshots\n"
         "		E - Expiry"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid   "List storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4156,11 +4184,11 @@ msgid   "List the available remotes\n"
         "  g - Global"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid   "List trusted clients"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid   "List trusted clients\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4212,11 +4240,15 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid   "Load balancer description"
+msgstr  ""
+
 #: cmd/incus/info.go:494
 msgid   "Load:"
 msgstr  ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -4229,7 +4261,7 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid   "Logical router"
 msgstr  ""
 
@@ -4250,15 +4282,15 @@ msgstr  ""
 msgid   "Low-level cluster administration commands"
 msgstr  ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid   "Lower device"
 msgstr  ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid   "Lower devices"
 msgstr  ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid   "MAC ADDRESS"
 msgstr  ""
 
@@ -4266,7 +4298,7 @@ msgstr  ""
 msgid   "MAC address"
 msgstr  ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
@@ -4276,11 +4308,11 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid   "MANAGED"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid   "MEMBERS"
 msgstr  ""
 
@@ -4301,11 +4333,11 @@ msgstr  ""
 msgid   "MESSAGE"
 msgstr  ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid   "MII Frequency"
 msgstr  ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid   "MII state"
 msgstr  ""
 
@@ -4313,7 +4345,7 @@ msgstr  ""
 msgid   "MTU"
 msgstr  ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -4400,7 +4432,7 @@ msgstr  ""
 msgid   "Manage instance snapshots"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid   "Manage network ACL rules"
 msgstr  ""
 
@@ -4408,7 +4440,7 @@ msgstr  ""
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid   "Manage network forward ports"
 msgstr  ""
 
@@ -4420,11 +4452,11 @@ msgstr  ""
 msgid   "Manage network integrations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:876 cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:884
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1065 cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075 cmd/incus/network_load_balancer.go:1076
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
@@ -4436,11 +4468,11 @@ msgstr  ""
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid   "Manage network zone record entries"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid   "Manage network zone records"
 msgstr  ""
 
@@ -4456,11 +4488,11 @@ msgstr  ""
 msgid   "Manage projects"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid   "Manage storage bucket keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid   "Manage storage bucket keys."
 msgstr  ""
 
@@ -4476,7 +4508,7 @@ msgstr  ""
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 msgid   "Manage storage volume snapshots"
 msgstr  ""
 
@@ -4578,31 +4610,31 @@ msgstr  ""
 msgid   "Minimum size is 1GiB"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229 cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424 cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764 cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240 cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237 cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432 cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074 cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254 cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid   "Missing bucket name"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305 cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313 cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515 cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646 cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82 cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515 cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654 cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82 cmd/incus/cluster_role.go:150
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219 cmd/incus/config_template.go:115 cmd/incus/config_template.go:170 cmd/incus/config_template.go:224 cmd/incus/config_template.go:321 cmd/incus/config_template.go:392 cmd/incus/profile.go:145 cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219 cmd/incus/config_template.go:115 cmd/incus/config_template.go:170 cmd/incus/config_template.go:224 cmd/incus/config_template.go:321 cmd/incus/config_template.go:392 cmd/incus/profile.go:145 cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid   "Missing instance name"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165 cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid   "Missing key name"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357 cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557 cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863 cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038 cmd/incus/network_load_balancer.go:292 cmd/incus/network_load_balancer.go:361 cmd/incus/network_load_balancer.go:459 cmd/incus/network_load_balancer.go:544 cmd/incus/network_load_balancer.go:712 cmd/incus/network_load_balancer.go:844 cmd/incus/network_load_balancer.go:932 cmd/incus/network_load_balancer.go:1008 cmd/incus/network_load_balancer.go:1121 cmd/incus/network_load_balancer.go:1195 cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048 cmd/incus/network_load_balancer.go:292 cmd/incus/network_load_balancer.go:363 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:550 cmd/incus/network_load_balancer.go:718 cmd/incus/network_load_balancer.go:850 cmd/incus/network_load_balancer.go:940 cmd/incus/network_load_balancer.go:1017 cmd/incus/network_load_balancer.go:1132 cmd/incus/network_load_balancer.go:1207 cmd/incus/network_load_balancer.go:1317
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -4610,7 +4642,7 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280 cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415 cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666 cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834 cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280 cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674 cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid   "Missing network ACL name"
 msgstr  ""
 
@@ -4618,31 +4650,31 @@ msgstr  ""
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367 cmd/incus/network.go:1445 cmd/incus/network.go:1511 cmd/incus/network.go:1603 cmd/incus/network_forward.go:204 cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553 cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859 cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034 cmd/incus/network_load_balancer.go:207 cmd/incus/network_load_balancer.go:288 cmd/incus/network_load_balancer.go:357 cmd/incus/network_load_balancer.go:455 cmd/incus/network_load_balancer.go:540 cmd/incus/network_load_balancer.go:708 cmd/incus/network_load_balancer.go:840 cmd/incus/network_load_balancer.go:928 cmd/incus/network_load_balancer.go:1004 cmd/incus/network_load_balancer.go:1117 cmd/incus/network_load_balancer.go:1191 cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205 cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366 cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591 cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374 cmd/incus/network.go:1452 cmd/incus/network.go:1518 cmd/incus/network.go:1610 cmd/incus/network_forward.go:204 cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356 cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560 cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866 cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044 cmd/incus/network_load_balancer.go:207 cmd/incus/network_load_balancer.go:288 cmd/incus/network_load_balancer.go:359 cmd/incus/network_load_balancer.go:461 cmd/incus/network_load_balancer.go:546 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:846 cmd/incus/network_load_balancer.go:936 cmd/incus/network_load_balancer.go:1013 cmd/incus/network_load_balancer.go:1128 cmd/incus/network_load_balancer.go:1203 cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205 cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368 cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597 cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid   "Missing network name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521 cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967 cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548 cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781 cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975 cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225 cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564 cmd/incus/network_zone.go:1621
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid   "Missing network zone record name"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370 cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595 cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601 cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969 cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618 cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802 cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017 cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609 cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383 cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599 cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837 cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977 cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233 cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428 cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676 cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977 cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171 cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373 cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616 cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008 cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393 cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847 cmd/incus/storage_volume.go:2924
 msgid   "Missing pool name"
 msgstr  ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554 cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056 cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562 cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064 cmd/incus/profile.go:1145
 msgid   "Missing profile name"
 msgstr  ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357 cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828 cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363 cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834 cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid   "Missing project name"
 msgstr  ""
 
@@ -4654,11 +4686,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -4666,11 +4698,11 @@ msgstr  ""
 msgid   "Missing target directory"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 msgid   "Missing target network or integration"
 msgstr  ""
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid   "Mode"
 msgstr  ""
 
@@ -4694,7 +4726,7 @@ msgid   "Monitor a local or remote server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659 cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666 cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -4706,7 +4738,7 @@ msgstr  ""
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 msgid   "Move custom storage volumes between pools"
 msgstr  ""
 
@@ -4729,7 +4761,7 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid   "Move to a project different from the source"
 msgstr  ""
 
@@ -4738,11 +4770,11 @@ msgstr  ""
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
@@ -4754,7 +4786,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:584 cmd/incus/network.go:1101 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:624 cmd/incus/list.go:584 cmd/incus/network.go:1108 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924 cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715 cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923 cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid   "NAME"
 msgstr  ""
 
@@ -4762,11 +4794,11 @@ msgstr  ""
 msgid   "NAT"
 msgstr  ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -4783,7 +4815,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200 cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608 cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635 cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200 cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614 cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641 cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid   "NO"
 msgstr  ""
 
@@ -4805,7 +4837,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477 cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484 cmd/incus/storage_volume.go:1534
 msgid   "Name"
 msgstr  ""
 
@@ -4864,7 +4896,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976 cmd/incus/storage_volume.go:1424
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4874,59 +4906,71 @@ msgstr  ""
 msgid   "Name: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+msgid   "Network ACL description"
+msgstr  ""
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+msgid   "Network description"
+msgstr  ""
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid   "Network forward %s deleted"
+msgstr  ""
+
+#: cmd/incus/network_forward.go:335
+msgid   "Network forward description"
 msgstr  ""
 
 #: cmd/incus/network_integration.go:160
@@ -4944,54 +4988,54 @@ msgstr  ""
 msgid   "Network integration %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid   "Network name"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid   "Network peer %s created"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid   "Network peer %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid   "Network peer %s is in unexpected state %q"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid   "Network usage:"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
@@ -5004,7 +5048,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -5013,7 +5057,7 @@ msgstr  ""
 msgid   "No %s storage backends available"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
@@ -5023,27 +5067,27 @@ msgstr  ""
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid   "No device found for this network"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid   "No load-balancer health information available"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid   "No matching backend found"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid   "No matching port(s) found"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid   "No matching rule(s) found"
 msgstr  ""
 
@@ -5051,11 +5095,11 @@ msgstr  ""
 msgid   "No storage backends available"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -5093,7 +5137,7 @@ msgstr  ""
 msgid   "OS Version"
 msgstr  ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid   "OVN:"
 msgstr  ""
 
@@ -5101,11 +5145,11 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -5117,11 +5161,11 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -5142,7 +5186,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -5188,15 +5232,15 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513 cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77 cmd/incus/warning.go:214
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132 cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521 cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77 cmd/incus/warning.go:214
 msgid   "PROJECT"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid   "PROJECTS"
 msgstr  ""
 
@@ -5208,11 +5252,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid   "Packets sent"
 msgstr  ""
 
@@ -5243,6 +5287,10 @@ msgstr  ""
 msgid   "Pause instances"
 msgstr  ""
 
+#: cmd/incus/network_peer.go:335
+msgid   "Peer description"
+msgstr  ""
+
 #: cmd/incus/copy.go:64
 msgid   "Perform an incremental copy"
 msgstr  ""
@@ -5265,6 +5313,10 @@ msgstr  ""
 
 #: cmd/incus/admin_recover.go:101
 msgid   "Pool name cannot be empty"
+msgstr  ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid   "Port description"
 msgstr  ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -5305,7 +5357,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:465 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805 cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406 cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301 cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:357 cmd/incus/image.go:465 cmd/incus/network.go:810 cmd/incus/network_acl.go:723 cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811 cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422 cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376 cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315 cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5360,36 +5412,40 @@ msgstr  ""
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid   "Profile %s renamed to %s"
+msgstr  ""
+
+#: cmd/incus/profile.go:369
+msgid   "Profile description"
 msgstr  ""
 
 #: cmd/incus/image.go:161
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
@@ -5410,19 +5466,23 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid   "Project %s renamed to %s"
+msgstr  ""
+
+#: cmd/incus/project.go:114
+msgid   "Project description"
 msgstr  ""
 
 #: cmd/incus/remote.go:124
@@ -5442,7 +5502,7 @@ msgstr  ""
 msgid   "Protocol: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, c-format
 msgid   "Provided certificate path doesn't exist: %s"
 msgstr  ""
@@ -5495,15 +5555,15 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid   "RESOURCE"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid   "RESTRICTED"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid   "ROLE"
 msgstr  ""
 
@@ -5522,6 +5582,10 @@ msgstr  ""
 
 #: cmd/incus/rebuild.go:26
 msgid   "Rebuild instances"
+msgstr  ""
+
+#: cmd/incus/network_zone.go:1092
+msgid   "Record description"
 msgstr  ""
 
 #: cmd/incus/admin_recover.go:28
@@ -5563,7 +5627,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927 cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927 cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -5601,12 +5665,12 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid   "Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
@@ -5614,7 +5678,7 @@ msgstr  ""
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
@@ -5622,23 +5686,23 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid   "Remove all ports that match"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
@@ -5646,19 +5710,19 @@ msgstr  ""
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid   "Remove member from group"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1153 cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165 cmd/incus/network_load_balancer.go:1166
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -5670,7 +5734,7 @@ msgstr  ""
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
@@ -5679,11 +5743,11 @@ msgstr  ""
 msgid   "Remove snapshot %s from %s (yes/no): "
 msgstr  ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid   "Remove trusted client"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid   "Rename a cluster group"
 msgstr  ""
 
@@ -5691,11 +5755,11 @@ msgstr  ""
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367 cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372 cmd/incus/image_alias.go:373
 msgid   "Rename aliases"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 msgid   "Rename custom storage volumes"
 msgstr  ""
 
@@ -5707,7 +5771,7 @@ msgstr  ""
 msgid   "Rename instances"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid   "Rename network ACLs"
 msgstr  ""
 
@@ -5715,15 +5779,15 @@ msgstr  ""
 msgid   "Rename network integrations"
 msgstr  ""
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid   "Rename networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid   "Rename profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid   "Rename projects"
 msgstr  ""
 
@@ -5731,16 +5795,16 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 msgid   "Rename storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
@@ -5780,7 +5844,7 @@ msgstr  ""
 msgid   "Restore instance snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -5789,7 +5853,7 @@ msgstr  ""
 msgid   "Restoring cluster member: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid   "Restrict the certificate to one or more projects"
 msgstr  ""
 
@@ -5801,12 +5865,12 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid   "Revoke certificate add token"
 msgstr  ""
 
@@ -5814,13 +5878,17 @@ msgstr  ""
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid   "Rows affected: %d"
+msgstr  ""
+
+#: cmd/incus/network_acl.go:887
+msgid   "Rule description"
 msgstr  ""
 
 #: cmd/incus/remote_unix.go:36
@@ -5860,7 +5928,7 @@ msgstr  ""
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid   "SOURCE"
 msgstr  ""
 
@@ -5887,7 +5955,7 @@ msgstr  ""
 msgid   "STARTED AT"
 msgstr  ""
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108 cmd/incus/network_peer.go:132 cmd/incus/operation.go:153 cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115 cmd/incus/network_peer.go:132 cmd/incus/operation.go:153 cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid   "STATE"
 msgstr  ""
 
@@ -5903,7 +5971,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -5911,11 +5979,11 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid   "STP"
 msgstr  ""
 
@@ -5923,11 +5991,11 @@ msgstr  ""
 msgid   "Scanning for unknown volumes..."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid   "Secret key (auto-generated if empty)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid   "Secret key: %s"
 msgstr  ""
@@ -5963,7 +6031,7 @@ msgstr  ""
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273 cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273 cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid   "Server isn't part of a cluster"
 msgstr  ""
 
@@ -5981,7 +6049,7 @@ msgstr  ""
 msgid   "Server: %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 msgid   "Set a cluster group's configuration keys"
 msgstr  ""
 
@@ -6026,33 +6094,33 @@ msgid   "Set instance or server configuration keys\n"
         "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid   "Set network ACL configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid   "Set network ACL configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6070,92 +6138,92 @@ msgid   "Set network integration configuration keys\n"
         "    incus network integration set [<remote>:]<network integration> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid   "Set network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid   "Set network peer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid   "Set storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid   "Set storage bucket configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid   "Set storage pool configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6193,7 +6261,7 @@ msgstr  ""
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 msgid   "Set the key as a cluster group property"
 msgstr  ""
 
@@ -6201,11 +6269,11 @@ msgstr  ""
 msgid   "Set the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
@@ -6213,43 +6281,43 @@ msgstr  ""
 msgid   "Set the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid   "Set the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 msgid   "Set the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid   "Set the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 msgid   "Set the key as a storage bucket property"
 msgstr  ""
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -6277,7 +6345,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid   "Show cluster group configurations"
 msgstr  ""
 
@@ -6337,7 +6405,7 @@ msgstr  ""
 msgid   "Show network ACL log"
 msgstr  ""
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid   "Show network configurations"
 msgstr  ""
 
@@ -6361,39 +6429,39 @@ msgstr  ""
 msgid   "Show network zone configurations"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid   "Show network zone record configuration"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid   "Show project options"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid   "Show storage bucket configurations"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid   "Show storage bucket key configurations"
 msgstr  ""
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid   "Show storage volume configurations\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
@@ -6402,26 +6470,26 @@ msgid   "Show storage volume configurations\n"
         "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 msgid   "Show storage volume snapshhot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 msgid   "Show storage volume snapshot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid   "Show storage volume state information\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid   "Show the current project"
 msgstr  ""
 
@@ -6433,7 +6501,7 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 msgid   "Show the instance's access list"
 msgstr  ""
 
@@ -6445,15 +6513,15 @@ msgstr  ""
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid   "Show the used and free space in bytes"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid   "Show trust configurations"
 msgstr  ""
 
@@ -6465,7 +6533,7 @@ msgstr  ""
 msgid   "Show useful information about images"
 msgstr  ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
@@ -6487,15 +6555,19 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid   "Snapshot description"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -6543,7 +6615,7 @@ msgstr  ""
 msgid   "State"
 msgstr  ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid   "State: %s"
 msgstr  ""
@@ -6578,22 +6650,22 @@ msgstr  ""
 msgid   "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, c-format
 msgid   "Storage bucket %q created"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, c-format
 msgid   "Storage bucket %q deleted"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, c-format
 msgid   "Storage bucket key %q added"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, c-format
 msgid   "Storage bucket key %q removed"
 msgstr  ""
@@ -6612,22 +6684,26 @@ msgstr  ""
 msgid   "Storage pool %q of type %q"
 msgstr  ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid   "Storage pool %s created"
 msgstr  ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid   "Storage pool %s deleted"
 msgstr  ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34 cmd/incus/move.go:63
+#: cmd/incus/storage.go:111
+msgid   "Storage pool description"
+msgstr  ""
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34 cmd/incus/move.go:63
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -6635,12 +6711,12 @@ msgstr  ""
 msgid   "Storage pool to use or create"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
@@ -6653,7 +6729,7 @@ msgstr  ""
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, c-format
 msgid   "Storage volume snapshot %s deleted from %s"
 msgstr  ""
@@ -6684,7 +6760,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -6700,7 +6776,7 @@ msgstr  ""
 msgid   "System:"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid   "TAKEN AT"
 msgstr  ""
 
@@ -6708,15 +6784,15 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102 cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673 cmd/incus/warning.go:217
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123 cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109 cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680 cmd/incus/warning.go:217
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid   "Taken at"
 msgstr  ""
 
@@ -6779,7 +6855,7 @@ msgstr  ""
 msgid   "The device already exists"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
@@ -6799,7 +6875,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -6807,7 +6883,7 @@ msgstr  ""
 msgid   "The is no config key to set on an instance snapshot."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, c-format
 msgid   "The key %q does not exist on cluster group %q"
 msgstr  ""
@@ -6835,7 +6911,7 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, c-format
 msgid   "The property %q does not exist on the cluster group %q: %v"
 msgstr  ""
@@ -6855,12 +6931,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, c-format
 msgid   "The property %q does not exist on the network %q: %v"
 msgstr  ""
@@ -6870,7 +6946,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
@@ -6880,7 +6956,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network integration %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, c-format
 msgid   "The property %q does not exist on the network peer %q: %v"
 msgstr  ""
@@ -6890,37 +6966,37 @@ msgstr  ""
 msgid   "The property %q does not exist on the network zone %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, c-format
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, c-format
 msgid   "The property %q does not exist on the storage bucket %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, c-format
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -6966,11 +7042,11 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673 cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680 cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
@@ -7017,11 +7093,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid   "To attach a network to an instance, use: incus network attach"
 msgstr  ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid   "To create a new network, use: incus network create"
 msgstr  ""
 
@@ -7034,7 +7110,7 @@ msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387 cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387 cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -7042,7 +7118,7 @@ msgstr  ""
 msgid   "Too many links"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -7057,7 +7133,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -7087,7 +7163,7 @@ msgstr  ""
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid   "Transmit policy"
 msgstr  ""
 
@@ -7105,7 +7181,7 @@ msgstr  ""
 msgid   "Type"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid   "Type of certificate"
 msgstr  ""
 
@@ -7113,16 +7189,16 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434 cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973 cmd/incus/storage_volume.go:1426
+#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434 cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980 cmd/incus/storage_volume.go:1433
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -7134,7 +7210,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid   "USAGE"
 msgstr  ""
 
@@ -7146,7 +7222,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:748 cmd/incus/project.go:560 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1677
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:756 cmd/incus/project.go:566 cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1684
 msgid   "USED BY"
 msgstr  ""
 
@@ -7172,7 +7248,7 @@ msgstr  ""
 msgid   "Unavailable remote server"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid   "Unknown certificate type %q"
 msgstr  ""
@@ -7182,7 +7258,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127 cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:173 cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667 cmd/incus/top.go:96 cmd/incus/warning.go:245
+#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458 cmd/incus/config_trust.go:640 cmd/incus/image.go:1141 cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134 cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:173 cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:735 cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939 cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677 cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7197,7 +7273,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid   "Unknown key: %s"
 msgstr  ""
@@ -7207,7 +7283,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 msgid   "Unset a cluster group's configuration keys"
 msgstr  ""
 
@@ -7231,19 +7307,19 @@ msgstr  ""
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid   "Unset network forward keys"
 msgstr  ""
 
@@ -7251,58 +7327,58 @@ msgstr  ""
 msgid   "Unset network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid   "Unset network peer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid   "Unset network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid   "Unset storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid   "Unset storage volume configuration keys\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 msgid   "Unset the key as a cluster group property"
 msgstr  ""
 
@@ -7310,11 +7386,11 @@ msgstr  ""
 msgid   "Unset the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
@@ -7322,43 +7398,43 @@ msgstr  ""
 msgid   "Unset the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid   "Unset the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 msgid   "Unset the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid   "Unset the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 msgid   "Unset the key as a storage bucket property"
 msgstr  ""
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -7371,7 +7447,7 @@ msgstr  ""
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid   "Up delay"
 msgstr  ""
 
@@ -7397,16 +7473,16 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid   "Upper devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -7427,7 +7503,7 @@ msgstr  ""
 msgid   "User aborted configuration"
 msgstr  ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228 cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234 cmd/incus/snapshot.go:257
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -7440,15 +7516,15 @@ msgstr  ""
 msgid   "VFs: %d"
 msgstr  ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid   "VLAN ID"
 msgstr  ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid   "VLAN filtering"
 msgstr  ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid   "VLAN:"
 msgstr  ""
 
@@ -7487,8 +7563,12 @@ msgstr  ""
 msgid   "Version: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid   "Volume Only"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:590
+msgid   "Volume description"
 msgstr  ""
 
 #: cmd/incus/info.go:307
@@ -7629,7 +7709,7 @@ msgstr  ""
 msgid   "Would you like to use clustering?"
 msgstr  ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203 cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610 cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637 cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203 cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616 cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643 cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid   "YES"
 msgstr  ""
 
@@ -7657,7 +7737,11 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid   "Zone description"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:865
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
@@ -7665,7 +7749,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1058 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509 cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70 cmd/incus/webui.go:17
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31 cmd/incus/network.go:1065 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -7677,11 +7761,11 @@ msgstr  ""
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid   "[<remote>:] <cert>"
 msgstr  ""
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -7689,31 +7773,31 @@ msgstr  ""
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249 cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249 cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid   "[<remote>:]<ACL> <key>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid   "[<remote>:]<ACL> [key=value...]"
 msgstr  ""
 
@@ -7721,51 +7805,51 @@ msgstr  ""
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614 cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622 cmd/incus/network_zone.go:748
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid   "[<remote>:]<alias>"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid   "[<remote>:]<alias> <fingerprint>"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740 cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:861
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269 cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277 cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 msgid   "[<remote>:]<group> <key>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 msgid   "[<remote>:]<group> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
@@ -7789,7 +7873,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:]<instance>"
 msgstr  ""
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
@@ -7833,7 +7917,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr  ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
@@ -7901,7 +7985,7 @@ msgstr  ""
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607 cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615 cmd/incus/cluster_group.go:818
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
@@ -7945,11 +8029,11 @@ msgstr  ""
 msgid   "[<remote>:]<network integration> <type>"
 msgstr  ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1257 cmd/incus/network.go:1567 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97 cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1264 cmd/incus/network.go:1574 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97 cmd/incus/network_peer.go:84
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
@@ -7957,51 +8041,51 @@ msgstr  ""
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250 cmd/incus/network_load_balancer.go:637 cmd/incus/network_load_balancer.go:801 cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674 cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250 cmd/incus/network_load_balancer.go:643 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:1287
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620 cmd/incus/network_load_balancer.go:429 cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627 cmd/incus/network_load_balancer.go:435 cmd/incus/network_load_balancer.go:613
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid   "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
@@ -8009,23 +8093,23 @@ msgstr  ""
 msgid   "[<remote>:]<network> <peer name>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid   "[<remote>:]<network> <peer_name>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 msgid   "[<remote>:]<network> <peer_name> <[target project/]<target network or integration> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid   "[<remote>:]<network> <peer_name> <key>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
@@ -8033,7 +8117,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
@@ -8041,59 +8125,59 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 msgid   "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260 cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid   "[<remote>:]<pool> <bucket>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800 cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131 cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808 cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid   "[<remote>:]<pool> <bucket> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid   "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 msgid   "[<remote>:]<pool> <bucket> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid   "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid   "[<remote>:]<pool> <driver> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid   "[<remote>:]<pool> <key>"
 msgstr  ""
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 msgid   "[<remote>:]<pool> <old name> <new name>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -8101,51 +8185,51 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 msgid   "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 msgid   "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322 cmd/incus/storage_volume.go:2118
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -8153,7 +8237,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754 cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496 cmd/incus/profile.go:1103
+#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754 cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504 cmd/incus/profile.go:1111
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -8169,11 +8253,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
@@ -8181,7 +8265,7 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
@@ -8189,19 +8273,19 @@ msgstr  ""
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299 cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305 cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -8213,27 +8297,27 @@ msgstr  ""
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306 cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322 cmd/incus/network_zone.go:1451
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
@@ -8265,11 +8349,11 @@ msgstr  ""
 msgid   "application"
 msgstr  ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid   "current"
 msgstr  ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid   "description"
 msgstr  ""
 
@@ -8277,7 +8361,7 @@ msgstr  ""
 msgid   "disabled"
 msgstr  ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid   "driver"
 msgstr  ""
 
@@ -8322,7 +8406,7 @@ msgid   "incus cluster group assign foo default,bar\n"
         "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid   "incus cluster group create g1\n"
         "\n"
         "incus cluster group create g1 < config.yaml\n"
@@ -8357,7 +8441,7 @@ msgid   "incus config template create u1 t1\n"
         "    Create template t1 for instance u1 from config.tpl"
 msgstr  ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid   "incus create images:ubuntu/22.04 u1\n"
         "\n"
         "incus create images:ubuntu/22.04 u1 < config.yaml\n"
@@ -8367,7 +8451,7 @@ msgid   "incus create images:ubuntu/22.04 u1\n"
         "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr  ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid   "incus create storage s1 dir\n"
         "\n"
         "incus create storage s1 dir < config.yaml\n"
@@ -8479,14 +8563,14 @@ msgid   "incus move [<remote>:]<source instance> [<remote>:][<destination instan
         "    Rename a snapshot."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid   "incus network acl create a1\n"
         "\n"
         "incus network acl create a1 < config.yaml\n"
         "    Create network acl with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid   "incus network create foo\n"
         "    Create a new network called foo\n"
         "\n"
@@ -8497,7 +8581,7 @@ msgid   "incus network create foo\n"
         "    Create a new OVN network called bar using baz as its uplink network"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid   "incus network forward create n1 127.0.0.1\n"
         "\n"
         "incus network forward create n1 127.0.0.1 < config.yaml\n"
@@ -8516,14 +8600,14 @@ msgid   "incus network integration edit <network integration> < network-integrat
         "    Update a network integration using the content of network-integration.yaml"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid   "incus network load-balancer create n1 127.0.0.1\n"
         "\n"
         "incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
         "    Create network load-balancer for network n1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid   "incus network peer create default peer1 web/default\n"
         "    Create a new peering between network \"default\" in the current project and network \"default\" in the \"web\" project\n"
         "\n"
@@ -8535,14 +8619,14 @@ msgid   "incus network peer create default peer1 web/default\n"
         "	in the file config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid   "incus network zone create z1\n"
         "\n"
         "incus network zone create z1 < config.yaml\n"
         "    Create network zone z1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid   "incus network zone record create z1 r1\n"
         "\n"
         "incus network zone record create z1 r1 < config.yaml\n"
@@ -8565,7 +8649,7 @@ msgid   "incus profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid   "incus profile create p1\n"
         "    Create a profile named p1\n"
         "\n"
@@ -8581,12 +8665,12 @@ msgid   "incus profile device add [<remote>:]profile1 <device-name> disk source=
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid   "incus profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid   "incus project create p1\n"
         "    Create a project named p1\n"
         "\n"
@@ -8594,7 +8678,7 @@ msgid   "incus project create p1\n"
         "    Create a project named p1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid   "incus project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -8617,7 +8701,7 @@ msgid   "incus snapshot restore u1 snap0\n"
         "    Restore instance u1 to snapshot snap0"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid   "incus storage bucket create p1 b01\n"
         "	Create a new storage bucket named b01 in storage pool p1\n"
         "\n"
@@ -8625,27 +8709,27 @@ msgid   "incus storage bucket create p1 b01\n"
         "	Create a new storage bucket named b01 in storage pool p1 using the content of config.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid   "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
         "    Update a storage bucket using the content of bucket.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid   "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
         "    Update a storage bucket key using the content of key.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid   "incus storage bucket export default b1\n"
         "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid   "incus storage bucket import default backup0.tar.gz\n"
         "		Create a new storage bucket using backup0.tar.gz as the source."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid   "incus storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1.\n"
         "\n"
@@ -8653,22 +8737,22 @@ msgid   "incus storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1 using the content of config.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid   "incus storage bucket key show default data foo\n"
         "    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid   "incus storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid   "incus storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid   "incus storage volume create default foo\n"
         "    Create custom storage volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8676,7 +8760,7 @@ msgid   "incus storage volume create default foo\n"
         "    Create custom storage volume \"foo\" in pool \"default\" with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid   "incus storage volume edit default container/c1\n"
         "    Edit container storage volume \"c1\" in pool \"default\"\n"
         "\n"
@@ -8684,7 +8768,7 @@ msgid   "incus storage volume edit default container/c1\n"
         "    Edit custom storage volume \"foo\" in pool \"default\" using the content of volume.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid   "incus storage volume get default data size\n"
         "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
         "\n"
@@ -8692,7 +8776,7 @@ msgid   "incus storage volume get default data size\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume using backup0.tar.gz as the source\n"
         "\n"
@@ -8700,7 +8784,7 @@ msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume storing some-installer.iso for use as a CD-ROM image"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid   "incus storage volume info default foo\n"
         "    Returns state information for a custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8708,7 +8792,7 @@ msgid   "incus storage volume info default foo\n"
         "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid   "incus storage volume set default data size=1GiB\n"
         "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
         "\n"
@@ -8716,7 +8800,7 @@ msgid   "incus storage volume set default data size=1GiB\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid   "incus storage volume show default foo\n"
         "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8727,7 +8811,7 @@ msgid   "incus storage volume show default foo\n"
         "    Will show the properties of the container volume \"c1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid   "incus storage volume snapshot create default foo snap0\n"
         "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
         "\n"
@@ -8735,7 +8819,7 @@ msgid   "incus storage volume snapshot create default foo snap0\n"
         "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid   "incus storage volume unset default foo size\n"
         "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8743,7 +8827,7 @@ msgid   "incus storage volume unset default foo size\n"
         "    Removes the snapshot expiration period of virtual machine volume \"v1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid   "info"
 msgstr  ""
 
@@ -8751,11 +8835,11 @@ msgstr  ""
 msgid   "n"
 msgstr  ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid   "name"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976 cmd/incus/image.go:1181
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976 cmd/incus/image.go:1181
 msgid   "no"
 msgstr  ""
 
@@ -8767,7 +8851,7 @@ msgstr  ""
 msgid   "please use `incus profile`"
 msgstr  ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid   "space used"
 msgstr  ""
 
@@ -8784,7 +8868,7 @@ msgstr  ""
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid   "total space"
 msgstr  ""
 
@@ -8792,7 +8876,7 @@ msgstr  ""
 msgid   "unreachable"
 msgstr  ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid   "used by"
 msgstr  ""
 
@@ -8800,7 +8884,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493 cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978 cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496 cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978 cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid   "yes"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -58,7 +58,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -119,7 +119,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -135,7 +135,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -242,7 +242,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -285,7 +285,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -340,7 +340,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -389,7 +389,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -421,7 +421,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -450,7 +450,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -479,7 +479,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -514,7 +514,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -550,7 +550,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr "Il nome del container è: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -827,25 +827,25 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Action (defaults to GET)"
 msgstr "Azione (default a GET)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -882,12 +882,12 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -904,12 +904,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -922,7 +922,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -949,12 +949,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr "La periferica esiste già: %s"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -969,8 +969,8 @@ msgstr "il remote %s esiste già"
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
@@ -992,7 +992,7 @@ msgstr "Alias:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr ""
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1112,7 +1112,11 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -1121,22 +1125,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -1145,22 +1149,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1170,7 +1174,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -1183,8 +1187,12 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+msgid "Bucket description"
 msgstr ""
 
 #: cmd/incus/info.go:365
@@ -1192,11 +1200,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1204,11 +1212,11 @@ msgstr "Byte inviati"
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1300,7 +1308,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1308,7 +1316,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1342,7 +1350,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1361,7 +1369,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1376,10 +1384,14 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
+
+#: cmd/incus/config_trust.go:184
+msgid "Certificate description"
+msgstr ""
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1398,7 +1410,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1427,25 +1439,30 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "Il nome del container è: %s"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1457,57 +1474,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1516,17 +1533,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Colonne"
@@ -1554,7 +1571,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1563,7 +1580,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1575,16 +1592,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1606,11 +1623,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1748,7 +1765,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1757,7 +1774,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1766,16 +1783,16 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
@@ -1812,12 +1829,12 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1826,12 +1843,12 @@ msgstr ""
 msgid "Create network integrations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1840,60 +1857,60 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
@@ -1903,7 +1920,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1917,16 +1934,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1938,7 +1955,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1961,11 +1978,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1977,7 +1994,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1985,7 +2002,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Creazione del container in corso"
@@ -1995,7 +2012,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2017,15 +2034,15 @@ msgstr "Creazione del container in corso"
 msgid "Delete instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2034,47 +2051,47 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Creazione del container in corso"
@@ -2097,12 +2114,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2117,11 +2134,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2129,31 +2146,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2161,45 +2178,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2207,63 +2224,63 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2325,7 +2342,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2388,7 +2405,7 @@ msgstr "Creazione del container in corso"
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
@@ -2397,7 +2414,7 @@ msgstr "Creazione del container in corso"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Creazione del container in corso"
@@ -2448,7 +2465,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2477,7 +2494,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2490,13 +2507,13 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
@@ -2506,7 +2523,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2535,15 +2552,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2552,52 +2569,52 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2606,22 +2623,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2655,7 +2672,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2663,7 +2680,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2687,15 +2704,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2710,14 +2727,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2808,8 +2825,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2833,7 +2850,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2847,26 +2864,26 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2884,8 +2901,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2967,7 +2984,7 @@ msgstr "Accetta certificato"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2977,17 +2994,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
@@ -3076,7 +3093,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Accetta certificato"
@@ -3086,7 +3103,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
@@ -3096,12 +3113,12 @@ msgstr "Accetta certificato"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
@@ -3248,7 +3265,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -3267,7 +3284,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3331,19 +3348,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3360,7 +3377,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3410,16 +3427,16 @@ msgstr "Accetta certificato"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Il nome del container è: %s"
@@ -3428,11 +3445,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Il nome del container è: %s"
@@ -3445,7 +3462,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3454,16 +3471,16 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3472,29 +3489,29 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3502,7 +3519,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3524,11 +3541,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -3537,13 +3554,13 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3553,33 +3570,33 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3600,7 +3617,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3638,7 +3655,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3652,7 +3669,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3665,7 +3682,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3673,27 +3690,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3705,7 +3722,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3719,7 +3736,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3731,6 +3748,10 @@ msgstr ""
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
+msgstr ""
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -3774,16 +3795,16 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Creazione del container in corso"
@@ -3804,29 +3825,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3836,7 +3857,7 @@ msgstr "Creazione del container in corso"
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3861,6 +3882,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "Il nome del container è: %s"
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3874,7 +3900,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3893,7 +3919,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3902,8 +3928,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
@@ -3923,8 +3949,8 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid arguments"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3934,7 +3960,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -4012,7 +4038,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -4022,7 +4048,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Proprietà errata: %s"
@@ -4032,9 +4058,9 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -4081,6 +4107,10 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid "Key description"
+msgstr ""
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -4089,7 +4119,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -4097,10 +4127,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4118,12 +4148,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
@@ -4138,11 +4168,11 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4171,12 +4201,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias:"
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4225,12 +4255,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4375,7 +4405,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
@@ -4407,11 +4437,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4432,11 +4462,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4491,11 +4521,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4737,12 +4767,12 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4751,11 +4781,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4771,11 +4801,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4796,11 +4826,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4822,12 +4852,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4850,12 +4880,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4869,11 +4899,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4922,11 +4952,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4982,11 +5012,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4999,7 +5033,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -5020,17 +5054,17 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 #, fuzzy
 msgid "Lower device"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 #, fuzzy
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5038,7 +5072,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -5048,11 +5082,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5073,11 +5107,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5085,7 +5119,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5181,7 +5215,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -5189,7 +5223,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -5202,14 +5236,14 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
@@ -5224,12 +5258,12 @@ msgstr "Creazione del container in corso"
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
@@ -5247,12 +5281,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -5270,7 +5304,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Creazione del container in corso"
@@ -5377,29 +5411,29 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -5409,32 +5443,32 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 #, fuzzy
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -5447,10 +5481,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
@@ -5463,86 +5497,86 @@ msgstr "Il nome del container è: %s"
 msgid "Missing network integration name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -5556,11 +5590,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -5569,12 +5603,12 @@ msgstr "Il nome del container è: %s"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5600,8 +5634,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5614,7 +5648,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Creazione del container in corso"
@@ -5643,7 +5677,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5652,11 +5686,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5669,15 +5703,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5685,11 +5719,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5706,9 +5740,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5732,8 +5766,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5793,8 +5827,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5804,59 +5838,71 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+msgid "Network ACL description"
+msgstr ""
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+msgid "Network description"
+msgstr ""
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
+msgstr ""
+
+#: cmd/incus/network_forward.go:335
+msgid "Network forward description"
 msgstr ""
 
 #: cmd/incus/network_integration.go:160
@@ -5874,55 +5920,55 @@ msgstr "Il nome del container è: %s"
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5935,7 +5981,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5944,7 +5990,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5954,27 +6000,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5982,11 +6028,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6026,7 +6072,7 @@ msgstr ""
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -6034,11 +6080,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6050,11 +6096,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6077,7 +6123,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6125,19 +6171,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6149,11 +6195,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -6185,6 +6231,10 @@ msgstr ""
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
 
+#: cmd/incus/network_peer.go:335
+msgid "Peer description"
+msgstr ""
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6208,6 +6258,10 @@ msgstr ""
 
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
+msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid "Port description"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -6248,17 +6302,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6313,29 +6367,33 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/profile.go:369
+msgid "Profile description"
 msgstr ""
 
 #: cmd/incus/image.go:161
@@ -6343,7 +6401,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6365,19 +6423,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/project.go:114
+msgid "Project description"
 msgstr ""
 
 #: cmd/incus/remote.go:124
@@ -6397,7 +6459,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Il nome del container è: %s"
@@ -6451,15 +6513,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6481,6 +6543,10 @@ msgstr "Creazione del container in corso"
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
+
+#: cmd/incus/network_zone.go:1092
+msgid "Record description"
+msgstr ""
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6527,7 +6593,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -6566,14 +6632,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
@@ -6582,7 +6648,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -6591,25 +6657,25 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6618,21 +6684,21 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6645,7 +6711,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6654,11 +6720,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6666,12 +6732,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Creazione del container in corso"
@@ -6686,7 +6752,7 @@ msgstr "Creazione del container in corso"
 msgid "Rename instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6695,15 +6761,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6711,17 +6777,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6765,7 +6831,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6774,7 +6840,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6787,12 +6853,12 @@ msgstr "Creazione del container in corso"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
@@ -6802,13 +6868,17 @@ msgstr "Il nome del container è: %s"
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
+msgstr ""
+
+#: cmd/incus/network_acl.go:887
+msgid "Rule description"
 msgstr ""
 
 #: cmd/incus/remote_unix.go:36
@@ -6849,7 +6919,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6877,9 +6947,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr "CREATO IL"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6895,7 +6965,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6903,11 +6973,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6915,11 +6985,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6956,7 +7026,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6974,7 +7044,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -7027,11 +7097,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7040,11 +7110,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7053,11 +7123,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7081,12 +7151,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7095,11 +7165,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7108,12 +7178,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7122,16 +7192,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7140,11 +7210,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7153,12 +7223,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7167,11 +7237,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7180,11 +7250,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7226,7 +7296,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Creazione del container in corso"
@@ -7235,11 +7305,11 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -7248,47 +7318,47 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7316,7 +7386,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
@@ -7379,7 +7449,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7408,43 +7478,43 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7456,21 +7526,21 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7479,7 +7549,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7491,7 +7561,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Creazione del container in corso"
@@ -7505,15 +7575,15 @@ msgstr "Creazione del container in corso"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr ""
 
@@ -7526,7 +7596,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7548,15 +7618,19 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7608,7 +7682,7 @@ msgstr ""
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -7643,22 +7717,22 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Il nome del container è: %s"
@@ -7677,22 +7751,26 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+msgid "Storage pool description"
+msgstr ""
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7701,12 +7779,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7719,7 +7797,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Creazione del container in corso"
@@ -7752,7 +7830,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7768,7 +7846,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7776,20 +7854,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -7863,7 +7941,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7885,7 +7963,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7893,7 +7971,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Il nome del container è: %s"
@@ -7922,7 +8000,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7942,12 +8020,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7957,7 +8035,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7967,7 +8045,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7977,37 +8055,37 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8058,12 +8136,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -8114,11 +8192,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -8134,7 +8212,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8142,7 +8220,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -8158,7 +8236,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8188,7 +8266,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8206,7 +8284,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accetta certificato"
@@ -8217,18 +8295,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8240,7 +8318,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8254,11 +8332,11 @@ msgstr "Creazione del container in corso"
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -8286,7 +8364,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -8297,17 +8375,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8323,7 +8401,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8333,7 +8411,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -8360,19 +8438,19 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -8381,57 +8459,57 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8440,7 +8518,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Il nome del container è: %s"
@@ -8449,11 +8527,11 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -8462,47 +8540,47 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8515,7 +8593,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8544,17 +8622,17 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 #, fuzzy
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8578,7 +8656,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8593,15 +8671,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8641,8 +8719,12 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+msgid "Volume description"
 msgstr ""
 
 #: cmd/incus/info.go:307
@@ -8794,9 +8876,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8828,7 +8910,11 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid "Zone description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:865
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -8839,12 +8925,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -8860,12 +8946,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -8875,38 +8961,38 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -8916,65 +9002,65 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
@@ -9004,7 +9090,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
@@ -9062,7 +9148,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
@@ -9151,8 +9237,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
@@ -9208,15 +9294,15 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -9226,73 +9312,73 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
@@ -9302,29 +9388,29 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -9334,7 +9420,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -9344,76 +9430,76 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -9423,63 +9509,63 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -9490,8 +9576,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -9511,12 +9597,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
@@ -9526,7 +9612,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
@@ -9536,23 +9622,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -9567,33 +9653,33 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -9632,11 +9718,11 @@ msgstr "Creazione del container in corso"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9644,7 +9730,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9694,7 +9780,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9736,7 +9822,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9748,7 +9834,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9883,7 +9969,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9891,7 +9977,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9903,7 +9989,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9928,7 +10014,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9937,7 +10023,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9953,7 +10039,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9961,7 +10047,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9987,7 +10073,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10007,13 +10093,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10022,7 +10108,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10050,7 +10136,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10060,31 +10146,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10094,27 +10180,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10124,7 +10210,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10134,7 +10220,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10144,7 +10230,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10154,7 +10240,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10164,7 +10250,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10174,7 +10260,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10188,7 +10274,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10198,7 +10284,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10208,7 +10294,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -10217,11 +10303,11 @@ msgstr ""
 msgid "n"
 msgstr "no"
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr "no"
@@ -10234,7 +10320,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -10251,7 +10337,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -10259,7 +10345,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -10267,9 +10353,9 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-12-14 14:00+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -30,7 +30,7 @@ msgstr "  ファームウェア:"
 msgid "  Motherboard:"
 msgstr "  マザーボード:"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -52,7 +52,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -82,7 +82,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -107,7 +107,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -119,7 +119,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -225,7 +225,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -334,7 +334,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -389,7 +389,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -419,7 +419,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -443,7 +443,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -467,7 +467,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -503,7 +503,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -541,7 +541,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -660,7 +660,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -766,7 +766,7 @@ msgstr "クラスターメンバー名が必要です"
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -790,11 +790,11 @@ msgstr "AUTH TYPE"
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr "アクセスキー（空白の場合自動生成）"
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
@@ -816,23 +816,23 @@ msgstr "%q はこのツールではサポートされていません"
 msgid "Action (defaults to GET)"
 msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスターメンバーをクラスターグループに追加します"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
@@ -840,7 +840,7 @@ msgstr "ネットワークゾーンレコードにエントリを追加します
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr "メンバーをグループに追加します"
 
@@ -875,11 +875,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr "新たに信頼済みのクライアントを追加します"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr "新たに信頼済みのクライアント証明書を追加します"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -905,12 +905,12 @@ msgstr ""
 "クライアントが自身をトラストストアに追加するために使うトラストトークンが発行"
 "されます。\n"
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
@@ -922,7 +922,7 @@ msgstr "インスタンスにプロファイルを追加します"
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
@@ -949,12 +949,12 @@ msgstr "アドレス: %s"
 msgid "Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
@@ -969,8 +969,8 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
@@ -992,7 +992,7 @@ msgstr "エイリアス:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr "クラスターに join すると、すべてのデータが削除されます。続けますか?"
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1000,7 +1000,7 @@ msgstr "すべてのプロジェクト"
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1115,7 +1115,12 @@ msgstr "平均: %.2f %.2f %.2f"
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+#, fuzzy
+msgid "Backend description"
+msgstr "説明"
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr "バックエンドの稼働状況:"
 
@@ -1124,22 +1129,22 @@ msgstr "バックエンドの稼働状況:"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップを行います"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1150,22 +1155,22 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1175,7 +1180,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr "ボンディング:"
 
@@ -1188,20 +1193,25 @@ msgstr "--all とインスタンス名を両方同時に指定することはで
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr "ブリッジ:"
+
+#: cmd/incus/storage_bucket.go:106
+#, fuzzy
+msgid "Bucket description"
+msgstr "説明"
 
 #: cmd/incus/info.go:365
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1209,11 +1219,11 @@ msgstr "送信バイト数"
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1306,7 +1316,7 @@ msgstr "デフォルトのリモートは削除できません"
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr "--project と --all-project は同時に指定できません"
 
@@ -1314,7 +1324,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
@@ -1348,7 +1358,7 @@ msgstr "--minimal と --preseed を同時に使えません"
 msgid "Can't use an image with --empty"
 msgstr "イメージに --empty は使えません"
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1372,7 +1382,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "スナップショットをコピーするときに --volume-only は指定できません"
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1387,10 +1397,15 @@ msgstr "カード %d:"
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
+
+#: cmd/incus/config_trust.go:184
+#, fuzzy
+msgid "Certificate description"
+msgstr "証明書のフィンガープリント: %s"
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1412,7 +1427,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr "Chassis"
 
@@ -1440,25 +1455,30 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスターグループ名 %s を %s に変更しました"
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "クラスターグループ %s を作成しました"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1470,57 +1490,57 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "クラスターメンバー %s がグループ %s に追加されました"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "クラスターメンバー %s はグループ %s にすでに存在します"
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr "クラスターメンバ名"
 
@@ -1529,17 +1549,17 @@ msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1574,7 +1594,7 @@ msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `n
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
@@ -1583,7 +1603,7 @@ msgstr "新しいインスタンスに適用するキー/値の設定"
 msgid "Config key/value to apply to the new network integration"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
@@ -1595,16 +1615,16 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 msgid "Config option should be in the format KEY=VALUE"
 msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1627,11 +1647,11 @@ msgstr "更新間隔を秒単位で入力:"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "デーモンに接続しています (試行 %d)"
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1785,7 +1805,7 @@ msgstr "リモート '%s' に対する新しいリモート証明書がエラー
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
@@ -1794,7 +1814,7 @@ msgstr "一致するエントリを見つけられませんでした"
 msgid "Couldn't statfs %s: %w"
 msgstr "statfs %s できません: %w"
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
@@ -1803,15 +1823,15 @@ msgstr "クラスターグループを作成します"
 msgid "Create a new %s pool?"
 msgstr "新たに %s プールを作成しますか?"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr "仮想マシンを作成します"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
@@ -1848,11 +1868,11 @@ msgstr ""
 "--stateful を指定すると、インスタンスの実行状態（プロセスのメモリ状態、TCPコ"
 "ネクション、など…を含む）を保存しようとします。"
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr "ストレージバケットに対する鍵を作成します"
 
@@ -1861,11 +1881,11 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create network integrations"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1873,58 +1893,58 @@ msgstr "新たにカスタムストレージボリュームを作成します"
 msgid "Create new instance file templates"
 msgstr "新たにインスタンスのファイルテンプレートを作成します"
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
@@ -1934,7 +1954,7 @@ msgstr "%s を作成中"
 msgid "Creating %s: %%s"
 msgstr "%s: %%s を作成中"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1947,16 +1967,16 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1968,7 +1988,7 @@ msgstr "ディスク"
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1992,11 +2012,11 @@ msgstr "%d 秒のタイムアウトが経過しましたが、デーモンがま
 msgid "Date: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -2009,7 +2029,7 @@ msgstr "Down delay"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr "クラスターグループを削除します"
 
@@ -2017,7 +2037,7 @@ msgstr "クラスターグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "ストレージボリュームを削除します"
@@ -2026,7 +2046,7 @@ msgstr "ストレージボリュームを削除します"
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
@@ -2046,15 +2066,15 @@ msgstr "インスタンスのスナップショットを削除します"
 msgid "Delete instances"
 msgstr "インスタンスを削除します"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
@@ -2063,44 +2083,44 @@ msgstr "ネットワークフォワードを削除します"
 msgid "Delete network integrations"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid "Delete storage buckets"
 msgstr "ストレージバケットを削除します"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid "Delete storage volume snapshots"
 msgstr "ストレージボリュームのスナップショットを削除します"
 
@@ -2122,12 +2142,12 @@ msgstr "警告を削除します"
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2142,11 +2162,11 @@ msgstr "警告を削除します"
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2154,31 +2174,31 @@ msgstr "警告を削除します"
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2186,45 +2206,45 @@ msgstr "警告を削除します"
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2232,62 +2252,62 @@ msgstr "警告を削除します"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "説明"
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
@@ -2352,7 +2372,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr ""
@@ -2414,7 +2434,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのイメージを表示します"
@@ -2423,7 +2443,7 @@ msgstr "すべてのプロジェクトのイメージを表示します"
 msgid "Display resource usage info per instance"
 msgstr "インスタンスごとのリソース消費状況を表示する"
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2499,7 +2519,7 @@ msgstr "--force を使う際にユーザーの確認を必要としない"
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr "Down delay"
 
@@ -2532,7 +2552,7 @@ msgstr ""
 "更新時、最新のターゲットスナップショットより前のソーススナップショットを除外"
 "する"
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
@@ -2545,12 +2565,12 @@ msgstr "EPHEMERAL"
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "既存: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
@@ -2562,7 +2582,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr "クラスターグループを編集します"
 
@@ -2590,15 +2610,15 @@ msgstr "インスタンスのメタデータファイルを編集します"
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
@@ -2607,48 +2627,48 @@ msgstr "ネットワークフォワード設定をYAMLで編集します"
 msgid "Edit network integration configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid "Edit storage bucket configurations as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2662,22 +2682,22 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2721,7 +2741,7 @@ msgstr "ソートタイプを入力する（'a' はアルファベット、'c' C
 msgid "Enter new delay in seconds:"
 msgstr "更新間隔を秒単位で入力:"
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
@@ -2729,7 +2749,7 @@ msgstr "TTLを指定します"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
@@ -2753,15 +2773,15 @@ msgstr "デコーディングデータのエラー: %v"
 msgid "Error retrieving aliases: %w"
 msgstr "エイリアスの取得に失敗しました: %w"
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "プロパティの設定でエラーが発生しました: %v"
@@ -2776,14 +2796,14 @@ msgstr "ターミナルサイズの設定でエラーが発生しました: %s"
 msgid "Error unsetting properties: %v"
 msgstr "プロパティの削除でエラーが発生しました: %v"
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
@@ -2913,8 +2933,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2941,7 +2961,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2953,25 +2973,25 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr "ストレージバケットをエクスポートします"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid "Export storage buckets as tarball."
 msgstr "ストレージバケットを tarball 形式でエクスポートします。"
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップをエクスポートします"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2989,8 +3009,8 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -3072,7 +3092,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed getting existing storage pools: %w"
 msgstr "既存のストレージプールの取得に失敗しました: %w"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
@@ -3082,17 +3102,17 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed import request: %w"
 msgstr "インポート要求が失敗しました: %w"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "ネットワーク %q の取得に失敗しました: %w"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "ストレージプール %q の取得に失敗しました: %w"
@@ -3181,7 +3201,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "%q の作成に失敗しました: %w"
@@ -3191,7 +3211,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
@@ -3201,12 +3221,12 @@ msgstr "ストレージボリュームのバックアップ作成に失敗しま
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "移動元のインスタンスをコピーしたあとの削除に失敗しました: %w"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
@@ -3353,7 +3373,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Fetch instance backup file: %w"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -3371,7 +3391,7 @@ msgstr "特定の待避アクションを強制します"
 msgid "Force creating files or directories"
 msgstr "強制的にファイルまたはディレクトリーを作成します"
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr "プロジェクトとプロジェクトに含まれるすべてを強制的に削除します。"
 
@@ -3451,19 +3471,19 @@ msgstr ""
 "すでにアクティブなセッションがある場合でも、コンソールへの接続を強制します"
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -3481,7 +3501,7 @@ msgstr "フォーマット (man|md|rest|yaml)"
 msgid "Format (table|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr "Forward delay"
 
@@ -3531,16 +3551,16 @@ msgstr "新たに信頼済みのクライアント証明書を追加します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "ネットワークロードバランサーの設定を行います"
@@ -3549,11 +3569,11 @@ msgstr "ネットワークロードバランサーの設定を行います"
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "クラスターグループを作成します"
@@ -3567,7 +3587,7 @@ msgstr "クラスターグループを作成します"
 msgid "Get the key as a network ACL property"
 msgstr "key をネットワーク ACL プロパティとして取得します"
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
@@ -3577,17 +3597,17 @@ msgstr "ネットワークフォワードのポートを管理します"
 msgid "Get the key as a network integration property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr "key をネットワークプロパティとして取得します"
 
@@ -3596,30 +3616,30 @@ msgstr "key をネットワークプロパティとして取得します"
 msgid "Get the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr "key をプロファイルプロパティとして取得します"
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr "key をプロジェクトプロパティとして取得します"
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3628,7 +3648,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Get the key as an instance property"
 msgstr "key をインスタンスプロパティとして取得します"
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
@@ -3649,11 +3669,11 @@ msgstr "インスタンスもしくはサーバの設定値を取得します"
 msgid "Get values for network ACL configuration keys"
 msgstr "ネットワーク ACL の設定値を取得します"
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
@@ -3662,12 +3682,12 @@ msgstr "ネットワークフォワードの設定値を取得します"
 msgid "Get values for network integration configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
@@ -3675,31 +3695,31 @@ msgstr "ネットワークピアの設定値を取得します"
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid "Get values for storage bucket configuration keys"
 msgstr "ストレージバケットの設定値を取得します"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 #, fuzzy
 msgid ""
 "Get values for storage volume configuration keys\n"
@@ -3723,7 +3743,7 @@ msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3760,7 +3780,7 @@ msgstr "インスタンスから sshfs への I/O コピーに失敗しました
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr "ID"
 
@@ -3774,7 +3794,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -3787,7 +3807,7 @@ msgstr "インスタンス名"
 msgid "IOMMU group: %v"
 msgstr "IOMMU グループ: %v"
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
@@ -3795,29 +3815,29 @@ msgstr "IP ADDRESS"
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr "IPV4"
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr "IPV6"
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "IP アドレス"
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "IP アドレス"
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
@@ -3832,7 +3852,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3849,7 +3869,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3860,6 +3880,11 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
+
+#: cmd/incus/image_alias.go:71
+#, fuzzy
+msgid "Image alias description"
+msgstr "説明"
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -3904,16 +3929,16 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "新たにカスタムストレージボリュームをインポートします"
@@ -3937,30 +3962,30 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 "インポートするタイプは \"backup\" もしくは \"iso\" である必要があります"
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "インポートするタイプ。backup もしくは iso (デフォルト \\\"backup\\\")"
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "ISO イメージをインポートするには、ボリューム名を設定する必要があります"
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3970,7 +3995,7 @@ msgstr "カスタムボリュームのインポート中: %s"
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr "ファイルからの環境変数を含める"
 
@@ -3996,6 +4021,11 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "説明"
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
@@ -4009,7 +4039,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -4028,7 +4058,7 @@ msgstr "インスタンスは以下のフィンガープリントで publish さ
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
@@ -4037,8 +4067,8 @@ msgstr "インスタンスタイプ"
 msgid "Invalid IP address or DNS name"
 msgstr "不正なスナップショット名"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
@@ -4058,8 +4088,8 @@ msgstr "不正な引数 %q"
 msgid "Invalid arguments"
 msgstr "不正な引数 %q"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "パス %q に不正なバックアップ名のセグメントがあります: %w"
@@ -4069,7 +4099,7 @@ msgstr "パス %q に不正なバックアップ名のセグメントがあり�
 msgid "Invalid boolean value: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
@@ -4152,7 +4182,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -4161,7 +4191,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "不正な送り先 %s"
@@ -4171,9 +4201,9 @@ msgstr "不正な送り先 %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -4219,6 +4249,11 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "Kernel Version"
 msgstr "サーバのバージョン: %s"
 
+#: cmd/incus/storage_bucket.go:1049
+#, fuzzy
+msgid "Key description"
+msgstr "説明"
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
@@ -4227,7 +4262,7 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr "LIMIT"
 
@@ -4235,10 +4270,10 @@ msgstr "LIMIT"
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -4256,12 +4291,12 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
@@ -4276,11 +4311,11 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 #, fuzzy
 msgid ""
 "List DHCP leases\n"
@@ -4333,11 +4368,11 @@ msgstr ""
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 #, fuzzy
 msgid ""
 "List all active certificate add tokens\n"
@@ -4435,11 +4470,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid "List all the cluster groups"
 msgstr "クラスターグループをすべて一覧表示します"
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid ""
 "List all the cluster groups\n"
@@ -4707,7 +4742,7 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
@@ -4763,11 +4798,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 #, fuzzy
 msgid ""
 "List available networks\n"
@@ -4813,11 +4848,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4917,11 +4952,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr "イメージのエイリアスを一覧表示します"
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5359,12 +5394,12 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
@@ -5373,11 +5408,11 @@ msgstr "証明書の使用を制限するプロジェクトのリスト"
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 #, fuzzy
 msgid ""
 "List profiles\n"
@@ -5418,11 +5453,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 #, fuzzy
 msgid ""
 "List projects\n"
@@ -5468,11 +5503,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr "ストレージバケットの鍵を一覧表示します"
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 #, fuzzy
 msgid ""
 "List storage bucket keys\n"
@@ -5519,11 +5554,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 #, fuzzy
 msgid ""
 "List storage buckets\n"
@@ -5571,12 +5606,12 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 #, fuzzy
 msgid ""
 "List storage volume snapshots\n"
@@ -5615,11 +5650,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -5703,11 +5738,11 @@ msgstr ""
 "  s - 静的\n"
 "  g - グローバル"
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 #, fuzzy
 msgid ""
 "List trusted clients\n"
@@ -5799,11 +5834,16 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
+#: cmd/incus/network_load_balancer.go:338
+#, fuzzy
+msgid "Load balancer description"
+msgstr "説明"
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr "負荷:"
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -5816,7 +5856,7 @@ msgstr "ログレベルのフィルタリングは pretty フォーマットで�
 msgid "Log:"
 msgstr "ログ:"
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr "論理ルーター"
 
@@ -5837,15 +5877,15 @@ msgstr "クラスターの検査と回復のための低レベルの管理ツー
 msgid "Low-level cluster administration commands"
 msgstr "低レベルのクラスター管理コマンド"
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr "Lower device"
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
@@ -5853,7 +5893,7 @@ msgstr "MAC ADDRESS"
 msgid "MAC address"
 msgstr "MAC アドレス"
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
@@ -5863,11 +5903,11 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
@@ -5889,11 +5929,11 @@ msgstr "MEMORY USAGE%"
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr "MII 監視頻度"
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr "MII 状態"
 
@@ -5901,7 +5941,7 @@ msgstr "MII 状態"
 msgid "MTU"
 msgstr "MTU"
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
@@ -6007,7 +6047,7 @@ msgstr "インスタンスのメタデータファイルを管理します"
 msgid "Manage instance snapshots"
 msgstr "インスタンスのスナップショットを作成します"
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr "ネットワーク ACL ルールを管理します"
 
@@ -6015,7 +6055,7 @@ msgstr "ネットワーク ACL ルールを管理します"
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
@@ -6028,13 +6068,13 @@ msgstr "ネットワークフォワードを管理します"
 msgid "Manage network integrations"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
@@ -6046,11 +6086,11 @@ msgstr "ネットワークロードバランサーを管理します"
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
@@ -6066,11 +6106,11 @@ msgstr "プロファイルを管理します"
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid "Manage storage bucket keys"
 msgstr "ストレージバケットの鍵を管理します"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr "ストレージバケットの鍵を管理します。"
 
@@ -6086,7 +6126,7 @@ msgstr "ストレージバケットを管理します。"
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "ストレージボリュームを管理します"
@@ -6196,27 +6236,27 @@ msgstr "ログメッセージの最小レベル（pretty フォーマット使�
 msgid "Minimum size is 1GiB"
 msgstr "最小サイズは 1GiB です"
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid "Missing bucket name"
 msgstr "バケット名を指定する必要があります"
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
@@ -6225,30 +6265,30 @@ msgstr "クラスターメンバー名がありません"
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
@@ -6260,10 +6300,10 @@ msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
@@ -6275,83 +6315,83 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 msgid "Missing network integration name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -6364,11 +6404,11 @@ msgstr "プロファイル名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -6376,12 +6416,12 @@ msgstr "ストレージプール名を指定する必要があります"
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "作成するネットワーク名を指定する必要があります"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr "モード"
 
@@ -6411,8 +6451,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -6426,7 +6466,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
@@ -6468,7 +6508,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
@@ -6477,12 +6517,12 @@ msgstr "コピー／移動元とは異なるプロジェクトに移動します
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
@@ -6496,15 +6536,15 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr "NAME"
 
@@ -6512,11 +6552,11 @@ msgstr "NAME"
 msgid "NAT"
 msgstr "NAT"
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -6533,9 +6573,9 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr "NO"
@@ -6559,8 +6599,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr "名前"
 
@@ -6624,8 +6664,8 @@ msgstr "使用するストレージバックエンド名 (%s)"
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -6635,60 +6675,75 @@ msgstr "名前: %s"
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク ACL %s を削除しました"
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr "ネットワーク ACL %s を作成しました"
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr "説明"
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
+msgstr "ネットワークフォワード %s を作成しました"
 
 #: cmd/incus/network_integration.go:160
 #, fuzzy, c-format
@@ -6705,36 +6760,36 @@ msgstr "ネットワークゾーン %s を削除しました"
 msgid "Network integration %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr "ネットワークピア %s を作成しました"
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr "ネットワークピア %s を削除しました"
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr "ネットワークピア %s は想定外のステータスです %q"
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -6742,20 +6797,20 @@ msgstr ""
 "ネットワークピア %s はピアリング状態です (ピアネットワーク上で相互ピアリング"
 "を完了させてください)"
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
@@ -6768,7 +6823,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -6777,7 +6832,7 @@ msgstr "指定するデバイスに適用する新しいキー/値"
 msgid "No %s storage backends available"
 msgstr "利用可能なストレージバックエンド %s がありません"
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
@@ -6788,27 +6843,27 @@ msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 "メンバー %s に対するクラスターへの join トークンがリモート %s にありません"
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr "ロードバランサーのヘルス情報がありません"
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
@@ -6816,11 +6871,11 @@ msgstr "マッチするルールが見つかりません"
 msgid "No storage backends available"
 msgstr "利用可能なストレージバックエンドがありません"
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -6865,7 +6920,7 @@ msgstr "OS"
 msgid "OS Version"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr "OVN:"
 
@@ -6873,11 +6928,11 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -6890,11 +6945,11 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -6920,7 +6975,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -6968,19 +7023,19 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 #, fuzzy
 msgid "PROJECTS"
 msgstr "PROJECT"
@@ -6993,11 +7048,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -7028,6 +7083,11 @@ msgstr "既存のブロックデバイスのパス:"
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
+#: cmd/incus/network_peer.go:335
+#, fuzzy
+msgid "Peer description"
+msgstr "説明"
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
@@ -7052,6 +7112,11 @@ msgstr "'y', 'n', フィンガープリントのどれかを入力してくだ�
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
 msgstr "プール名を空白にすることはできません"
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+#, fuzzy
+msgid "Port description"
+msgstr "説明"
 
 #: cmd/incus/admin_init_interactive.go:816
 msgid "Port to bind to"
@@ -7091,17 +7156,17 @@ msgstr "終了するには CTRL-C を押してください"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -7158,36 +7223,41 @@ msgstr "製品名: %v (%v)"
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
+
+#: cmd/incus/profile.go:369
+#, fuzzy
+msgid "Profile description"
+msgstr "説明"
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
@@ -7208,20 +7278,25 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
+
+#: cmd/incus/project.go:114
+#, fuzzy
+msgid "Project description"
+msgstr "説明"
 
 #: cmd/incus/remote.go:124
 msgid "Project to use for the remote"
@@ -7240,7 +7315,7 @@ msgstr "プロパティが見つかりません"
 msgid "Protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "クライアント %s の証明書追加トークン: %s"
@@ -7293,15 +7368,15 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr "RESTRICTED"
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr "ROLE"
 
@@ -7323,6 +7398,11 @@ msgstr "空のインスタンスを作成"
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
+
+#: cmd/incus/network_zone.go:1092
+#, fuzzy
+msgid "Record description"
+msgstr "説明"
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -7377,7 +7457,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -7417,7 +7497,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -7426,7 +7506,7 @@ msgstr ""
 "%s とそれに含まれるすべて（インスタンス、イメージ、ボリューム、ネットワー"
 "ク、…）を削除します (yes/no): "
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスターグループからメンバを削除します"
 
@@ -7434,7 +7514,7 @@ msgstr "クラスターグループからメンバを削除します"
 msgid "Remove a member from the cluster"
 msgstr "クラスターからメンバを削除します"
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
@@ -7442,23 +7522,23 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
@@ -7466,20 +7546,20 @@ msgstr "ネットワークゾーンレコードからエントリを削除しま
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -7491,7 +7571,7 @@ msgstr "リモートサーバを削除します"
 msgid "Remove roles from a cluster member"
 msgstr "クラスターメンバからロールを削除します"
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
 
@@ -7500,11 +7580,11 @@ msgstr "ACL からルールを削除します"
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr "クラスターグループの名前を変更します"
 
@@ -7512,12 +7592,12 @@ msgstr "クラスターグループの名前を変更します"
 msgid "Rename a cluster member"
 msgstr "クラスターメンバの名前を変更します"
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "ストレージボリューム名を変更します"
@@ -7532,7 +7612,7 @@ msgstr "インスタンスまたはインスタンスのスナップショット
 msgid "Rename instances"
 msgstr "インスタンスを再起動します"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
@@ -7541,15 +7621,15 @@ msgstr "ネットワーク ACL 名を変更します"
 msgid "Rename network integrations"
 msgstr "ネットワーク名を変更します"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -7557,17 +7637,17 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -7613,7 +7693,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -7622,7 +7702,7 @@ msgstr "スナップショットからストレージボリュームをリスト
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
@@ -7635,12 +7715,12 @@ msgstr "インスタンスを再起動します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
@@ -7648,7 +7728,7 @@ msgstr "証明書追加トークンを失効（Revoke）させます"
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
@@ -7656,6 +7736,11 @@ msgstr "ロール（admin または read-only）"
 #, c-format
 msgid "Rows affected: %d"
 msgstr "影響を受ける行: %d"
+
+#: cmd/incus/network_acl.go:887
+#, fuzzy
+msgid "Rule description"
+msgstr "説明"
 
 #: cmd/incus/remote_unix.go:36
 msgid "Run a local API proxy"
@@ -7695,7 +7780,7 @@ msgstr "UUID: %v"
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -7723,9 +7808,9 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STARTED AT"
 msgstr "CREATED AT"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr "STATE"
 
@@ -7742,7 +7827,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -7750,11 +7835,11 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr "STP"
 
@@ -7762,11 +7847,11 @@ msgstr "STP"
 msgid "Scanning for unknown volumes..."
 msgstr "未知のボリュームをスキャンしています..."
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr "秘密鍵（空白の場合自動生成）"
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
@@ -7805,7 +7890,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 #, fuzzy
 msgid "Server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
@@ -7825,7 +7910,7 @@ msgstr "サーバのバージョン: %s\n"
 msgid "Server: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
@@ -7892,11 +7977,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr "ネットワーク ACL の設定項目を設定します"
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 #, fuzzy
 msgid ""
 "Set network ACL configuration keys\n"
@@ -7910,11 +7995,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 #, fuzzy
 msgid ""
 "Set network configuration keys\n"
@@ -7928,11 +8013,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 #, fuzzy
 msgid ""
 "Set network forward keys\n"
@@ -7966,11 +8051,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 #, fuzzy
 msgid ""
 "Set network load balancer keys\n"
@@ -7984,11 +8069,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 #, fuzzy
 msgid ""
 "Set network peer keys\n"
@@ -8002,11 +8087,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 #, fuzzy
 msgid ""
 "Set network zone configuration keys\n"
@@ -8020,15 +8105,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 #, fuzzy
 msgid ""
 "Set profile configuration keys\n"
@@ -8042,11 +8127,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 #, fuzzy
 msgid ""
 "Set project configuration keys\n"
@@ -8060,11 +8145,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid "Set storage bucket configuration keys"
 msgstr "ストレージバケットの設定項目を設定します"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 #, fuzzy
 msgid ""
 "Set storage bucket configuration keys\n"
@@ -8078,11 +8163,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage bucket set [<remote>:]<pool> <volume> <key> <value>"
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 #, fuzzy
 msgid ""
 "Set storage pool configuration keys\n"
@@ -8096,11 +8181,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -8150,7 +8235,7 @@ msgstr "プッシュ時にファイルのuidを設定します"
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "クラスターグループを作成します"
@@ -8160,11 +8245,11 @@ msgstr "クラスターグループを作成します"
 msgid "Set the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティとして設定します"
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
@@ -8174,49 +8259,49 @@ msgstr "ネットワークフォワードの設定値を設定します"
 msgid "Set the key as a network integration property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr "ネットワークプロパティとして設定します"
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr "プロファイルプロパティとして設定します"
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr "プロジェクトプロパティとして設定します"
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -8246,7 +8331,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid "Show cluster group configurations"
 msgstr "クラスターグループの設定を表示します"
 
@@ -8307,7 +8392,7 @@ msgstr "ネットワーク ACL の設定を表示します"
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
@@ -8333,39 +8418,39 @@ msgstr "ネットワークピアの設定を表示します"
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid "Show network zone record configuration"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid "Show storage bucket configurations"
 msgstr "ストレージバケットの設定を表示する"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid "Show storage bucket key configurations"
 msgstr "ストレージバケットの鍵の設定を表示する"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 #, fuzzy
 msgid ""
 "Show storage volume configurations\n"
@@ -8380,21 +8465,21 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -8408,7 +8493,7 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 #, fuzzy
 msgid "Show the current project"
 msgstr "現在のプロジェクトを切り替えます"
@@ -8421,7 +8506,7 @@ msgstr "デフォルトのリモートを表示します"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
@@ -8435,15 +8520,15 @@ msgstr "インスタンスログの最後の 100 行を表示しますか?"
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr "使用量と空き容量を byte で表示します"
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
@@ -8455,7 +8540,7 @@ msgstr "クラスターメンバーについての情報を表示します"
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
@@ -8477,15 +8562,20 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+#, fuzzy
+msgid "Snapshot description"
+msgstr "説明"
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -8537,7 +8627,7 @@ msgstr "リカバリーを開始します..."
 msgid "State"
 msgstr "状態"
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
@@ -8572,22 +8662,22 @@ msgstr "インスタンスの停止に失敗しました: %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr "使用するストレージバックエンド (btrfs, dir, lvm, zfs, デフォルト: dir)"
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "ストレージバケット %s を作成しました"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "ストレージバケット %s を削除しました"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "ストレージバケットの鍵 %s を作成しました"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "ストレージバケットの鍵 %s を削除しました"
@@ -8606,22 +8696,27 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool %q of type %q"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr "ストレージプール %s を作成しました"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "ストレージプール名"
@@ -8631,12 +8726,12 @@ msgstr "ストレージプール名"
 msgid "Storage pool to use or create"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
@@ -8649,7 +8744,7 @@ msgstr "ストレージボリュームのコピーが成功しました!"
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "ストレージボリューム %s を削除しました"
@@ -8681,7 +8776,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -8697,7 +8792,7 @@ msgstr "シンボリックリンクのターゲットパスは \"symlink\" タ�
 msgid "System:"
 msgstr "システム:"
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr "TAKEN AT"
 
@@ -8705,20 +8800,20 @@ msgstr "TAKEN AT"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -8819,7 +8914,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
@@ -8843,7 +8938,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -8851,7 +8946,7 @@ msgstr "起動しようとしたインスタンスに接続されているネッ
 msgid "The is no config key to set on an instance snapshot."
 msgstr "インスタンスのスナップショットに設定する設定キーはありません。"
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "設定 %q はクラスターメンバー %q には存在しません"
@@ -8882,7 +8977,7 @@ msgstr "更新間隔の最小値は 10 秒です"
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8902,12 +8997,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8917,7 +9012,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8927,7 +9022,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8937,37 +9032,37 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -9028,12 +9123,12 @@ msgstr "サーバーに Web UI がインストールされていません"
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
@@ -9098,14 +9193,14 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr ""
@@ -9127,7 +9222,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスターに属していなければ"
@@ -9137,7 +9232,7 @@ msgstr ""
 msgid "Too many links"
 msgstr "リンクが多すぎます"
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -9153,7 +9248,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -9183,7 +9278,7 @@ msgstr "イメージを転送中: %s"
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
@@ -9201,7 +9296,7 @@ msgstr "更に情報を得るために `lxc info --show-log %s` を実行して�
 msgid "Type"
 msgstr "タイプ"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
@@ -9213,18 +9308,18 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr "ピアのタイプ（localまたはremote）"
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -9236,7 +9331,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr "USAGE"
 
@@ -9250,11 +9345,11 @@ msgstr "device"
 msgid "USB devices:"
 msgstr "上位デバイス"
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -9281,7 +9376,7 @@ msgstr "テンポラリファイルを作成できません: %v"
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
@@ -9292,17 +9387,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -9318,7 +9413,7 @@ msgstr "未知のコンソールタイプ %q"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
@@ -9328,7 +9423,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
@@ -9353,19 +9448,19 @@ msgstr "イメージのプロパティを削除します"
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
@@ -9374,51 +9469,51 @@ msgstr "ネットワークフォワードの設定を削除します"
 msgid "Unset network integration configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid "Unset network peer configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid "Unset storage bucket configuration keys"
 msgstr "ストレージバケットの設定を削除します"
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -9432,7 +9527,7 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "クラスタープロパティの設定を削除します"
@@ -9441,11 +9536,11 @@ msgstr "クラスタープロパティの設定を削除します"
 msgid "Unset the key as a cluster property"
 msgstr "クラスタープロパティの設定を削除します"
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティの設定を削除します"
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
@@ -9455,50 +9550,50 @@ msgstr "ネットワークフォワードの設定を削除します"
 msgid "Unset the key as a network integration property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr "プロファイルプロパティの設定を削除します"
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr "プロジェクトプロパティの設定を削除します"
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -9512,7 +9607,7 @@ msgstr "インスタンスプロパティの設定を削除します"
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr "Up delay"
 
@@ -9542,16 +9637,16 @@ msgstr "間隔を %v に更新します"
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9577,7 +9672,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted configuration"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
@@ -9594,15 +9689,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr "VFs: %d"
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr "VLAN ID"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr "VLAN フィルタリング"
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr "VLAN:"
 
@@ -9642,9 +9737,14 @@ msgstr "CUDA バージョン: %v"
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
 msgstr "Volume Only"
+
+#: cmd/incus/storage_volume.go:590
+#, fuzzy
+msgid "Volume description"
+msgstr "説明"
 
 #: cmd/incus/info.go:307
 #, c-format
@@ -9815,9 +9915,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr "クラスタリングを使用しますか?"
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr "YES"
@@ -9849,7 +9949,12 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+#, fuzzy
+msgid "Zone description"
+msgstr "説明"
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
@@ -9858,12 +9963,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -9876,12 +9981,12 @@ msgstr "[<remote>:] <backup file> [<instance name>]"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "[<remote>:] [<cert>]"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -9889,32 +9994,32 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <direction> <key>=<value>..."
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <key>"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <key>=<value>..."
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <new-name>"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [key=value...]"
 
@@ -9922,56 +10027,56 @@ msgstr "[<remote>:]<ACL> [key=value...]"
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <fingerprint>"
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "[<remote>:]<group>"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
@@ -9996,7 +10101,7 @@ msgstr "[<remote>:]<image> <remote>:"
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
@@ -10047,7 +10152,7 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
@@ -10124,8 +10229,8 @@ msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
@@ -10176,14 +10281,14 @@ msgstr "[<remote>:]<network> <new-name>"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
@@ -10191,27 +10296,27 @@ msgstr "[<remote>:]<network> <instance> [<device name>]"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -10219,17 +10324,17 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -10237,7 +10342,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -10245,15 +10350,15 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
@@ -10261,11 +10366,11 @@ msgstr "[<remote>:]<network> <new-name>"
 msgid "[<remote>:]<network> <peer name>"
 msgstr "[<remote>:]<network> <peer name>"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "[<remote>:]<network> <peer_name>"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -10274,15 +10379,15 @@ msgstr ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "[<remote>:]<network> <peer_name> <key>"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
@@ -10290,7 +10395,7 @@ msgstr "[<remote>:]<network> <profile> [<device name>]"
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
@@ -10298,67 +10403,67 @@ msgstr "[<remote>:]<network> [key=value...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <key>"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <key>=<value>..."
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [key=value...]"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [key=value...]"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <key>"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
@@ -10366,58 +10471,58 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
@@ -10426,8 +10531,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -10443,11 +10548,11 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
@@ -10455,7 +10560,7 @@ msgstr "[<remote>:]<profile> <key><value>..."
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
@@ -10463,20 +10568,20 @@ msgstr "[<remote>:]<profile> <new-name>"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -10488,28 +10593,28 @@ msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
@@ -10542,11 +10647,11 @@ msgstr "[[<remote>:]<member>]"
 msgid "application"
 msgstr "operation"
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr "現在値"
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr "説明"
 
@@ -10554,7 +10659,7 @@ msgstr "説明"
 msgid "disabled"
 msgstr "無効"
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr "ドライバ"
 
@@ -10623,7 +10728,7 @@ msgstr ""
 "lxc cluster group assign foo default\n"
 "    \"foo\" を \"default\" クラスタグループのみ使用するように再設定します。"
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 #, fuzzy
 msgid ""
 "incus cluster group create g1\n"
@@ -10696,7 +10801,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 #, fuzzy
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
@@ -10713,7 +10818,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 #, fuzzy
 msgid ""
 "incus create storage s1 dir\n"
@@ -10931,7 +11036,7 @@ msgstr ""
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 #, fuzzy
 msgid ""
 "incus network acl create a1\n"
@@ -10944,7 +11049,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 #, fuzzy
 msgid ""
 "incus network create foo\n"
@@ -10963,7 +11068,7 @@ msgstr ""
 "    上流ネットワークに baz を使用する、bar という名前の新しい OVN ネットワー"
 "クを作成します"
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 #, fuzzy
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
@@ -11001,7 +11106,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 #, fuzzy
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
@@ -11015,7 +11120,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -11043,7 +11148,7 @@ msgstr ""
 "\"default\" と \"web\" プロジェクト内の \"default\" ネットワークの間に、新た"
 "にピアリングを作成します"
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 #, fuzzy
 msgid ""
 "incus network zone create z1\n"
@@ -11056,7 +11161,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 #, fuzzy
 msgid ""
 "incus network zone record create z1 r1\n"
@@ -11100,7 +11205,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 #, fuzzy
 msgid ""
 "incus profile create p1\n"
@@ -11134,7 +11239,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 #, fuzzy
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
@@ -11143,7 +11248,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 #, fuzzy
 msgid ""
 "incus project create p1\n"
@@ -11157,7 +11262,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 #, fuzzy
 msgid ""
 "incus project edit <project> < project.yaml\n"
@@ -11199,7 +11304,7 @@ msgstr ""
 "lxc snapshot u1 snap0\n"
 "    \"u1\" のスナップショットを \"snap0\" という名前で作成します。"
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid ""
 "incus storage bucket create p1 b01\n"
@@ -11212,7 +11317,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 #, fuzzy
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
@@ -11221,7 +11326,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    bucket.yaml の内容でストレージバケットを更新します。"
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
@@ -11230,7 +11335,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    key.yaml の内容でストレージバケットの鍵を更新します。"
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy
 msgid ""
 "incus storage bucket export default b1\n"
@@ -11239,7 +11344,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 #, fuzzy
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
@@ -11248,7 +11353,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 #, fuzzy
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
@@ -11261,7 +11366,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 #, fuzzy
 msgid ""
 "incus storage bucket key show default data foo\n"
@@ -11272,7 +11377,7 @@ msgstr ""
 "    \"default\" プール内の \"data\" という名前のバケットに対する \"foo\" とい"
 "う名前のバケットの鍵のプロパティを表示します。"
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 #, fuzzy
 msgid ""
 "incus storage bucket show default data\n"
@@ -11282,7 +11387,7 @@ msgstr ""
 "lxc storage bucket show default data\n"
 "    \"default\" プール内の \"data\" というバケットのプロパティを表示します。"
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 #, fuzzy
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -11291,7 +11396,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 #, fuzzy
 msgid ""
 "incus storage volume create default foo\n"
@@ -11306,7 +11411,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 #, fuzzy
 msgid ""
 "incus storage volume edit default container/c1\n"
@@ -11319,7 +11424,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 #, fuzzy
 msgid ""
 "incus storage volume get default data size\n"
@@ -11332,7 +11437,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11349,7 +11454,7 @@ msgstr ""
 "    CD-ROM イメージとして使用するために some-installer.iso を保存する新しいカ"
 "スタムボリュームを作成します"
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 #, fuzzy
 msgid ""
 "incus storage volume info default foo\n"
@@ -11362,7 +11467,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 #, fuzzy
 msgid ""
 "incus storage volume set default data size=1GiB\n"
@@ -11375,7 +11480,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 #, fuzzy
 msgid ""
 "incus storage volume show default foo\n"
@@ -11397,7 +11502,7 @@ msgstr ""
 "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
 "示します。"
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 #, fuzzy
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
@@ -11412,7 +11517,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 #, fuzzy
 msgid ""
 "incus storage volume unset default foo size\n"
@@ -11425,7 +11530,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr "ストレージ情報"
 
@@ -11433,11 +11538,11 @@ msgstr "ストレージ情報"
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr "名前"
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr "no"
@@ -11451,7 +11556,7 @@ msgstr "ok (y/n/[fingerprint])?"
 msgid "please use `incus profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr "使用量"
 
@@ -11470,7 +11575,7 @@ msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
 "てください"
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr "総容量"
 
@@ -11478,7 +11583,7 @@ msgstr "総容量"
 msgid "unreachable"
 msgstr "サーバに接続できません"
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr "ストレージを使用中の"
 
@@ -11486,9 +11591,9 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "yes"
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -31,7 +31,7 @@ msgstr "  Fastvare:"
 msgid "  Motherboard:"
 msgstr "  Hovedkort:"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -44,7 +44,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -75,7 +75,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -83,7 +83,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -144,7 +144,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -172,7 +172,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgstr ""
 "###\n"
 "### Bemerk at navnet vises, men kan ikke endres"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -242,7 +242,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -259,7 +259,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -273,7 +273,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -287,7 +287,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -307,7 +307,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -328,7 +328,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,7 +431,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -584,23 +584,23 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -636,11 +636,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -657,12 +657,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -701,12 +701,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -721,8 +721,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -860,7 +860,11 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -869,22 +873,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -893,22 +897,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -918,7 +922,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -931,8 +935,12 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+msgid "Bucket description"
 msgstr ""
 
 #: cmd/incus/info.go:365
@@ -940,11 +948,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr ""
 
@@ -952,11 +960,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1054,7 +1062,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1088,7 +1096,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1107,7 +1115,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1122,9 +1130,13 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
+msgstr ""
+
+#: cmd/incus/config_trust.go:184
+msgid "Certificate description"
 msgstr ""
 
 #: cmd/incus/remote.go:237
@@ -1144,7 +1156,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1172,24 +1184,28 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+msgid "Cluster group description"
 msgstr ""
 
 #: cmd/incus/cluster.go:1304
@@ -1202,57 +1218,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1261,17 +1277,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
@@ -1299,7 +1315,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1307,7 +1323,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1319,16 +1335,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1350,11 +1366,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1491,7 +1507,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1500,7 +1516,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1509,15 +1525,15 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1550,11 +1566,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1562,11 +1578,11 @@ msgstr ""
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1574,58 +1590,58 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1635,7 +1651,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid "Creating the instance"
 msgstr ""
 
@@ -1648,16 +1664,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1669,7 +1685,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr ""
 
@@ -1692,11 +1708,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1708,7 +1724,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1716,7 +1732,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1724,7 +1740,7 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1744,15 +1760,15 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1760,44 +1776,44 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1819,12 +1835,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -1839,11 +1855,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -1851,31 +1867,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -1883,45 +1899,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -1929,60 +1945,60 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2043,7 +2059,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2100,7 +2116,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2108,7 +2124,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2158,7 +2174,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2187,7 +2203,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2200,12 +2216,12 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -2215,7 +2231,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2243,15 +2259,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2259,48 +2275,48 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2309,22 +2325,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2358,7 +2374,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2366,7 +2382,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2390,15 +2406,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2413,14 +2429,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2510,8 +2526,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2535,7 +2551,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2547,24 +2563,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2582,8 +2598,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2665,7 +2681,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2675,17 +2691,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2774,7 +2790,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2784,7 +2800,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2794,12 +2810,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2946,7 +2962,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2964,7 +2980,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3027,19 +3043,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3056,7 +3072,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3105,15 +3121,15 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 msgid "Get current load-balacner status"
 msgstr ""
 
@@ -3121,11 +3137,11 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 msgid "Get the key as a cluster group property"
 msgstr ""
 
@@ -3137,7 +3153,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3145,15 +3161,15 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3161,27 +3177,27 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3189,7 +3205,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
@@ -3209,11 +3225,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -3221,12 +3237,12 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3234,31 +3250,31 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3279,7 +3295,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3316,7 +3332,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3330,7 +3346,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3343,7 +3359,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3351,27 +3367,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3383,7 +3399,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3397,7 +3413,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3407,6 +3423,10 @@ msgstr ""
 
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
+msgstr ""
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
 msgstr ""
 
 #: cmd/incus/image.go:1482
@@ -3451,15 +3471,15 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3478,28 +3498,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3509,7 +3529,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3533,6 +3553,10 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+msgid "Instance description"
+msgstr ""
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3546,7 +3570,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3565,7 +3589,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3573,8 +3597,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3593,8 +3617,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3604,7 +3628,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -3682,7 +3706,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3691,7 +3715,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 msgid "Invalid peer type"
 msgstr ""
 
@@ -3700,9 +3724,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3746,6 +3770,10 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid "Key description"
+msgstr ""
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -3754,7 +3782,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -3762,10 +3790,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3783,12 +3811,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 msgid "Launching the instance"
 msgstr ""
 
@@ -3802,11 +3830,11 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3834,11 +3862,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3886,11 +3914,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4033,7 +4061,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid "List available network zone records"
 msgstr ""
 
@@ -4064,11 +4092,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4089,11 +4117,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4148,11 +4176,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4389,11 +4417,11 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4401,11 +4429,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4421,11 +4449,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4446,11 +4474,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4472,11 +4500,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4499,11 +4527,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4517,11 +4545,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4570,11 +4598,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4629,11 +4657,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4646,7 +4678,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -4667,15 +4699,15 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4683,7 +4715,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4693,11 +4725,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -4718,11 +4750,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -4730,7 +4762,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4820,7 +4852,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4828,7 +4860,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4840,13 +4872,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4858,11 +4890,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4878,11 +4910,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4898,7 +4930,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5003,27 +5035,27 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid "Missing cluster group name"
 msgstr ""
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -5032,30 +5064,30 @@ msgstr ""
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 msgid "Missing listen address"
 msgstr ""
 
@@ -5067,10 +5099,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5081,83 +5113,83 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr ""
 
@@ -5169,11 +5201,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5181,11 +5213,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5210,8 +5242,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5223,7 +5255,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5251,7 +5283,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5260,11 +5292,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5277,15 +5309,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5293,11 +5325,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5314,9 +5346,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5340,8 +5372,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5401,8 +5433,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5412,59 +5444,71 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+msgid "Network ACL description"
+msgstr ""
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+msgid "Network description"
+msgstr ""
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
+msgstr ""
+
+#: cmd/incus/network_forward.go:335
+msgid "Network forward description"
 msgstr ""
 
 #: cmd/incus/network_integration.go:160
@@ -5482,55 +5526,55 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5543,7 +5587,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5552,7 +5596,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5562,27 +5606,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5590,11 +5634,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5634,7 +5678,7 @@ msgstr ""
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -5642,11 +5686,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5658,11 +5702,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5684,7 +5728,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5730,19 +5774,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -5754,11 +5798,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -5789,6 +5833,10 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+msgid "Peer description"
+msgstr ""
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -5811,6 +5859,10 @@ msgstr ""
 
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
+msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid "Port description"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -5851,17 +5903,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5916,36 +5968,40 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/profile.go:369
+msgid "Profile description"
 msgstr ""
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -5966,19 +6022,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/project.go:114
+msgid "Project description"
 msgstr ""
 
 #: cmd/incus/remote.go:124
@@ -5998,7 +6058,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
@@ -6051,15 +6111,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6078,6 +6138,10 @@ msgstr ""
 
 #: cmd/incus/rebuild.go:26
 msgid "Rebuild instances"
+msgstr ""
+
+#: cmd/incus/network_zone.go:1092
+msgid "Record description"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:28
@@ -6125,7 +6189,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6164,14 +6228,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -6179,7 +6243,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6187,23 +6251,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6211,20 +6275,20 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6236,7 +6300,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6245,11 +6309,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6257,12 +6321,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6274,7 +6338,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6282,15 +6346,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6298,16 +6362,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6348,7 +6412,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6357,7 +6421,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6369,12 +6433,12 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -6382,13 +6446,17 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
+msgstr ""
+
+#: cmd/incus/network_acl.go:887
+msgid "Rule description"
 msgstr ""
 
 #: cmd/incus/remote_unix.go:36
@@ -6428,7 +6496,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6455,9 +6523,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6473,7 +6541,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6481,11 +6549,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6493,11 +6561,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6534,7 +6602,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6552,7 +6620,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
@@ -6603,11 +6671,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6616,11 +6684,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6629,11 +6697,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6656,11 +6724,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6669,11 +6737,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6682,11 +6750,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6695,15 +6763,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6712,11 +6780,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6725,11 +6793,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6738,11 +6806,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6751,11 +6819,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6797,7 +6865,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 msgid "Set the key as a cluster group property"
 msgstr ""
 
@@ -6805,11 +6873,11 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -6817,43 +6885,43 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6881,7 +6949,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -6941,7 +7009,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -6966,39 +7034,39 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7010,19 +7078,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7031,7 +7099,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7043,7 +7111,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7055,15 +7123,15 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr ""
 
@@ -7075,7 +7143,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7097,15 +7165,19 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7155,7 +7227,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -7190,22 +7262,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7224,22 +7296,26 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+msgid "Storage pool description"
+msgstr ""
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7248,12 +7324,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7266,7 +7342,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7297,7 +7373,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7313,7 +7389,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7321,20 +7397,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7407,7 +7483,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7429,7 +7505,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7437,7 +7513,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
@@ -7465,7 +7541,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
@@ -7485,12 +7561,12 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -7500,7 +7576,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7510,7 +7586,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7520,37 +7596,37 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7601,12 +7677,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -7656,11 +7732,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7676,7 +7752,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -7684,7 +7760,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7700,7 +7776,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7730,7 +7806,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -7748,7 +7824,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid "Type of certificate"
 msgstr ""
 
@@ -7758,18 +7834,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7781,7 +7857,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -7793,11 +7869,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -7823,7 +7899,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -7834,17 +7910,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7860,7 +7936,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7870,7 +7946,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
@@ -7894,19 +7970,19 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7914,51 +7990,51 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -7967,7 +8043,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
@@ -7975,11 +8051,11 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -7987,43 +8063,43 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8036,7 +8112,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8064,16 +8140,16 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8096,7 +8172,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8111,15 +8187,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8159,8 +8235,12 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+msgid "Volume description"
 msgstr ""
 
 #: cmd/incus/info.go:307
@@ -8310,9 +8390,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8341,7 +8421,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid "Zone description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8350,12 +8434,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8368,11 +8452,11 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -8380,32 +8464,32 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -8413,54 +8497,54 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -8484,7 +8568,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8531,7 +8615,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -8604,8 +8688,8 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -8650,14 +8734,14 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -8665,63 +8749,63 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -8729,25 +8813,25 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
@@ -8755,7 +8839,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -8763,63 +8847,63 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8827,52 +8911,52 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8881,8 +8965,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -8898,11 +8982,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -8910,7 +8994,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
@@ -8918,20 +9002,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -8943,28 +9027,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -8996,11 +9080,11 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9008,7 +9092,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9058,7 +9142,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9100,7 +9184,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9112,7 +9196,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9247,7 +9331,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9255,7 +9339,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9267,7 +9351,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9292,7 +9376,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9301,7 +9385,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9317,7 +9401,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9325,7 +9409,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9351,7 +9435,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9371,13 +9455,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9386,7 +9470,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9414,7 +9498,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9424,31 +9508,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9458,27 +9542,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9488,7 +9572,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9498,7 +9582,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9508,7 +9592,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9518,7 +9602,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9528,7 +9612,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9538,7 +9622,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9552,7 +9636,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9562,7 +9646,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9572,7 +9656,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr "informasjon"
 
@@ -9580,11 +9664,11 @@ msgstr "informasjon"
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr "navn"
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr "nei"
@@ -9597,7 +9681,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr "vennligst bruk `incus profile`"
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr "brukt plass"
 
@@ -9614,7 +9698,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr "total plass"
 
@@ -9622,7 +9706,7 @@ msgstr "total plass"
 msgid "unreachable"
 msgstr "utilgjengelig"
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr "brukt av"
 
@@ -9630,8 +9714,8 @@ msgstr "brukt av"
 msgid "y"
 msgstr "j"
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -31,7 +31,7 @@ msgstr "  Firmware:"
 msgid "  Motherboard:"
 msgstr "  Moederboord:"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -54,7 +54,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -121,7 +121,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde fingerprint niet kan worden aangepast"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -227,7 +227,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -280,7 +280,7 @@ msgstr ""
 "### Merk op dat alleen de inkomende en uitgaande regels, beschrijving en "
 "configuratiesleutels kunnen worden aangepast."
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -337,7 +337,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de naam wordt getoond, maar aangepast kan worden"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -404,7 +404,7 @@ msgstr ""
 "### Merk op dat het luisteradres (listen_address) en locatie (location) niet "
 "kunnen worden aangepast."
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -435,7 +435,7 @@ msgstr ""
 "(target_project), bestemming netwerk (target_network) en de status velden "
 "(status fielsds) niet kunnen worden aangepast."
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -461,7 +461,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -486,7 +486,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -522,7 +522,7 @@ msgstr ""
 "###\n"
 "### Merk op dat alleen de configuratie kan worden aangepast."
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +561,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde naam (name) niet kan worden aangepast"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -687,7 +687,7 @@ msgid "--console only works with a single instance"
 msgstr ""
 "--console werkt alleen als het een enkele instantiatie (instance) betreft"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 "--empty kan niet gebruikt worden in combinatie met een virtuele disk (image) "
@@ -793,7 +793,7 @@ msgstr "Een clusterlid (cluster member) naam (name) moet worden meegegeven"
 msgid "ADDRESS"
 msgstr "ADRES"
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -817,11 +817,11 @@ msgstr "AUTHENTICATIE TYPE"
 msgid "Accept certificate"
 msgstr "Accepteer certificaat"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr "Toegangssleutel (automatisch gegenereerd wanneer leeg gegeven)"
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr "Toegangssleutel: %s"
@@ -843,24 +843,24 @@ msgstr "Actie %q is niet ondersteund door dit programma"
 msgid "Action (defaults to GET)"
 msgstr "Actie (standaard is: GET)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 "Voeg een clusterlid (cluster member) toe aan de clustergroep (cluster group)"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr "Voeg een netwerk (network) zone record toe"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr "Voeg een items toe aan een netwerk (network) zone record"
 
@@ -868,7 +868,7 @@ msgstr "Voeg een items toe aan een netwerk (network) zone record"
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr "Voeg een lid (member) toe aan een group (group)"
 
@@ -904,11 +904,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr "Voeg een vertrouwde cliënt (client) toe"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -925,12 +925,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr "Voeg poorten (ports) toe aan een doorstuurregel (forward)"
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr "Voeg poorten (ports) toe aan een werkverdeler (load balancer)"
 
@@ -942,7 +942,7 @@ msgstr "Voeg profielen (profiles) toe aan instantiaties (instances)"
 msgid "Add roles to a cluster member"
 msgstr "Voeg rollen (roles) toe aan een clusterlid (cluster member)"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 "Voeg regels (rules) toe aan een toegangscontrole lijst (Access Control List "
@@ -973,12 +973,12 @@ msgstr "Adres: %s"
 msgid "Address: %v"
 msgstr "Adres: %v"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Beheer (Admin) toegangssleutel: %s"
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Beheer (Admin) geheime toegangssleutel (secret key): %s"
@@ -993,8 +993,8 @@ msgstr "Alias %s bestaat al"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s bestaat niet"
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr "Alias naam (name) mist"
 
@@ -1018,7 +1018,7 @@ msgstr ""
 "Alle huidige gegevens gaan verloren bij het lid worden (joining) van een "
 "cluster, doorgaan?"
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr "Alle projecten"
 
@@ -1026,7 +1026,7 @@ msgstr "Alle projecten"
 msgid "All server addresses are unavailable"
 msgstr "Alle server adressen zijn onbeschikbaar"
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
@@ -1056,7 +1056,7 @@ msgstr ""
 "Beide konden niet worden gevonden, de directe SPICE plug (raw SPICE socket) "
 "kan hier gevonden worden:"
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 "Gevraagd naar een virtueel machine (VM), maar het bestand (image) is van het "
@@ -1141,7 +1141,11 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr "BASIS IMAGEBESTAND"
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -1150,22 +1154,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Backup aan het maken van instantiatie (instance): %s"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Back-uppen van opslag emmer (storage bucket): %s"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1174,22 +1178,22 @@ msgstr "Backups:"
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Ongeldig sleutel=waarde paar: %q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ongeldig sleutel=waarde paar: %s"
@@ -1199,7 +1203,7 @@ msgstr "Ongeldig sleutel=waarde paar: %s"
 msgid "Bad property: %s"
 msgstr "Ongeldig eigenschap: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr "Samenvoeging (Bond):"
 
@@ -1212,20 +1216,24 @@ msgstr "Beide --all en instantiatie naam (instance name) zijn gegeven"
 msgid "Brand: %v"
 msgstr "Merk (Brand): %v"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr "Brug (Bridge):"
+
+#: cmd/incus/storage_bucket.go:106
+msgid "Bucket description"
+msgstr ""
 
 #: cmd/incus/info.go:365
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Bus Adres: %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1233,11 +1241,11 @@ msgstr "Bytes verzonden"
 msgid "CANCELABLE"
 msgstr "ONDERBREEKBAAR"
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "GEWONE NAAM"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr "INHOUDSTYPE"
 
@@ -1329,7 +1337,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1337,7 +1345,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1371,7 +1379,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1390,7 +1398,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1405,9 +1413,13 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
+msgstr ""
+
+#: cmd/incus/config_trust.go:184
+msgid "Certificate description"
 msgstr ""
 
 #: cmd/incus/remote.go:237
@@ -1427,7 +1439,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1455,24 +1467,28 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+msgid "Cluster group description"
 msgstr ""
 
 #: cmd/incus/cluster.go:1304
@@ -1485,57 +1501,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1544,17 +1560,17 @@ msgid "Clustering enabled"
 msgstr "Clustering aan"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Kolommen"
@@ -1590,7 +1606,7 @@ msgstr "Compressie algoritme om te gebruiken (`none` is geen compressie)"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Compressie algoritme om te gebruiken (none is zonder compressie)"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuratie sleutel/waarde toe te passen op de nieuwe instantiatie"
 
@@ -1598,7 +1614,7 @@ msgstr "Configuratie sleutel/waarde toe te passen op de nieuwe instantiatie"
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1610,16 +1626,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1641,11 +1657,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1782,7 +1798,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1791,7 +1807,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1800,15 +1816,15 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1841,11 +1857,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1853,11 +1869,11 @@ msgstr ""
 msgid "Create network integrations"
 msgstr "Creëer netwerk integraties"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1865,58 +1881,58 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1926,7 +1942,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid "Creating the instance"
 msgstr ""
 
@@ -1939,16 +1955,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1960,7 +1976,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr ""
 
@@ -1983,11 +1999,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Datum: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1999,7 +2015,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -2007,7 +2023,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 msgid "Delete custom storage volumes"
 msgstr "Verwijder aangepaste opslag volumes (storage volume)"
 
@@ -2015,7 +2031,7 @@ msgstr "Verwijder aangepaste opslag volumes (storage volume)"
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2035,15 +2051,15 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2051,44 +2067,44 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Verwijder netwerk integratie"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -2110,12 +2126,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2130,11 +2146,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2142,31 +2158,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2174,45 +2190,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2220,60 +2236,60 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 msgid "Detach custom storage volumes from instances"
 msgstr "Ontkoppel aangepaste opslag volumes van een instantiatie (instance)"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 msgid "Detach custom storage volumes from profiles"
 msgstr "Ontkoppel aangepaste opslag volumes van profielen (profiles)"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2334,7 +2350,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2391,7 +2407,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr "Toon netwerk zones van alle projecten"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 msgid "Display profiles from all projects"
 msgstr "Toon profielen van alle projecten"
 
@@ -2399,7 +2415,7 @@ msgstr "Toon profielen van alle projecten"
 msgid "Display resource usage info per instance"
 msgstr "Toon resource gebruik per instantiatie"
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 msgid "Display storage pool buckets from all projects"
 msgstr "Toon opslag pool emmers (buckets) van alle projecten"
 
@@ -2449,7 +2465,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr "Toon geen voortgang indicator/informatie"
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2478,7 +2494,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2491,12 +2507,12 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -2506,7 +2522,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2534,15 +2550,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2550,48 +2566,48 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2600,22 +2616,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2649,7 +2665,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2657,7 +2673,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2681,15 +2697,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2704,14 +2720,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2801,8 +2817,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2826,7 +2842,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2838,24 +2854,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Exporteren van de backup van opslag (storage) emmer (bucket): %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2873,8 +2889,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2956,7 +2972,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2966,17 +2982,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -3065,7 +3081,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -3075,7 +3091,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -3085,12 +3101,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3237,7 +3253,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3255,7 +3271,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3318,19 +3334,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3347,7 +3363,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3396,15 +3412,15 @@ msgstr "Genereer het client certificaat"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 msgid "Get current load-balacner status"
 msgstr ""
 
@@ -3412,11 +3428,11 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 msgid "Get the key as a cluster group property"
 msgstr "Opvragen sleutel (key) als cluster groep eigenschap (property)"
 
@@ -3428,7 +3444,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3436,15 +3452,15 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr "Opvragen sleutel (key) als netwerk integratie eigenschap (property)"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3452,27 +3468,27 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3480,7 +3496,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 msgid "Get values for cluster group configuration keys"
 msgstr "Opvragen waarden van cluster groep configuratie sleutels (keys)"
 
@@ -3500,11 +3516,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -3512,12 +3528,12 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3525,31 +3541,31 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3570,7 +3586,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3606,7 +3622,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3620,7 +3636,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3633,7 +3649,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3641,27 +3657,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3673,7 +3689,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3687,7 +3703,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3697,6 +3713,10 @@ msgstr ""
 
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
+msgstr ""
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
 msgstr ""
 
 #: cmd/incus/image.go:1482
@@ -3741,15 +3761,15 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 msgid "Import custom storage volumes."
 msgstr "Importeer aangepaste opslag volumes (storage volume)."
 
@@ -3768,28 +3788,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3799,7 +3819,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3823,6 +3843,10 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+msgid "Instance description"
+msgstr ""
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3836,7 +3860,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3855,7 +3879,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3863,8 +3887,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3883,8 +3907,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3894,7 +3918,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -3972,7 +3996,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3981,7 +4005,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 msgid "Invalid peer type"
 msgstr ""
 
@@ -3990,9 +4014,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -4036,6 +4060,10 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid "Key description"
+msgstr ""
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -4044,7 +4072,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -4052,10 +4080,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4073,12 +4101,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 msgid "Launching the instance"
 msgstr ""
 
@@ -4092,11 +4120,11 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4124,11 +4152,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4176,11 +4204,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4323,7 +4351,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid "List available network zone records"
 msgstr ""
 
@@ -4354,11 +4382,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4379,11 +4407,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4438,11 +4466,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4679,11 +4707,11 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 msgid "List networks in all projects"
 msgstr "Toon lijst van netwerken in alle projecten"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4691,11 +4719,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4711,11 +4739,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4736,11 +4764,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4762,11 +4790,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4789,11 +4817,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4807,11 +4835,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4860,11 +4888,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4919,11 +4947,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4936,7 +4968,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -4957,15 +4989,15 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4973,7 +5005,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4983,11 +5015,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5008,11 +5040,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5020,7 +5052,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5110,7 +5142,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -5118,7 +5150,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -5130,13 +5162,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr "Beheer netwerk integraties"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -5148,11 +5180,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid "Manage network zone records"
 msgstr ""
 
@@ -5168,11 +5200,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -5188,7 +5220,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5293,27 +5325,27 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid "Missing cluster group name"
 msgstr ""
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -5322,30 +5354,30 @@ msgstr ""
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 msgid "Missing listen address"
 msgstr ""
 
@@ -5357,10 +5389,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5371,83 +5403,83 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr "Netwerk integratie naam mist"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr ""
 
@@ -5459,11 +5491,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5471,11 +5503,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5500,8 +5532,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5513,7 +5545,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5541,7 +5573,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5550,11 +5582,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5567,15 +5599,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5583,11 +5615,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5604,9 +5636,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5630,8 +5662,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5691,8 +5723,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5702,59 +5734,71 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+msgid "Network ACL description"
+msgstr ""
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+msgid "Network description"
+msgstr ""
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
+msgstr ""
+
+#: cmd/incus/network_forward.go:335
+msgid "Network forward description"
 msgstr ""
 
 #: cmd/incus/network_integration.go:160
@@ -5772,55 +5816,55 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5833,7 +5877,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5842,7 +5886,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5852,27 +5896,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5880,11 +5924,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5924,7 +5968,7 @@ msgstr ""
 msgid "OS Version"
 msgstr "OS Versie"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -5932,11 +5976,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5948,11 +5992,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5974,7 +6018,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6020,19 +6064,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6044,11 +6088,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -6079,6 +6123,10 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+msgid "Peer description"
+msgstr ""
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6101,6 +6149,10 @@ msgstr ""
 
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
+msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid "Port description"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -6141,17 +6193,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6206,36 +6258,40 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/profile.go:369
+msgid "Profile description"
 msgstr ""
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6256,19 +6312,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/project.go:114
+msgid "Project description"
 msgstr ""
 
 #: cmd/incus/remote.go:124
@@ -6288,7 +6348,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
@@ -6341,15 +6401,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6368,6 +6428,10 @@ msgstr ""
 
 #: cmd/incus/rebuild.go:26
 msgid "Rebuild instances"
+msgstr ""
+
+#: cmd/incus/network_zone.go:1092
+msgid "Record description"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:28
@@ -6415,7 +6479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6454,14 +6518,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -6469,7 +6533,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6477,23 +6541,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6501,20 +6565,20 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6526,7 +6590,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6535,11 +6599,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6547,12 +6611,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 msgid "Rename custom storage volumes"
 msgstr "Hernoem aangepaste opslag volumes"
 
@@ -6564,7 +6628,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6572,15 +6636,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr "Hernoem netwerk integraties"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6588,16 +6652,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6638,7 +6702,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6647,7 +6711,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6659,12 +6723,12 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -6672,13 +6736,17 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
+msgstr ""
+
+#: cmd/incus/network_acl.go:887
+msgid "Rule description"
 msgstr ""
 
 #: cmd/incus/remote_unix.go:36
@@ -6718,7 +6786,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6745,9 +6813,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr "GESTART OM"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6763,7 +6831,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6771,11 +6839,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6783,11 +6851,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6824,7 +6892,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6842,7 +6910,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 msgid "Set a cluster group's configuration keys"
 msgstr "Definieer een cluster groep configuratie sleutels (keys)"
 
@@ -6893,11 +6961,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6906,11 +6974,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6919,11 +6987,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6946,11 +7014,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6959,11 +7027,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6972,11 +7040,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6985,15 +7053,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7002,11 +7070,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7015,11 +7083,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7028,11 +7096,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7041,11 +7109,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7087,7 +7155,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 msgid "Set the key as a cluster group property"
 msgstr ""
 "Definieer de sleutel (key) voor markering als een cluster groep eigenschap"
@@ -7096,11 +7164,11 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -7109,43 +7177,43 @@ msgid "Set the key as a network integration property"
 msgstr ""
 "Definieer de sleutel (key) als een netwerk integratie eigenschap (property)"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7173,7 +7241,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -7233,7 +7301,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7258,39 +7326,39 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7302,19 +7370,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7323,7 +7391,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7335,7 +7403,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7347,15 +7415,15 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr ""
 
@@ -7367,7 +7435,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7389,15 +7457,19 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7447,7 +7519,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -7482,22 +7554,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7516,22 +7588,26 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+msgid "Storage pool description"
+msgstr ""
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7540,12 +7616,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7558,7 +7634,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7589,7 +7665,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7605,7 +7681,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7613,20 +7689,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7699,7 +7775,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7721,7 +7797,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7729,7 +7805,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
@@ -7757,7 +7833,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
@@ -7777,12 +7853,12 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -7792,7 +7868,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7802,7 +7878,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7812,37 +7888,37 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7893,12 +7969,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -7948,11 +8024,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7968,7 +8044,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -7976,7 +8052,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7992,7 +8068,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8022,7 +8098,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8040,7 +8116,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid "Type of certificate"
 msgstr ""
 
@@ -8050,18 +8126,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8073,7 +8149,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8085,11 +8161,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -8115,7 +8191,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -8126,17 +8202,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8152,7 +8228,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8162,7 +8238,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 msgid "Unset a cluster group's configuration keys"
 msgstr "Verwijder de cluster groep eigenschappen (keys)"
 
@@ -8186,19 +8262,19 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -8206,51 +8282,51 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8259,7 +8335,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 msgid "Unset the key as a cluster group property"
 msgstr ""
 "Verwijder de sleutel (key) voor markering als een cluster groep eigenschap"
@@ -8268,11 +8344,11 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -8280,43 +8356,43 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8329,7 +8405,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8357,16 +8433,16 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8389,7 +8465,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8404,15 +8480,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8452,8 +8528,12 @@ msgstr "Versie: %s"
 msgid "Version: %v"
 msgstr "Versie: %v"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+msgid "Volume description"
 msgstr ""
 
 #: cmd/incus/info.go:307
@@ -8603,9 +8683,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8634,7 +8714,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid "Zone description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8643,12 +8727,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8661,11 +8745,11 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -8673,32 +8757,32 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -8706,54 +8790,54 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -8777,7 +8861,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8824,7 +8908,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -8897,8 +8981,8 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -8943,14 +9027,14 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -8958,63 +9042,63 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -9022,25 +9106,25 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
@@ -9048,7 +9132,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -9056,63 +9140,63 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -9120,52 +9204,52 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -9174,8 +9258,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9191,11 +9275,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9203,7 +9287,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
@@ -9211,20 +9295,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -9236,28 +9320,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -9289,11 +9373,11 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9301,7 +9385,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9351,7 +9435,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9393,7 +9477,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9405,7 +9489,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9540,7 +9624,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9548,7 +9632,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9560,7 +9644,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9585,7 +9669,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9594,7 +9678,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9610,7 +9694,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9618,7 +9702,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9644,7 +9728,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9664,13 +9748,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9679,7 +9763,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9707,7 +9791,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9717,31 +9801,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9751,27 +9835,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9781,7 +9865,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9791,7 +9875,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9801,7 +9885,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9811,7 +9895,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9821,7 +9905,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9831,7 +9915,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9845,7 +9929,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9855,7 +9939,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9872,7 +9956,7 @@ msgstr ""
 "    Verwijdert de snapshot houdbaarheidsperiode van de virtuele machine "
 "volume \"v1\" in pool \"default\""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr "informatie"
 
@@ -9880,11 +9964,11 @@ msgstr "informatie"
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr "naam"
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr "nee"
@@ -9897,7 +9981,7 @@ msgstr "ok (j/n/[vingerafdruk])?"
 msgid "please use `incus profile`"
 msgstr "gebruik `incus profile`"
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr "ruimte gebruikt"
 
@@ -9914,7 +9998,7 @@ msgstr "sshfs koppelen van %q op %q"
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr "sshfs niet gevonden. Probeer SSH SFTP methode via de --listen optie"
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr "totale ruimte"
 
@@ -9922,7 +10006,7 @@ msgstr "totale ruimte"
 msgid "unreachable"
 msgstr "onbereikbaar"
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr "gebruikt door"
 
@@ -9930,9 +10014,9 @@ msgstr "gebruikt door"
 msgid "y"
 msgstr "j"
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -41,7 +41,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -58,7 +58,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -80,7 +80,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -141,7 +141,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -169,7 +169,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -201,7 +201,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -235,7 +235,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -266,7 +266,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -280,7 +280,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -300,7 +300,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -321,7 +321,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr ""
 
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -577,23 +577,23 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -629,11 +629,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -650,12 +650,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -667,7 +667,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -694,12 +694,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -714,8 +714,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -853,7 +853,11 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -862,22 +866,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -886,22 +890,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -911,7 +915,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -924,8 +928,12 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+msgid "Bucket description"
 msgstr ""
 
 #: cmd/incus/info.go:365
@@ -933,11 +941,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr ""
 
@@ -945,11 +953,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1039,7 +1047,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1047,7 +1055,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1081,7 +1089,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1100,7 +1108,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1115,9 +1123,13 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
+msgstr ""
+
+#: cmd/incus/config_trust.go:184
+msgid "Certificate description"
 msgstr ""
 
 #: cmd/incus/remote.go:237
@@ -1137,7 +1149,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1165,24 +1177,28 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+msgid "Cluster group description"
 msgstr ""
 
 #: cmd/incus/cluster.go:1304
@@ -1195,57 +1211,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1254,17 +1270,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
@@ -1292,7 +1308,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1300,7 +1316,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1312,16 +1328,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1343,11 +1359,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1484,7 +1500,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1493,7 +1509,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1502,15 +1518,15 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1543,11 +1559,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1555,11 +1571,11 @@ msgstr ""
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1567,58 +1583,58 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1628,7 +1644,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid "Creating the instance"
 msgstr ""
 
@@ -1641,16 +1657,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1662,7 +1678,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr ""
 
@@ -1685,11 +1701,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1701,7 +1717,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1709,7 +1725,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1717,7 +1733,7 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1737,15 +1753,15 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1753,44 +1769,44 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1812,12 +1828,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -1832,11 +1848,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -1844,31 +1860,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -1876,45 +1892,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -1922,60 +1938,60 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2036,7 +2052,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2093,7 +2109,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2101,7 +2117,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2151,7 +2167,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2180,7 +2196,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2193,12 +2209,12 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -2208,7 +2224,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2236,15 +2252,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2252,48 +2268,48 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2302,22 +2318,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2351,7 +2367,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2359,7 +2375,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2383,15 +2399,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2406,14 +2422,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2503,8 +2519,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2528,7 +2544,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2540,24 +2556,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2575,8 +2591,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2658,7 +2674,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2668,17 +2684,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2767,7 +2783,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2777,7 +2793,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2787,12 +2803,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2939,7 +2955,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2957,7 +2973,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3020,19 +3036,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3049,7 +3065,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3098,15 +3114,15 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 msgid "Get current load-balacner status"
 msgstr ""
 
@@ -3114,11 +3130,11 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 msgid "Get the key as a cluster group property"
 msgstr ""
 
@@ -3130,7 +3146,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3138,15 +3154,15 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3154,27 +3170,27 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3182,7 +3198,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
@@ -3202,11 +3218,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -3214,12 +3230,12 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3227,31 +3243,31 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3272,7 +3288,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3308,7 +3324,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3322,7 +3338,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3335,7 +3351,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3343,27 +3359,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3375,7 +3391,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3389,7 +3405,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3399,6 +3415,10 @@ msgstr ""
 
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
+msgstr ""
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
 msgstr ""
 
 #: cmd/incus/image.go:1482
@@ -3443,15 +3463,15 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3470,28 +3490,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3501,7 +3521,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3525,6 +3545,10 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+msgid "Instance description"
+msgstr ""
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3538,7 +3562,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3557,7 +3581,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3565,8 +3589,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3585,8 +3609,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3596,7 +3620,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -3674,7 +3698,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3683,7 +3707,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 msgid "Invalid peer type"
 msgstr ""
 
@@ -3692,9 +3716,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3738,6 +3762,10 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid "Key description"
+msgstr ""
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -3746,7 +3774,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -3754,10 +3782,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3775,12 +3803,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 msgid "Launching the instance"
 msgstr ""
 
@@ -3794,11 +3822,11 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3826,11 +3854,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3878,11 +3906,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4025,7 +4053,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid "List available network zone records"
 msgstr ""
 
@@ -4056,11 +4084,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4081,11 +4109,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4140,11 +4168,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4381,11 +4409,11 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4393,11 +4421,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4413,11 +4441,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4438,11 +4466,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4464,11 +4492,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4491,11 +4519,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4509,11 +4537,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4562,11 +4590,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4621,11 +4649,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4638,7 +4670,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -4659,15 +4691,15 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4675,7 +4707,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4685,11 +4717,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -4710,11 +4742,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -4722,7 +4754,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4812,7 +4844,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4820,7 +4852,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4832,13 +4864,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4850,11 +4882,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4870,11 +4902,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4890,7 +4922,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -4995,27 +5027,27 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid "Missing cluster group name"
 msgstr ""
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -5024,30 +5056,30 @@ msgstr ""
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 msgid "Missing listen address"
 msgstr ""
 
@@ -5059,10 +5091,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5073,83 +5105,83 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr ""
 
@@ -5161,11 +5193,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5173,11 +5205,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5202,8 +5234,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5215,7 +5247,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5243,7 +5275,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5252,11 +5284,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5269,15 +5301,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5285,11 +5317,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5306,9 +5338,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5332,8 +5364,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5393,8 +5425,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5404,59 +5436,71 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+msgid "Network ACL description"
+msgstr ""
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+msgid "Network description"
+msgstr ""
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
+msgstr ""
+
+#: cmd/incus/network_forward.go:335
+msgid "Network forward description"
 msgstr ""
 
 #: cmd/incus/network_integration.go:160
@@ -5474,55 +5518,55 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5535,7 +5579,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5544,7 +5588,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5554,27 +5598,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5582,11 +5626,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5626,7 +5670,7 @@ msgstr ""
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -5634,11 +5678,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5650,11 +5694,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5676,7 +5720,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5722,19 +5766,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -5746,11 +5790,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -5781,6 +5825,10 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+msgid "Peer description"
+msgstr ""
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -5803,6 +5851,10 @@ msgstr ""
 
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
+msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid "Port description"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -5843,17 +5895,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5908,36 +5960,40 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/profile.go:369
+msgid "Profile description"
 msgstr ""
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -5958,19 +6014,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/project.go:114
+msgid "Project description"
 msgstr ""
 
 #: cmd/incus/remote.go:124
@@ -5990,7 +6050,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
@@ -6043,15 +6103,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6070,6 +6130,10 @@ msgstr ""
 
 #: cmd/incus/rebuild.go:26
 msgid "Rebuild instances"
+msgstr ""
+
+#: cmd/incus/network_zone.go:1092
+msgid "Record description"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:28
@@ -6117,7 +6181,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6156,14 +6220,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -6171,7 +6235,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6179,23 +6243,23 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6203,20 +6267,20 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6228,7 +6292,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6237,11 +6301,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6249,12 +6313,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6266,7 +6330,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6274,15 +6338,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6290,16 +6354,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6340,7 +6404,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6349,7 +6413,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6361,12 +6425,12 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -6374,13 +6438,17 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
+msgstr ""
+
+#: cmd/incus/network_acl.go:887
+msgid "Rule description"
 msgstr ""
 
 #: cmd/incus/remote_unix.go:36
@@ -6420,7 +6488,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6447,9 +6515,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6465,7 +6533,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6473,11 +6541,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6485,11 +6553,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6526,7 +6594,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6544,7 +6612,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
@@ -6595,11 +6663,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6608,11 +6676,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6621,11 +6689,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6648,11 +6716,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6661,11 +6729,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6674,11 +6742,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6687,15 +6755,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6704,11 +6772,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6717,11 +6785,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6730,11 +6798,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6743,11 +6811,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6789,7 +6857,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 msgid "Set the key as a cluster group property"
 msgstr ""
 
@@ -6797,11 +6865,11 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -6809,43 +6877,43 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6873,7 +6941,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -6933,7 +7001,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -6958,39 +7026,39 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7002,19 +7070,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7023,7 +7091,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7035,7 +7103,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7047,15 +7115,15 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr ""
 
@@ -7067,7 +7135,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7089,15 +7157,19 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7147,7 +7219,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -7182,22 +7254,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7216,22 +7288,26 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+msgid "Storage pool description"
+msgstr ""
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7240,12 +7316,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7258,7 +7334,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7289,7 +7365,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7305,7 +7381,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7313,20 +7389,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7399,7 +7475,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7421,7 +7497,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7429,7 +7505,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
@@ -7457,7 +7533,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
@@ -7477,12 +7553,12 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -7492,7 +7568,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7502,7 +7578,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7512,37 +7588,37 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7593,12 +7669,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -7648,11 +7724,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7668,7 +7744,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -7676,7 +7752,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7692,7 +7768,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7722,7 +7798,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -7740,7 +7816,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid "Type of certificate"
 msgstr ""
 
@@ -7750,18 +7826,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7773,7 +7849,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -7785,11 +7861,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -7815,7 +7891,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -7826,17 +7902,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7852,7 +7928,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7862,7 +7938,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
@@ -7886,19 +7962,19 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7906,51 +7982,51 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -7959,7 +8035,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
@@ -7967,11 +8043,11 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -7979,43 +8055,43 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8028,7 +8104,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8056,16 +8132,16 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8088,7 +8164,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8103,15 +8179,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8151,8 +8227,12 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+msgid "Volume description"
 msgstr ""
 
 #: cmd/incus/info.go:307
@@ -8302,9 +8382,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8333,7 +8413,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid "Zone description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8342,12 +8426,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8360,11 +8444,11 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -8372,32 +8456,32 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -8405,54 +8489,54 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -8476,7 +8560,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8523,7 +8607,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -8596,8 +8680,8 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -8642,14 +8726,14 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -8657,63 +8741,63 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -8721,25 +8805,25 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
@@ -8747,7 +8831,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -8755,63 +8839,63 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8819,52 +8903,52 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8873,8 +8957,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -8890,11 +8974,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -8902,7 +8986,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
@@ -8910,20 +8994,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -8935,28 +9019,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -8988,11 +9072,11 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9000,7 +9084,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9050,7 +9134,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9092,7 +9176,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9104,7 +9188,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9239,7 +9323,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9247,7 +9331,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9259,7 +9343,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9284,7 +9368,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9293,7 +9377,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9309,7 +9393,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9317,7 +9401,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9343,7 +9427,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9363,13 +9447,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9378,7 +9462,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9406,7 +9490,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9416,31 +9500,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9450,27 +9534,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9480,7 +9564,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9490,7 +9574,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9500,7 +9584,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9510,7 +9594,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9520,7 +9604,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9530,7 +9614,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9544,7 +9628,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9554,7 +9638,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9564,7 +9648,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -9572,11 +9656,11 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
@@ -9589,7 +9673,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -9606,7 +9690,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -9614,7 +9698,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -9622,8 +9706,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -54,7 +54,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -85,7 +85,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -111,7 +111,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -123,7 +123,7 @@ msgstr ""
 "###\n"
 "### Observe que a impressão digital é exibida, mas não pode ser alterada"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -229,7 +229,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -274,7 +274,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -328,7 +328,7 @@ msgstr ""
 "###\n"
 "### Observe que a impressão digital é exibida, mas não pode ser alterada"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -379,7 +379,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -411,7 +411,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -437,7 +437,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -463,7 +463,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -500,7 +500,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -662,7 +662,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -778,7 +778,7 @@ msgstr "Nome de membro do cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -802,11 +802,11 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -829,25 +829,25 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Action (defaults to GET)"
 msgstr "Ação (padrão para o GET)"
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -885,12 +885,12 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -907,12 +907,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -954,12 +954,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr "O dispositivo já existe: %s"
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
@@ -974,8 +974,8 @@ msgstr "Alias %s já existe"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
@@ -997,7 +997,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1006,7 +1006,7 @@ msgstr "Criar projetos"
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1123,7 +1123,12 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+#, fuzzy
+msgid "Backend description"
+msgstr "Descrição"
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -1132,22 +1137,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -1156,22 +1161,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1181,7 +1186,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -1194,20 +1199,25 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
 msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+#, fuzzy
+msgid "Bucket description"
+msgstr "Descrição"
 
 #: cmd/incus/info.go:365
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1215,11 +1225,11 @@ msgstr "Bytes enviado"
 msgid "CANCELABLE"
 msgstr "CANCELÁVEL"
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1312,7 +1322,7 @@ msgstr "Não é possível remover o default remoto"
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 #, fuzzy
 msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
@@ -1321,7 +1331,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
@@ -1355,7 +1365,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1374,7 +1384,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1389,10 +1399,15 @@ msgstr "Cartão %d:"
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
+
+#: cmd/incus/config_trust.go:184
+#, fuzzy
+msgid "Certificate description"
+msgstr "Certificado fingerprint: %s"
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1411,7 +1426,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1440,25 +1455,30 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr "Clustering ativado"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1470,57 +1490,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1529,17 +1549,17 @@ msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Colunas"
@@ -1576,7 +1596,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1586,7 +1606,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new network integration"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1599,16 +1619,16 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1630,11 +1650,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1774,7 +1794,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1783,7 +1803,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1792,16 +1812,16 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Criar novas redes"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1841,11 +1861,11 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1854,12 +1874,12 @@ msgstr ""
 msgid "Create network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1868,64 +1888,64 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 #, fuzzy
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
@@ -1935,7 +1955,7 @@ msgstr "Criando %s"
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1949,16 +1969,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1970,7 +1990,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -1993,11 +2013,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -2010,7 +2030,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -2019,7 +2039,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Apagar nomes alternativos da imagem"
@@ -2029,7 +2049,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
@@ -2052,16 +2072,16 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
@@ -2071,49 +2091,49 @@ msgstr "Criar novas redes"
 msgid "Delete network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Apagar nomes alternativos da imagem"
@@ -2136,12 +2156,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2156,11 +2176,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2168,31 +2188,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2200,45 +2220,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2246,64 +2266,64 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
@@ -2365,7 +2385,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2427,7 +2447,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
@@ -2436,7 +2456,7 @@ msgstr "Criar projetos"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Criar projetos"
@@ -2487,7 +2507,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2516,7 +2536,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2529,13 +2549,13 @@ msgstr "EFÊMERO"
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
@@ -2545,7 +2565,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2578,16 +2598,16 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2597,54 +2617,54 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network integration configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2653,23 +2673,23 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2703,7 +2723,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2711,7 +2731,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2735,15 +2755,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2758,14 +2778,14 @@ msgstr "Editar propriedades da imagem"
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2856,8 +2876,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2881,7 +2901,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2893,26 +2913,26 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Criar novas redes"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2930,8 +2950,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -3013,7 +3033,7 @@ msgstr "Aceitar certificado"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3023,17 +3043,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
@@ -3122,7 +3142,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Aceitar certificado"
@@ -3132,7 +3152,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
@@ -3142,12 +3162,12 @@ msgstr "Aceitar certificado"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
@@ -3294,7 +3314,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3312,7 +3332,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3376,19 +3396,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3405,7 +3425,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3455,16 +3475,16 @@ msgstr "Adicionar novos clientes confiáveis"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Criar novas redes"
@@ -3474,11 +3494,11 @@ msgstr "Criar novas redes"
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3491,7 +3511,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
@@ -3501,17 +3521,17 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3520,29 +3540,29 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3551,7 +3571,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3576,11 +3596,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3590,13 +3610,13 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3606,34 +3626,34 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3654,7 +3674,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3690,7 +3710,7 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr "ID"
 
@@ -3704,7 +3724,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3717,7 +3737,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3725,27 +3745,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr "IPV4"
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr "IPV6"
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3757,7 +3777,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3771,7 +3791,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3783,6 +3803,10 @@ msgstr ""
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
+msgstr ""
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -3827,16 +3851,16 @@ msgstr "Anexar interfaces de rede aos perfis"
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Criar novas redes"
@@ -3856,29 +3880,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3888,7 +3912,7 @@ msgstr "Editar arquivos no container"
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3913,6 +3937,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "Descrição"
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3926,7 +3955,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3945,7 +3974,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3954,8 +3983,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
@@ -3975,8 +4004,8 @@ msgstr "Editar arquivos no container"
 msgid "Invalid arguments"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3986,7 +4015,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -4064,7 +4093,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4073,7 +4102,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Editar arquivos no container"
@@ -4083,9 +4112,9 @@ msgstr "Editar arquivos no container"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -4132,6 +4161,11 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+#, fuzzy
+msgid "Key description"
+msgstr "Descrição"
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -4140,7 +4174,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -4148,10 +4182,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4169,12 +4203,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
@@ -4189,11 +4223,11 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4221,12 +4255,12 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4275,12 +4309,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4424,7 +4458,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Criar novas redes"
@@ -4456,11 +4490,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4481,11 +4515,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4540,11 +4574,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4786,12 +4820,12 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4800,11 +4834,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4820,11 +4854,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4845,11 +4879,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4871,11 +4905,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4898,12 +4932,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4917,11 +4951,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4970,11 +5004,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5029,11 +5063,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5046,7 +5084,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -5067,17 +5105,17 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 #, fuzzy
 msgid "Lower device"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 #, fuzzy
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5085,7 +5123,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -5095,11 +5133,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5120,11 +5158,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5132,7 +5170,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5230,7 +5268,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Manage instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -5239,7 +5277,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
@@ -5254,14 +5292,14 @@ msgstr "Criar novas redes"
 msgid "Manage network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
@@ -5276,12 +5314,12 @@ msgstr "Criar novas redes"
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
@@ -5299,12 +5337,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -5322,7 +5360,7 @@ msgstr "Criar novas redes"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Criar novas redes"
@@ -5430,30 +5468,30 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -5463,31 +5501,31 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -5500,10 +5538,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
@@ -5516,86 +5554,86 @@ msgstr "Nome de membro do cluster"
 msgid "Missing network integration name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr ""
 
@@ -5608,11 +5646,11 @@ msgstr "Nome de membro do cluster"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -5621,12 +5659,12 @@ msgstr "Nome de membro do cluster"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5652,8 +5690,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5666,7 +5704,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -5696,7 +5734,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5705,11 +5743,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5722,15 +5760,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5738,11 +5776,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5759,9 +5797,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5785,8 +5823,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5846,8 +5884,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5857,60 +5895,75 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr "Descrição"
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
+msgstr "Editar configurações do container ou do servidor como YAML"
 
 #: cmd/incus/network_integration.go:160
 #, fuzzy, c-format
@@ -5927,55 +5980,55 @@ msgstr "Clustering ativado"
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5988,7 +6041,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5997,7 +6050,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -6007,27 +6060,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -6035,11 +6088,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6080,7 +6133,7 @@ msgstr ""
 msgid "OS Version"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -6088,11 +6141,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6104,11 +6157,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6131,7 +6184,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6179,19 +6232,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6203,11 +6256,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -6238,6 +6291,11 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+#, fuzzy
+msgid "Peer description"
+msgstr "Descrição"
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6262,6 +6320,11 @@ msgstr ""
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
 msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+#, fuzzy
+msgid "Port description"
+msgstr "Descrição"
 
 #: cmd/incus/admin_init_interactive.go:816
 msgid "Port to bind to"
@@ -6301,17 +6364,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6366,37 +6429,42 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/profile.go:369
+#, fuzzy
+msgid "Profile description"
+msgstr "Descrição"
 
 #: cmd/incus/image.go:161
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -6421,20 +6489,25 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/project.go:114
+#, fuzzy
+msgid "Project description"
+msgstr "Descrição"
 
 #: cmd/incus/remote.go:124
 msgid "Project to use for the remote"
@@ -6453,7 +6526,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Nome de membro do cluster"
@@ -6507,15 +6580,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6537,6 +6610,11 @@ msgstr "Editar arquivos no container"
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
+
+#: cmd/incus/network_zone.go:1092
+#, fuzzy
+msgid "Record description"
+msgstr "Descrição"
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6583,7 +6661,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6623,14 +6701,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
@@ -6639,7 +6717,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -6648,25 +6726,25 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
@@ -6675,22 +6753,22 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -6704,7 +6782,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -6714,12 +6792,12 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6727,12 +6805,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6747,7 +6825,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Rename instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
@@ -6757,15 +6835,15 @@ msgstr "Criar novas redes"
 msgid "Rename network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6773,17 +6851,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6832,7 +6910,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6841,7 +6919,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6854,12 +6932,12 @@ msgstr "Editar arquivos no container"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
@@ -6869,7 +6947,7 @@ msgstr "Nome de membro do cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6877,6 +6955,11 @@ msgstr ""
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
+
+#: cmd/incus/network_acl.go:887
+#, fuzzy
+msgid "Rule description"
+msgstr "Descrição"
 
 #: cmd/incus/remote_unix.go:36
 msgid "Run a local API proxy"
@@ -6916,7 +6999,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6944,9 +7027,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr "CRIADO EM"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6962,7 +7045,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6970,11 +7053,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6982,11 +7065,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Criado: %s"
@@ -7023,7 +7106,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -7041,7 +7124,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7097,12 +7180,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7111,11 +7194,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7124,12 +7207,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7153,12 +7236,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7167,12 +7250,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7181,12 +7264,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7195,16 +7278,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7213,12 +7296,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7227,12 +7310,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7241,11 +7324,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7254,11 +7337,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7300,7 +7383,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -7309,11 +7392,11 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
@@ -7323,48 +7406,48 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -7393,7 +7476,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7462,7 +7545,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7492,43 +7575,43 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7540,22 +7623,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7564,7 +7647,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7576,7 +7659,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Ignorar o estado do container"
@@ -7590,15 +7673,15 @@ msgstr "Ignorar o estado do container"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7612,7 +7695,7 @@ msgstr "Nome de membro do cluster"
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7634,15 +7717,20 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+#, fuzzy
+msgid "Snapshot description"
+msgstr "Descrição"
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7692,7 +7780,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -7727,22 +7815,22 @@ msgstr "Copiar a imagem: %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Clustering ativado"
@@ -7761,22 +7849,27 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr "Clustering ativado"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7786,12 +7879,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7804,7 +7897,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -7837,7 +7930,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7853,7 +7946,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7861,20 +7954,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7948,7 +8041,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7970,7 +8063,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7978,7 +8071,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Nome de membro do cluster"
@@ -8006,7 +8099,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Nome de membro do cluster"
@@ -8026,12 +8119,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nome de membro do cluster"
@@ -8041,7 +8134,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
@@ -8051,7 +8144,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nome de membro do cluster"
@@ -8061,37 +8154,37 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8142,12 +8235,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -8198,11 +8291,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -8218,7 +8311,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8226,7 +8319,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -8242,7 +8335,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8272,7 +8365,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8290,7 +8383,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
@@ -8301,18 +8394,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8324,7 +8417,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8338,11 +8431,11 @@ msgstr "Editar arquivos no container"
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -8370,7 +8463,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -8381,17 +8474,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8407,7 +8500,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8417,7 +8510,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -8447,21 +8540,21 @@ msgstr "Editar propriedades da imagem"
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
@@ -8471,59 +8564,59 @@ msgstr "Criar novas redes"
 msgid "Unset network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8532,7 +8625,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Editar configurações de perfil como YAML"
@@ -8541,11 +8634,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
@@ -8555,49 +8648,49 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8610,7 +8703,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8639,17 +8732,17 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 #, fuzzy
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8673,7 +8766,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8688,15 +8781,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8736,9 +8829,14 @@ msgstr "Versão CUDA: %v"
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+#, fuzzy
+msgid "Volume description"
+msgstr "Descrição"
 
 #: cmd/incus/info.go:307
 #, c-format
@@ -8889,9 +8987,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8920,7 +9018,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+#, fuzzy
+msgid "Zone description"
+msgstr "Descrição"
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8930,12 +9033,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8950,12 +9053,12 @@ msgstr "Criar perfis"
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -8963,37 +9066,37 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -9002,62 +9105,62 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
@@ -9085,7 +9188,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -9134,7 +9237,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -9213,8 +9316,8 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
@@ -9269,14 +9372,14 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -9284,70 +9387,70 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -9356,29 +9459,29 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
@@ -9386,7 +9489,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -9394,72 +9497,72 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -9468,60 +9571,60 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -9532,8 +9635,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -9550,11 +9653,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9562,7 +9665,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
@@ -9570,21 +9673,21 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -9597,33 +9700,33 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -9658,11 +9761,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9670,7 +9773,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9720,7 +9823,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9762,7 +9865,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9774,7 +9877,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9909,7 +10012,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9917,7 +10020,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9929,7 +10032,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9954,7 +10057,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9963,7 +10066,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9979,7 +10082,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9987,7 +10090,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10013,7 +10116,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10033,13 +10136,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10048,7 +10151,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10076,7 +10179,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10086,31 +10189,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10120,27 +10223,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10150,7 +10253,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10160,7 +10263,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10170,7 +10273,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10180,7 +10283,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10190,7 +10293,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10200,7 +10303,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10214,7 +10317,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10224,7 +10327,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10234,7 +10337,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -10242,11 +10345,11 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
@@ -10259,7 +10362,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -10276,7 +10379,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -10284,7 +10387,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -10292,9 +10395,9 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -59,7 +59,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -118,7 +118,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -133,7 +133,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -244,7 +244,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -289,7 +289,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -345,7 +345,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -396,7 +396,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -431,7 +431,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -459,7 +459,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -487,7 +487,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -524,7 +524,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -563,7 +563,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -684,7 +684,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr "Копирование образа: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -849,25 +849,25 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -905,12 +905,12 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -927,12 +927,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -945,7 +945,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -972,12 +972,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -992,8 +992,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr "Псевдонимы:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1024,7 +1024,7 @@ msgstr "Доступные команды:"
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1137,7 +1137,11 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -1146,22 +1150,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -1170,22 +1174,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1195,7 +1199,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -1208,8 +1212,12 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+msgid "Bucket description"
 msgstr ""
 
 #: cmd/incus/info.go:365
@@ -1217,11 +1225,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1229,11 +1237,11 @@ msgstr "Отправлено байтов"
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1326,7 +1334,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1334,7 +1342,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1368,7 +1376,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1387,7 +1395,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1402,10 +1410,14 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
+
+#: cmd/incus/config_trust.go:184
+msgid "Certificate description"
+msgstr ""
 
 #: cmd/incus/remote.go:237
 #, c-format
@@ -1424,7 +1436,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1453,25 +1465,30 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+#, fuzzy
+msgid "Cluster group description"
+msgstr " Использование сети:"
 
 #: cmd/incus/cluster.go:1304
 #, c-format
@@ -1483,57 +1500,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1542,17 +1559,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Столбцы"
@@ -1580,7 +1597,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1588,7 +1605,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1600,16 +1617,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1631,11 +1648,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1774,7 +1791,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1783,7 +1800,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1792,16 +1809,16 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1837,12 +1854,12 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Копирование образа: %s"
@@ -1852,12 +1869,12 @@ msgstr "Копирование образа: %s"
 msgid "Create network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1867,65 +1884,65 @@ msgstr "Копирование образа: %s"
 msgid "Create new instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1935,7 +1952,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1949,16 +1966,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1970,7 +1987,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr ""
 
@@ -1993,11 +2010,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2009,7 +2026,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -2017,7 +2034,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -2027,7 +2044,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2050,16 +2067,16 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2068,48 +2085,48 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -2132,12 +2149,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -2152,11 +2169,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2164,31 +2181,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2196,45 +2213,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2242,63 +2259,63 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2359,7 +2376,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2423,7 +2440,7 @@ msgstr "Копирование образа: %s"
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
@@ -2432,7 +2449,7 @@ msgstr "Копирование образа: %s"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Копирование образа: %s"
@@ -2483,7 +2500,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2512,7 +2529,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2525,12 +2542,12 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -2540,7 +2557,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2570,15 +2587,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2587,53 +2604,53 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2642,22 +2659,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2691,7 +2708,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2699,7 +2716,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2723,15 +2740,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2746,14 +2763,14 @@ msgstr "Копирование образа: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2847,8 +2864,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2873,7 +2890,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2888,27 +2905,27 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2926,8 +2943,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -3009,7 +3026,7 @@ msgstr "Принять сертификат"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3019,17 +3036,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
@@ -3118,7 +3135,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Принять сертификат"
@@ -3128,7 +3145,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
@@ -3138,12 +3155,12 @@ msgstr "Принять сертификат"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
@@ -3290,7 +3307,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3308,7 +3325,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3372,19 +3389,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3401,7 +3418,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3451,16 +3468,16 @@ msgstr "Принять сертификат"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Копирование образа: %s"
@@ -3469,11 +3486,11 @@ msgstr "Копирование образа: %s"
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Копирование образа: %s"
@@ -3486,7 +3503,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -3496,17 +3513,17 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3515,30 +3532,30 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -3547,7 +3564,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Копирование образа: %s"
@@ -3569,11 +3586,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
@@ -3583,13 +3600,13 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
@@ -3599,33 +3616,33 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3646,7 +3663,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3684,7 +3701,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3698,7 +3715,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3711,7 +3728,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3719,27 +3736,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3751,7 +3768,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3765,7 +3782,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3777,6 +3794,10 @@ msgstr ""
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
+msgstr ""
 
 #: cmd/incus/image.go:1482
 msgid "Image already up to date."
@@ -3820,17 +3841,17 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Копирование образа: %s"
@@ -3852,29 +3873,29 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3884,7 +3905,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3909,6 +3930,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
+#: cmd/incus/create.go:67
+#, fuzzy
+msgid "Instance description"
+msgstr "Имя контейнера: %s"
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3923,7 +3949,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3942,7 +3968,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3951,8 +3977,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
@@ -3972,8 +3998,8 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid arguments"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3983,7 +4009,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -4061,7 +4087,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4070,7 +4096,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Имя контейнера: %s"
@@ -4080,9 +4106,9 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -4129,6 +4155,10 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid "Key description"
+msgstr ""
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -4137,7 +4167,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -4145,10 +4175,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -4166,12 +4196,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4186,11 +4216,11 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4219,12 +4249,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4273,12 +4303,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4423,7 +4453,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
@@ -4455,11 +4485,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4480,11 +4510,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4539,11 +4569,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4786,12 +4816,12 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4800,11 +4830,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4820,11 +4850,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4845,12 +4875,12 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4872,12 +4902,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4900,12 +4930,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4919,12 +4949,12 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4973,11 +5003,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5033,11 +5063,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5050,7 +5084,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -5071,17 +5105,17 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 #, fuzzy
 msgid "Lower device"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 #, fuzzy
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5089,7 +5123,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -5099,11 +5133,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -5124,11 +5158,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -5136,7 +5170,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -5233,7 +5267,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
@@ -5242,7 +5276,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
@@ -5257,14 +5291,14 @@ msgstr "Копирование образа: %s"
 msgid "Manage network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
@@ -5279,12 +5313,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
@@ -5302,12 +5336,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Копирование образа: %s"
@@ -5327,7 +5361,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5437,29 +5471,29 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 #, fuzzy
 msgid "Missing cluster member name"
@@ -5469,32 +5503,32 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 #, fuzzy
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -5507,10 +5541,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
@@ -5523,86 +5557,86 @@ msgstr "Имя контейнера: %s"
 msgid "Missing network integration name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -5616,12 +5650,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -5630,12 +5664,12 @@ msgstr "Копирование образа: %s"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5660,8 +5694,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5674,7 +5708,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -5703,7 +5737,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5712,11 +5746,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5729,15 +5763,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5745,11 +5779,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5766,9 +5800,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5792,8 +5826,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5857,8 +5891,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5868,59 +5902,74 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+#, fuzzy
+msgid "Network ACL description"
+msgstr " Использование сети:"
+
+#: cmd/incus/network_zone.go:475
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+#, fuzzy
+msgid "Network description"
+msgstr " Использование сети:"
+
+#: cmd/incus/network_forward.go:416
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
+msgstr " Использование сети:"
+
+#: cmd/incus/network_forward.go:335
+#, fuzzy
+msgid "Network forward description"
 msgstr " Использование сети:"
 
 #: cmd/incus/network_integration.go:160
@@ -5938,57 +5987,57 @@ msgstr " Использование сети:"
 msgid "Network integration %s renamed to %s"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
@@ -6001,7 +6050,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -6010,7 +6059,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -6020,28 +6069,28 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -6049,11 +6098,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6093,7 +6142,7 @@ msgstr ""
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -6101,11 +6150,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6117,11 +6166,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6144,7 +6193,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6192,19 +6241,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -6216,11 +6265,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -6251,6 +6300,10 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+msgid "Peer description"
+msgstr ""
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -6274,6 +6327,10 @@ msgstr ""
 
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
+msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid "Port description"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -6314,17 +6371,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6379,36 +6436,40 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/profile.go:369
+msgid "Profile description"
 msgstr ""
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6429,19 +6490,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/project.go:114
+msgid "Project description"
 msgstr ""
 
 #: cmd/incus/remote.go:124
@@ -6461,7 +6526,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Копирование образа: %s"
@@ -6514,15 +6579,15 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6544,6 +6609,10 @@ msgstr "Невозможно добавить имя контейнера в с�
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
+
+#: cmd/incus/network_zone.go:1092
+msgid "Record description"
+msgstr ""
 
 #: cmd/incus/admin_recover.go:28
 msgid ""
@@ -6592,7 +6661,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6631,14 +6700,14 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
@@ -6647,7 +6716,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -6656,25 +6725,25 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6683,21 +6752,21 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6710,7 +6779,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6719,11 +6788,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6731,12 +6800,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -6751,7 +6820,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rename instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6760,15 +6829,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6776,17 +6845,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
@@ -6830,7 +6899,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -6840,7 +6909,7 @@ msgstr "Копирование образа: %s"
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6853,12 +6922,12 @@ msgstr "Псевдонимы:"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
@@ -6868,13 +6937,17 @@ msgstr "Копирование образа: %s"
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
+msgstr ""
+
+#: cmd/incus/network_acl.go:887
+msgid "Rule description"
 msgstr ""
 
 #: cmd/incus/remote_unix.go:36
@@ -6915,7 +6988,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6943,9 +7016,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr "СОЗДАН"
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6961,7 +7034,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6969,11 +7042,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6981,11 +7054,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -7022,7 +7095,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -7040,7 +7113,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Копирование образа: %s"
@@ -7093,11 +7166,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7106,11 +7179,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7119,12 +7192,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7148,12 +7221,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7162,12 +7235,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7176,12 +7249,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7190,16 +7263,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7208,11 +7281,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7221,12 +7294,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7235,11 +7308,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7248,11 +7321,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7294,7 +7367,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Копирование образа: %s"
@@ -7303,11 +7376,11 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -7317,49 +7390,49 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -7388,7 +7461,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
@@ -7453,7 +7526,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7483,43 +7556,43 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7531,22 +7604,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7555,7 +7628,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7567,7 +7640,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -7581,15 +7654,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Копирование образа: %s"
@@ -7603,7 +7676,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7625,16 +7698,20 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7685,7 +7762,7 @@ msgstr ""
 msgid "State"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
@@ -7722,22 +7799,22 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr " Использование сети:"
@@ -7756,22 +7833,27 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+#, fuzzy
+msgid "Storage pool description"
+msgstr " Использование сети:"
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7781,12 +7863,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7799,7 +7881,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Копирование образа: %s"
@@ -7832,7 +7914,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7848,7 +7930,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7856,20 +7938,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7942,7 +8024,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7964,7 +8046,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7972,7 +8054,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Копирование образа: %s"
@@ -8000,7 +8082,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Копирование образа: %s"
@@ -8020,12 +8102,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Копирование образа: %s"
@@ -8035,7 +8117,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
@@ -8045,7 +8127,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Копирование образа: %s"
@@ -8055,37 +8137,37 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8136,12 +8218,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -8192,11 +8274,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -8212,7 +8294,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -8220,7 +8302,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -8236,7 +8318,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8266,7 +8348,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -8284,7 +8366,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Принять сертификат"
@@ -8295,18 +8377,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8318,7 +8400,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -8332,11 +8414,11 @@ msgstr "Копирование образа: %s"
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -8363,7 +8445,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -8374,17 +8456,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8400,7 +8482,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8410,7 +8492,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Копирование образа: %s"
@@ -8436,20 +8518,20 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
@@ -8459,58 +8541,58 @@ msgstr "Копирование образа: %s"
 msgid "Unset network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8519,7 +8601,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Копирование образа: %s"
@@ -8528,11 +8610,11 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -8542,50 +8624,50 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -8599,7 +8681,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8628,17 +8710,17 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 #, fuzzy
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8662,7 +8744,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8677,15 +8759,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8725,8 +8807,12 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+msgid "Volume description"
 msgstr ""
 
 #: cmd/incus/info.go:307
@@ -8878,9 +8964,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8909,7 +8995,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid "Zone description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:865
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -8926,12 +9016,12 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -8956,7 +9046,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr ""
@@ -8964,7 +9054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -8980,7 +9070,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -8989,7 +9079,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -8997,7 +9087,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -9005,7 +9095,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -9013,7 +9103,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -9021,7 +9111,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9029,7 +9119,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -9045,8 +9135,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -9054,7 +9144,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -9062,7 +9152,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9070,7 +9160,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9078,7 +9168,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9086,7 +9176,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -9094,7 +9184,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9102,8 +9192,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -9111,8 +9201,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -9120,7 +9210,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr ""
@@ -9128,7 +9218,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
@@ -9136,7 +9226,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -9184,7 +9274,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9275,7 +9365,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9416,8 +9506,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -9506,8 +9596,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
@@ -9517,7 +9607,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -9533,7 +9623,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -9541,7 +9631,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -9549,11 +9639,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -9561,7 +9651,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -9569,7 +9659,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -9579,9 +9669,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -9589,7 +9679,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -9597,7 +9687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -9607,13 +9697,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9621,7 +9711,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -9629,7 +9719,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -9645,7 +9735,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -9653,7 +9743,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -9663,7 +9753,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -9671,7 +9761,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -9679,7 +9769,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -9695,7 +9785,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -9711,8 +9801,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -9720,7 +9810,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -9728,7 +9818,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9736,8 +9826,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -9745,9 +9835,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -9755,7 +9845,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -9763,7 +9853,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -9771,7 +9861,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -9779,7 +9869,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -9787,7 +9877,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -9795,7 +9885,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -9803,7 +9893,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9811,7 +9901,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9819,7 +9909,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9835,7 +9925,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9843,7 +9933,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9851,7 +9941,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9859,7 +9949,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9867,7 +9957,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -9875,7 +9965,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9883,7 +9973,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9891,8 +9981,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9900,7 +9990,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9908,7 +9998,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9916,7 +10006,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9924,7 +10014,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9941,8 +10031,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -9974,7 +10064,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -9982,7 +10072,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -9998,7 +10088,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10014,8 +10104,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10023,7 +10113,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10031,7 +10121,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10039,7 +10129,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10063,7 +10153,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -10071,8 +10161,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -10080,7 +10170,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -10088,7 +10178,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -10096,7 +10186,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -10104,7 +10194,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -10164,11 +10254,11 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -10176,7 +10266,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -10226,7 +10316,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10268,7 +10358,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -10280,7 +10370,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -10415,7 +10505,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -10423,7 +10513,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -10435,7 +10525,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -10460,7 +10550,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -10469,7 +10559,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -10485,7 +10575,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -10493,7 +10583,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10519,7 +10609,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10539,13 +10629,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10554,7 +10644,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10582,7 +10672,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10592,31 +10682,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10626,27 +10716,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10656,7 +10746,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10666,7 +10756,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10676,7 +10766,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10686,7 +10776,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10696,7 +10786,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10706,7 +10796,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10720,7 +10810,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10730,7 +10820,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10740,7 +10830,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -10748,11 +10838,11 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
@@ -10765,7 +10855,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -10782,7 +10872,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -10790,7 +10880,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -10798,9 +10888,9 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "да"
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-17 00:47-0500\n"
+"POT-Creation-Date: 2024-12-17 02:23-0500\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -31,7 +31,7 @@ msgstr "  固件:"
 msgid "  Motherboard:"
 msgstr "  主板:"
 
-#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1222
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -53,7 +53,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:290
+#: cmd/incus/storage.go:297
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -83,7 +83,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:995
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:284
+#: cmd/incus/config_trust.go:287
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -119,7 +119,7 @@ msgstr ""
 "###\n"
 "### 注意这里展示的指纹不能被修改"
 
-#: cmd/incus/cluster_group.go:437
+#: cmd/incus/cluster_group.go:445
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -225,7 +225,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:624
+#: cmd/incus/network_acl.go:632
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: cmd/incus/network_forward.go:690
+#: cmd/incus/network_forward.go:697
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -332,7 +332,7 @@ msgstr ""
 "###\n"
 "### 注意这里展示的 name 不能被修改."
 
-#: cmd/incus/network_load_balancer.go:660
+#: cmd/incus/network_load_balancer.go:666
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -396,7 +396,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: cmd/incus/network_peer.go:719
+#: cmd/incus/network_peer.go:725
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -413,7 +413,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1328
+#: cmd/incus/network_zone.go:1344
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,7 +427,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:632
+#: cmd/incus/network_zone.go:640
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -441,7 +441,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:717
+#: cmd/incus/network.go:724
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -461,7 +461,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:518
+#: cmd/incus/profile.go:526
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -482,7 +482,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:321
+#: cmd/incus/project.go:327
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -585,7 +585,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:139 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:239
+#: cmd/incus/alias.go:149 cmd/incus/image.go:1119 cmd/incus/image_alias.go:244
 msgid "ALIAS"
 msgstr ""
 
@@ -712,11 +712,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1038
+#: cmd/incus/storage_bucket.go:1047
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1116
+#: cmd/incus/storage_bucket.go:1130
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -738,23 +738,23 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:812
+#: cmd/incus/cluster_group.go:820
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1513
+#: cmd/incus/network_zone.go:1529
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:892
+#: cmd/incus/network_load_balancer.go:899
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:898
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1530
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:811
+#: cmd/incus/cluster_group.go:819
 msgid "Add member to group"
 msgstr ""
 
@@ -790,11 +790,11 @@ msgstr ""
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:171
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:172
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -811,12 +811,12 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:919 cmd/incus/network_forward.go:920
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1081
+#: cmd/incus/network_load_balancer.go:1090
+#: cmd/incus/network_load_balancer.go:1091
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:875 cmd/incus/network_acl.go:876
+#: cmd/incus/network_acl.go:884 cmd/incus/network_acl.go:885
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -855,12 +855,12 @@ msgstr ""
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:182
+#: cmd/incus/storage_bucket.go:190
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:183
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -875,8 +875,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:162
-#: cmd/incus/image_alias.go:400
+#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
+#: cmd/incus/image_alias.go:405
 msgid "Alias name missing"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
+#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2562
 msgid "All projects"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:182
 msgid "Alternative certificate name"
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:381 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1014,7 +1014,11 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1320
+#: cmd/incus/network_load_balancer.go:903
+msgid "Backend description"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:1332
 msgid "Backend health:"
 msgstr ""
 
@@ -1023,22 +1027,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1462
+#: cmd/incus/storage_bucket.go:1476
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3046
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3113
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_volume.go:3123
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
 msgid "Backups:"
 msgstr ""
 
@@ -1047,22 +1051,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:386
-#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
-#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:416 cmd/incus/network_acl.go:455
+#: cmd/incus/network_forward.go:385 cmd/incus/network_load_balancer.go:388
+#: cmd/incus/network_peer.go:411 cmd/incus/network_zone.go:463
+#: cmd/incus/network_zone.go:1158 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:245 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:654
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
+#: cmd/incus/storage_volume.go:657
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1072,7 +1076,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:995
+#: cmd/incus/network.go:1002
 msgid "Bond:"
 msgstr ""
 
@@ -1085,8 +1089,12 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1008
+#: cmd/incus/network.go:1015
 msgid "Bridge:"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:106
+msgid "Bucket description"
 msgstr ""
 
 #: cmd/incus/info.go:365
@@ -1094,11 +1102,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:987
+#: cmd/incus/info.go:768 cmd/incus/network.go:994
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:988
+#: cmd/incus/info.go:769 cmd/incus/network.go:995
 msgid "Bytes sent"
 msgstr ""
 
@@ -1106,11 +1114,11 @@ msgstr ""
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:436
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1676
+#: cmd/incus/storage_volume.go:1683
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1200,7 +1208,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:803
+#: cmd/incus/cluster.go:249 cmd/incus/list.go:470 cmd/incus/profile.go:811
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1208,7 +1216,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1686
+#: cmd/incus/list.go:622 cmd/incus/storage_volume.go:1693
 #: cmd/incus/warning.go:226
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1242,7 +1250,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:350
+#: cmd/incus/create.go:357
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1261,7 +1269,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:945
+#: cmd/incus/network_acl.go:957
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1276,9 +1284,13 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:839
+#: cmd/incus/config_trust.go:842
 #, c-format
 msgid "Certificate add token for %s deleted"
+msgstr ""
+
+#: cmd/incus/config_trust.go:184
+msgid "Certificate description"
 msgstr ""
 
 #: cmd/incus/remote.go:237
@@ -1298,7 +1310,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1036
 msgid "Chassis"
 msgstr ""
 
@@ -1326,24 +1338,28 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:254
+#: cmd/incus/cluster_group.go:262
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:315
+#: cmd/incus/cluster_group.go:323
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:656
+#: cmd/incus/cluster_group.go:664
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:733
+#: cmd/incus/cluster_group.go:741
 #, c-format
 msgid "Cluster group %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/cluster_group.go:196
+msgid "Cluster group description"
 msgstr ""
 
 #: cmd/incus/cluster.go:1304
@@ -1356,57 +1372,57 @@ msgstr ""
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:869
+#: cmd/incus/cluster_group.go:877
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:858
+#: cmd/incus/cluster_group.go:866
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:676
+#: cmd/incus/cluster_group.go:684
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:62 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1572
-#: cmd/incus/network.go:1644 cmd/incus/network_forward.go:251
-#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
-#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
-#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
+#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
+#: cmd/incus/network.go:1486 cmd/incus/network.go:1579
+#: cmd/incus/network.go:1651 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:334 cmd/incus/network_forward.go:527
+#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:1007
 #: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:336
-#: cmd/incus/network_load_balancer.go:507
-#: cmd/incus/network_load_balancer.go:642
-#: cmd/incus/network_load_balancer.go:807
-#: cmd/incus/network_load_balancer.go:895
-#: cmd/incus/network_load_balancer.go:971
-#: cmd/incus/network_load_balancer.go:1084
-#: cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108
-#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
-#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
-#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
-#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
-#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
-#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
-#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
-#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
-#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
-#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
-#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
-#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
-#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
+#: cmd/incus/network_load_balancer.go:337
+#: cmd/incus/network_load_balancer.go:513
+#: cmd/incus/network_load_balancer.go:648
+#: cmd/incus/network_load_balancer.go:813
+#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1094
+#: cmd/incus/network_load_balancer.go:1170 cmd/incus/storage.go:110
+#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:839
+#: cmd/incus/storage.go:941 cmd/incus/storage.go:1034
+#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
+#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
+#: cmd/incus/storage_bucket.go:653 cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:911
+#: cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1150
+#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_bucket.go:1351
+#: cmd/incus/storage_bucket.go:1425 cmd/incus/storage_bucket.go:1574
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
+#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
+#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1880
+#: cmd/incus/storage_volume.go:1972 cmd/incus/storage_volume.go:2136
+#: cmd/incus/storage_volume.go:2236 cmd/incus/storage_volume.go:2343
+#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2723
+#: cmd/incus/storage_volume.go:2809 cmd/incus/storage_volume.go:2889
+#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:3147
 msgid "Cluster member name"
 msgstr ""
 
@@ -1415,17 +1431,17 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
-#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
-#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:206 cmd/incus/list.go:135 cmd/incus/network.go:1080
-#: cmd/incus/network.go:1281 cmd/incus/network_allocations.go:63
+#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
+#: cmd/incus/config_trust.go:613 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:211 cmd/incus/list.go:135 cmd/incus/network.go:1087
+#: cmd/incus/network.go:1288 cmd/incus/network_allocations.go:63
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
-#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:912
+#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2561
 #: cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
@@ -1453,7 +1469,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:54
+#: cmd/incus/copy.go:53 cmd/incus/create.go:55
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1461,7 +1477,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:112
+#: cmd/incus/project.go:113
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1473,16 +1489,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:464 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
-#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
+#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:722
+#: cmd/incus/network_forward.go:797 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:777 cmd/incus/network_peer.go:810
+#: cmd/incus/network_zone.go:718 cmd/incus/network_zone.go:1421
+#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
+#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1314
+#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1504,11 +1520,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:588
+#: cmd/incus/storage_volume.go:589
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1432
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1645,7 +1661,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1625
+#: cmd/incus/network_zone.go:1641
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1654,7 +1670,7 @@ msgstr ""
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:185 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1663,15 +1679,15 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:66
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:64
+#: cmd/incus/create.go:65
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1704,11 +1720,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/create.go:43
+#: cmd/incus/create.go:43 cmd/incus/create.go:44
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1026 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1035 cmd/incus/storage_bucket.go:1036
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1716,11 +1732,11 @@ msgstr ""
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:95 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1728,58 +1744,58 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:379 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:381 cmd/incus/network_acl.go:382
 msgid "Create new network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:323 cmd/incus/network_forward.go:324
+#: cmd/incus/network_forward.go:325 cmd/incus/network_forward.go:326
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:327
 #: cmd/incus/network_load_balancer.go:328
+#: cmd/incus/network_load_balancer.go:329
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:319 cmd/incus/network_peer.go:320
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:321
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1083 cmd/incus/network_zone.go:1084
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389 cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:391 cmd/incus/network_zone.go:392
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:336 cmd/incus/network.go:337
+#: cmd/incus/network.go:338 cmd/incus/network.go:339
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:356 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:104
+#: cmd/incus/project.go:104 cmd/incus/project.go:105
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:99 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:63
+#: cmd/incus/copy.go:63 cmd/incus/create.go:64
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1453
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:181
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1789,7 +1805,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:177
+#: cmd/incus/create.go:179
 msgid "Creating the instance"
 msgstr ""
 
@@ -1802,16 +1818,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:242 cmd/incus/list.go:576 cmd/incus/network.go:1106
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:507
+#: cmd/incus/config_trust.go:438 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:247 cmd/incus/list.go:576 cmd/incus/network.go:1113
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
-#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:152
-#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
-#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1675
+#: cmd/incus/network_zone.go:925 cmd/incus/operation.go:152
+#: cmd/incus/profile.go:755 cmd/incus/project.go:565 cmd/incus/storage.go:717
+#: cmd/incus/storage_bucket.go:523 cmd/incus/storage_bucket.go:924
+#: cmd/incus/storage_volume.go:1682
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1823,7 +1839,7 @@ msgstr ""
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:709
+#: cmd/incus/storage.go:716
 msgid "DRIVER"
 msgstr ""
 
@@ -1846,11 +1862,11 @@ msgstr ""
 msgid "Date: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1019
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
+#: cmd/incus/storage_bucket.go:1424 cmd/incus/storage_volume.go:2980
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1862,7 +1878,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:271 cmd/incus/cluster_group.go:272
+#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1870,7 +1886,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
+#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1878,7 +1894,7 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:130
+#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1898,15 +1914,15 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1132 cmd/incus/storage_bucket.go:1133
+#: cmd/incus/storage_bucket.go:1146 cmd/incus/storage_bucket.go:1147
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:803 cmd/incus/network_acl.go:804
+#: cmd/incus/network_acl.go:811 cmd/incus/network_acl.go:812
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:829 cmd/incus/network_forward.go:830
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1914,44 +1930,44 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:803
-#: cmd/incus/network_load_balancer.go:804
+#: cmd/incus/network_load_balancer.go:809
+#: cmd/incus/network_load_balancer.go:810
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:836 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:842 cmd/incus/network_peer.go:843
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1453 cmd/incus/network_zone.go:1454
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:742 cmd/incus/network_zone.go:743
+#: cmd/incus/network_zone.go:750 cmd/incus/network_zone.go:751
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:447 cmd/incus/network.go:448
+#: cmd/incus/network.go:454 cmd/incus/network.go:455
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:439 cmd/incus/profile.go:440
+#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:202 cmd/incus/project.go:203
+#: cmd/incus/project.go:208 cmd/incus/project.go:209
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
+#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:211 cmd/incus/storage.go:212
+#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2467 cmd/incus/storage_volume.go:2468
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1973,12 +1989,12 @@ msgstr ""
 #: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
 #: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
 #: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
-#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
-#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
-#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
-#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
-#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:617
+#: cmd/incus/cluster_group.go:702 cmd/incus/cluster_group.go:758
+#: cmd/incus/cluster_group.go:820 cmd/incus/cluster_group.go:896
+#: cmd/incus/cluster_group.go:971 cmd/incus/cluster_group.go:1053
 #: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
 #: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
 #: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
@@ -1993,11 +2009,11 @@ msgstr ""
 #: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
 #: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
 #: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
-#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:593
+#: cmd/incus/config_trust.go:746 cmd/incus/config_trust.go:792
+#: cmd/incus/config_trust.go:863 cmd/incus/console.go:38 cmd/incus/copy.go:41
+#: cmd/incus/create.go:44 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
 #: cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40
@@ -2005,31 +2021,31 @@ msgstr ""
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:66
-#: cmd/incus/image_alias.go:130 cmd/incus/image_alias.go:184
-#: cmd/incus/image_alias.go:368 cmd/incus/import.go:27 cmd/incus/info.go:36
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:373 cmd/incus/import.go:27 cmd/incus/info.go:36
 #: cmd/incus/launch.go:24 cmd/incus/list.go:51 cmd/incus/main.go:100
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1061 cmd/incus/network.go:1259
-#: cmd/incus/network.go:1413 cmd/incus/network.go:1473
-#: cmd/incus/network.go:1569 cmd/incus/network.go:1641
+#: cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513
+#: cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843
+#: cmd/incus/network.go:924 cmd/incus/network.go:1068 cmd/incus/network.go:1266
+#: cmd/incus/network.go:1420 cmd/incus/network.go:1480
+#: cmd/incus/network.go:1576 cmd/incus/network.go:1648
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
-#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
-#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
-#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
-#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
-#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:382
+#: cmd/incus/network_acl.go:485 cmd/incus/network_acl.go:573
+#: cmd/incus/network_acl.go:616 cmd/incus/network_acl.go:755
+#: cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:870
+#: cmd/incus/network_acl.go:885 cmd/incus/network_acl.go:1029
 #: cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
-#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
-#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
-#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
-#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
-#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:326 cmd/incus/network_forward.go:434
+#: cmd/incus/network_forward.go:519 cmd/incus/network_forward.go:629
+#: cmd/incus/network_forward.go:676 cmd/incus/network_forward.go:830
+#: cmd/incus/network_forward.go:905 cmd/incus/network_forward.go:920
+#: cmd/incus/network_forward.go:1003 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
 #: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
 #: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
@@ -2037,45 +2053,45 @@ msgstr ""
 #: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:252
-#: cmd/incus/network_load_balancer.go:328
-#: cmd/incus/network_load_balancer.go:431
-#: cmd/incus/network_load_balancer.go:499
-#: cmd/incus/network_load_balancer.go:609
-#: cmd/incus/network_load_balancer.go:639
-#: cmd/incus/network_load_balancer.go:804
-#: cmd/incus/network_load_balancer.go:877
-#: cmd/incus/network_load_balancer.go:892
-#: cmd/incus/network_load_balancer.go:968
-#: cmd/incus/network_load_balancer.go:1066
-#: cmd/incus/network_load_balancer.go:1081
-#: cmd/incus/network_load_balancer.go:1154
-#: cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:437
+#: cmd/incus/network_load_balancer.go:505
+#: cmd/incus/network_load_balancer.go:615
+#: cmd/incus/network_load_balancer.go:645
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:884
+#: cmd/incus/network_load_balancer.go:899
+#: cmd/incus/network_load_balancer.go:977
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1091
+#: cmd/incus/network_load_balancer.go:1166
+#: cmd/incus/network_load_balancer.go:1289 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
-#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
-#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
-#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_peer.go:321 cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:557 cmd/incus/network_peer.go:659
+#: cmd/incus/network_peer.go:706 cmd/incus/network_peer.go:843
 #: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
 #: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
-#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
-#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
-#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
-#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
-#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
-#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
-#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
-#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
-#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:30
+#: cmd/incus/network_zone.go:392 cmd/incus/network_zone.go:493
+#: cmd/incus/network_zone.go:581 cmd/incus/network_zone.go:624
+#: cmd/incus/network_zone.go:751 cmd/incus/network_zone.go:807
+#: cmd/incus/network_zone.go:864 cmd/incus/network_zone.go:942
+#: cmd/incus/network_zone.go:1006 cmd/incus/network_zone.go:1084
+#: cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1277
+#: cmd/incus/network_zone.go:1324 cmd/incus/network_zone.go:1454
+#: cmd/incus/network_zone.go:1515 cmd/incus/network_zone.go:1530
+#: cmd/incus/network_zone.go:1588 cmd/incus/operation.go:30
 #: cmd/incus/operation.go:63 cmd/incus/operation.go:114
 #: cmd/incus/operation.go:289 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
-#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
-#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
-#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
-#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
-#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
-#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
-#: cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:718 cmd/incus/profile.go:876 cmd/incus/profile.go:964
+#: cmd/incus/profile.go:1024 cmd/incus/profile.go:1113
+#: cmd/incus/profile.go:1177 cmd/incus/project.go:36 cmd/incus/project.go:105
+#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
+#: cmd/incus/project.go:518 cmd/incus/project.go:733 cmd/incus/project.go:798
+#: cmd/incus/project.go:886 cmd/incus/project.go:930 cmd/incus/project.go:991
+#: cmd/incus/project.go:1059 cmd/incus/project.go:1170 cmd/incus/publish.go:32
 #: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
 #: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
 #: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
@@ -2083,60 +2099,60 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
-#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
-#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
-#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
-#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
-#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
-#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
-#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
-#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
-#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
-#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
-#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:833
+#: cmd/incus/storage.go:937 cmd/incus/storage.go:1031
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:741
+#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:844
+#: cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:1036
+#: cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:1346 cmd/incus/storage_bucket.go:1418
+#: cmd/incus/storage_bucket.go:1569 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
-#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
-#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
-#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
-#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
-#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
-#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
-#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1784 cmd/incus/storage_volume.go:1877
+#: cmd/incus/storage_volume.go:1957 cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2283
+#: cmd/incus/storage_volume.go:2333 cmd/incus/storage_volume.go:2468
+#: cmd/incus/storage_volume.go:2557 cmd/incus/storage_volume.go:2563
+#: cmd/incus/storage_volume.go:2720 cmd/incus/storage_volume.go:2807
+#: cmd/incus/storage_volume.go:2887 cmd/incus/storage_volume.go:2974
+#: cmd/incus/storage_volume.go:3140 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:264
 #: cmd/incus/warning.go:305 cmd/incus/warning.go:359 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1419
+#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1789
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
+#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:505 cmd/incus/network.go:506
+#: cmd/incus/network.go:512 cmd/incus/network.go:513
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:602 cmd/incus/network.go:603
+#: cmd/incus/network.go:609 cmd/incus/network.go:610
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -2197,7 +2213,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:438
+#: cmd/incus/create.go:445
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2254,7 +2270,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:727
+#: cmd/incus/profile.go:735
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2262,7 +2278,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:501
+#: cmd/incus/storage_bucket.go:509
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2312,7 +2328,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:999
+#: cmd/incus/network.go:1006
 msgid "Down delay"
 msgstr ""
 
@@ -2341,7 +2357,7 @@ msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:918
+#: cmd/incus/network_zone.go:926
 msgid "ENTRIES"
 msgstr ""
 
@@ -2354,12 +2370,12 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:626
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2663
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:437
+#: cmd/incus/config_trust.go:440
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -2369,7 +2385,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2397,15 +2413,15 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:607 cmd/incus/network_acl.go:608
+#: cmd/incus/network_acl.go:615 cmd/incus/network_acl.go:616
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:699 cmd/incus/network.go:700
+#: cmd/incus/network.go:706 cmd/incus/network.go:707
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:668 cmd/incus/network_forward.go:669
+#: cmd/incus/network_forward.go:675 cmd/incus/network_forward.go:676
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2413,48 +2429,48 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:638
-#: cmd/incus/network_load_balancer.go:639
+#: cmd/incus/network_load_balancer.go:644
+#: cmd/incus/network_load_balancer.go:645
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:699 cmd/incus/network_peer.go:700
+#: cmd/incus/network_peer.go:705 cmd/incus/network_peer.go:706
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:623 cmd/incus/network_zone.go:624
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1307 cmd/incus/network_zone.go:1308
+#: cmd/incus/network_zone.go:1323 cmd/incus/network_zone.go:1324
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:497 cmd/incus/profile.go:498
+#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:300 cmd/incus/project.go:301
+#: cmd/incus/project.go:306 cmd/incus/project.go:307
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1196 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1210 cmd/incus/storage_bucket.go:1211
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:269 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:956
+#: cmd/incus/storage_volume.go:963
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:964
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2463,22 +2479,22 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
-#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
-#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:634 cmd/incus/network.go:1121
-#: cmd/incus/network.go:1315 cmd/incus/network_allocations.go:84
+#: cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:450
+#: cmd/incus/config_trust.go:634 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:634 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1322 cmd/incus/network_allocations.go:84
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:167
-#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
-#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
-#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/profile.go:771 cmd/incus/project.go:575 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:729
+#: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_volume.go:1710 cmd/incus/storage_volume.go:2671
 #: cmd/incus/top.go:90 cmd/incus/warning.go:237
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2512,7 +2528,7 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1516
+#: cmd/incus/network_zone.go:1532
 msgid "Entry TTL"
 msgstr ""
 
@@ -2520,7 +2536,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:58
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2544,15 +2560,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1547
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
-#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
-#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
-#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
-#: cmd/incus/storage_volume.go:2084
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1027
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1554
+#: cmd/incus/network_acl.go:548 cmd/incus/network_forward.go:602
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:588
+#: cmd/incus/network_peer.go:634 cmd/incus/network_zone.go:556
+#: cmd/incus/network_zone.go:1252 cmd/incus/profile.go:1091
+#: cmd/incus/project.go:861 cmd/incus/storage.go:903
+#: cmd/incus/storage_bucket.go:714 cmd/incus/storage_volume.go:2048
+#: cmd/incus/storage_volume.go:2091
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2567,14 +2583,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
-#: cmd/incus/network.go:1541 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
-#: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
-#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1021
+#: cmd/incus/network.go:1548 cmd/incus/network_acl.go:542
+#: cmd/incus/network_forward.go:596 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628
+#: cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1246
+#: cmd/incus/profile.go:1085 cmd/incus/project.go:855 cmd/incus/storage.go:897
+#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_volume.go:2042
+#: cmd/incus/storage_volume.go:2085
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2664,8 +2680,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1479
-#: cmd/incus/storage_volume.go:1529
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
+#: cmd/incus/storage_volume.go:1536
 msgid "Expires at"
 msgstr ""
 
@@ -2689,7 +2705,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2973 cmd/incus/storage_volume.go:2974
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2701,24 +2717,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1403
+#: cmd/incus/storage_bucket.go:1417
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1418
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_volume.go:2977
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1522
+#: cmd/incus/storage_bucket.go:1536
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3106
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2736,8 +2752,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:240
+#: cmd/incus/config_trust.go:437 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:245
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2819,7 +2835,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:439
+#: cmd/incus/network_peer.go:445
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2829,17 +2845,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:193
+#: cmd/incus/create.go:195
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:329
+#: cmd/incus/create.go:336
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:255
+#: cmd/incus/create.go:257
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2928,7 +2944,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1457
+#: cmd/incus/storage_bucket.go:1471
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2938,7 +2954,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3041
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2948,12 +2964,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1536
+#: cmd/incus/storage_bucket.go:1550
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3120
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3100,7 +3116,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1199 cmd/incus/network_acl.go:133
+#: cmd/incus/network.go:1206 cmd/incus/network_acl.go:133
 #: cmd/incus/network_zone.go:201 cmd/incus/operation.go:237
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3118,7 +3134,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:206
+#: cmd/incus/project.go:212
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3181,19 +3197,19 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
-#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
-#: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:205 cmd/incus/list.go:136 cmd/incus/network.go:1081
-#: cmd/incus/network.go:1280 cmd/incus/network_acl.go:97
+#: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:486
+#: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425
+#: cmd/incus/config_trust.go:612 cmd/incus/image.go:1094
+#: cmd/incus/image_alias.go:210 cmd/incus/list.go:136 cmd/incus/network.go:1088
+#: cmd/incus/network.go:1287 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
-#: cmd/incus/network_zone.go:859 cmd/incus/operation.go:137
-#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
-#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
-#: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
+#: cmd/incus/network_zone.go:867 cmd/incus/operation.go:137
+#: cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1062
+#: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:910
+#: cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2574
 #: cmd/incus/warning.go:95
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3210,7 +3226,7 @@ msgstr ""
 msgid "Format (table|compact)"
 msgstr ""
 
-#: cmd/incus/network.go:1011
+#: cmd/incus/network.go:1018
 msgid "Forward delay"
 msgstr ""
 
@@ -3259,15 +3275,15 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
+#: cmd/incus/project.go:1058 cmd/incus/project.go:1059
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1276
+#: cmd/incus/network_load_balancer.go:1288
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1277
+#: cmd/incus/network_load_balancer.go:1289
 msgid "Get current load-balacner status"
 msgstr ""
 
@@ -3275,11 +3291,11 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:916 cmd/incus/network.go:917
+#: cmd/incus/network.go:923 cmd/incus/network.go:924
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:890
+#: cmd/incus/cluster_group.go:898
 msgid "Get the key as a cluster group property"
 msgstr ""
 
@@ -3291,7 +3307,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:429
+#: cmd/incus/network_forward.go:436
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3299,15 +3315,15 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:434
+#: cmd/incus/network_load_balancer.go:440
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:469
+#: cmd/incus/network_peer.go:475
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:840
+#: cmd/incus/network.go:847
 msgid "Get the key as a network property"
 msgstr ""
 
@@ -3315,27 +3331,27 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1009
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:639
+#: cmd/incus/profile.go:647
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:441
+#: cmd/incus/project.go:447
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:398
+#: cmd/incus/storage_bucket.go:406
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:406
+#: cmd/incus/storage.go:413
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1196
+#: cmd/incus/storage_volume.go:1203
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3343,7 +3359,7 @@ msgstr ""
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:895
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
@@ -3363,11 +3379,11 @@ msgstr ""
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:835 cmd/incus/network.go:836
+#: cmd/incus/network.go:842 cmd/incus/network.go:843
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:426 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:434
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -3375,12 +3391,12 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:430
-#: cmd/incus/network_load_balancer.go:431
+#: cmd/incus/network_load_balancer.go:436
+#: cmd/incus/network_load_balancer.go:437
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:465 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:471 cmd/incus/network_peer.go:472
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3388,31 +3404,31 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1006
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:633 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:436 cmd/incus/project.go:437
+#: cmd/incus/project.go:442 cmd/incus/project.go:443
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
+#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:401 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1180
+#: cmd/incus/storage_volume.go:1187
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1181
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3433,7 +3449,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1300
+#: cmd/incus/network.go:1307
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3469,7 +3485,7 @@ msgstr ""
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1009 cmd/incus/operation.go:150
+#: cmd/incus/network.go:1016 cmd/incus/operation.go:150
 msgid "ID"
 msgstr ""
 
@@ -3483,7 +3499,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:559
 msgid "IMAGES"
 msgstr ""
 
@@ -3496,7 +3512,7 @@ msgstr ""
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1302
+#: cmd/incus/network.go:1309
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3504,27 +3520,27 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:978
+#: cmd/incus/network.go:985
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:571 cmd/incus/network.go:1104
+#: cmd/incus/list.go:571 cmd/incus/network.go:1111
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:572 cmd/incus/network.go:1105
+#: cmd/incus/list.go:572 cmd/incus/network.go:1112
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1035
+#: cmd/incus/network.go:1042
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1046
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:436
+#: cmd/incus/config_trust.go:439
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -3536,7 +3552,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2342
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3550,7 +3566,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2333
+#: cmd/incus/storage_volume.go:2341
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3560,6 +3576,10 @@ msgstr ""
 
 #: cmd/incus/action.go:166
 msgid "Ignore the instance state"
+msgstr ""
+
+#: cmd/incus/image_alias.go:71
+msgid "Image alias description"
 msgstr ""
 
 #: cmd/incus/image.go:1482
@@ -3604,15 +3624,15 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1555
+#: cmd/incus/storage_bucket.go:1569
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3139
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3130
+#: cmd/incus/storage_volume.go:3140
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3631,28 +3651,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1554
+#: cmd/incus/storage_bucket.go:1568
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3204
+#: cmd/incus/storage_volume.go:3214
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3139
+#: cmd/incus/storage_volume.go:3149
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3209
+#: cmd/incus/storage_volume.go:3219
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1610
+#: cmd/incus/storage_bucket.go:1624
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3213
+#: cmd/incus/storage_volume.go:3223
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3662,7 +3682,7 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:58
+#: cmd/incus/create.go:59
 msgid "Include environment variables from file"
 msgstr ""
 
@@ -3686,6 +3706,10 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
+#: cmd/incus/create.go:67
+msgid "Instance description"
+msgstr ""
+
 #: cmd/incus/file.go:1473
 msgid "Instance disconnected"
 msgstr ""
@@ -3699,7 +3723,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:448
+#: cmd/incus/create.go:455
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3718,7 +3742,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:61
+#: cmd/incus/create.go:62
 msgid "Instance type"
 msgstr ""
 
@@ -3726,8 +3750,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3064
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1504
+#: cmd/incus/storage_volume.go:3074
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3746,8 +3770,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1509
+#: cmd/incus/storage_volume.go:3079
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3757,7 +3781,7 @@ msgstr ""
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:543
+#: cmd/incus/config_trust.go:546
 msgid "Invalid certificate"
 msgstr ""
 
@@ -3835,7 +3859,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:555 cmd/incus/storage.go:134
+#: cmd/incus/main.go:555 cmd/incus/storage.go:138
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3844,7 +3868,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:354
+#: cmd/incus/network_peer.go:356
 msgid "Invalid peer type"
 msgstr ""
 
@@ -3853,9 +3877,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
-#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
-#: cmd/incus/storage_volume.go:2924
+#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
+#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2025
+#: cmd/incus/storage_volume.go:2934
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3899,6 +3923,10 @@ msgstr ""
 msgid "Kernel Version"
 msgstr ""
 
+#: cmd/incus/storage_bucket.go:1049
+msgid "Key description"
+msgstr ""
+
 #: cmd/incus/warning.go:213
 msgid "LAST SEEN"
 msgstr ""
@@ -3907,7 +3935,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1146
+#: cmd/incus/project.go:1152
 msgid "LIMIT"
 msgstr ""
 
@@ -3915,10 +3943,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/network.go:1304
+#: cmd/incus/list.go:618 cmd/incus/network.go:1311
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
-#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:222
+#: cmd/incus/operation.go:156 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_volume.go:1689 cmd/incus/warning.go:222
 msgid "LOCATION"
 msgstr ""
 
@@ -3936,12 +3964,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:175
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:171
+#: cmd/incus/create.go:173
 msgid "Launching the instance"
 msgstr ""
 
@@ -3955,11 +3983,11 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1258
+#: cmd/incus/network.go:1265
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1259
+#: cmd/incus/network.go:1266
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3987,11 +4015,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:589
+#: cmd/incus/config_trust.go:592
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:593
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4039,11 +4067,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:456
+#: cmd/incus/cluster_group.go:464
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:457
+#: cmd/incus/cluster_group.go:465
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4186,7 +4214,7 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:863 cmd/incus/network_zone.go:864
 msgid "List available network zone records"
 msgstr ""
 
@@ -4217,11 +4245,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1067
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1061
+#: cmd/incus/network.go:1068
 msgid ""
 "List available networks\n"
 "\n"
@@ -4242,11 +4270,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:664
+#: cmd/incus/storage.go:671
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:665
+#: cmd/incus/storage.go:672
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4301,11 +4329,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:188
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:184
+#: cmd/incus/image_alias.go:189
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4542,11 +4570,11 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1082
+#: cmd/incus/network.go:1089
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
@@ -4554,11 +4582,11 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:717
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:710
+#: cmd/incus/profile.go:718
 msgid ""
 "List profiles\n"
 "\n"
@@ -4574,11 +4602,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:511
+#: cmd/incus/project.go:517
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:512
+#: cmd/incus/project.go:518
 msgid ""
 "List projects\n"
 "\n"
@@ -4599,11 +4627,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:881
+#: cmd/incus/storage_bucket.go:889
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:883
+#: cmd/incus/storage_bucket.go:891
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4625,11 +4653,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:477
+#: cmd/incus/storage_bucket.go:485
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:487
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4652,11 +4680,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
+#: cmd/incus/storage_volume.go:2556 cmd/incus/storage_volume.go:2557
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2563
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4670,11 +4698,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1557
+#: cmd/incus/storage_volume.go:1564
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1569
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4723,11 +4751,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:399
+#: cmd/incus/config_trust.go:402
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:403
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4782,11 +4810,15 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
+#: cmd/incus/network_load_balancer.go:338
+msgid "Load balancer description"
+msgstr ""
+
 #: cmd/incus/info.go:494
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1435
+#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4799,7 +4831,7 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1038
 msgid "Logical router"
 msgstr ""
 
@@ -4820,15 +4852,15 @@ msgstr ""
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1021
+#: cmd/incus/network.go:1028
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1002
+#: cmd/incus/network.go:1009
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1301 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1308 cmd/incus/network_allocations.go:76
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4836,7 +4868,7 @@ msgstr ""
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:970
+#: cmd/incus/network.go:977
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -4846,11 +4878,11 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1103
+#: cmd/incus/network.go:1110
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:498
+#: cmd/incus/cluster_group.go:506
 msgid "MEMBERS"
 msgstr ""
 
@@ -4871,11 +4903,11 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1000
+#: cmd/incus/network.go:1007
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1001
+#: cmd/incus/network.go:1008
 msgid "MII state"
 msgstr ""
 
@@ -4883,7 +4915,7 @@ msgstr ""
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:971
+#: cmd/incus/network.go:978
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -4973,7 +5005,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:860 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:869 cmd/incus/network_acl.go:870
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4981,7 +5013,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:896 cmd/incus/network_forward.go:897
+#: cmd/incus/network_forward.go:904 cmd/incus/network_forward.go:905
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4993,13 +5025,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:884
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1065
-#: cmd/incus/network_load_balancer.go:1066
+#: cmd/incus/network_load_balancer.go:1075
+#: cmd/incus/network_load_balancer.go:1076
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -5011,11 +5043,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1498 cmd/incus/network_zone.go:1499
+#: cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1515
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:798 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:806 cmd/incus/network_zone.go:807
 msgid "Manage network zone records"
 msgstr ""
 
@@ -5031,11 +5063,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:835
+#: cmd/incus/storage_bucket.go:843
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:844
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -5051,7 +5083,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2282 cmd/incus/storage_volume.go:2283
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5156,27 +5188,27 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
-#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
-#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
-#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
-#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
-#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
+#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
+#: cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772
+#: cmd/incus/storage_bucket.go:981 cmd/incus/storage_bucket.go:1074
+#: cmd/incus/storage_bucket.go:1175 cmd/incus/storage_bucket.go:1254
+#: cmd/incus/storage_bucket.go:1377 cmd/incus/storage_bucket.go:1453
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:307 cmd/incus/config_trust.go:885
+#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:888
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
-#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
+#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:791
 msgid "Missing cluster group name"
 msgstr ""
 
 #: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
-#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:654
+#: cmd/incus/cluster_group.go:856 cmd/incus/cluster_role.go:82
 #: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
@@ -5185,30 +5217,30 @@ msgstr ""
 #: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
 #: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
 #: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:912 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
-#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
+#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
-#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
-#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
-#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
+#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
+#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
 #: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:361
-#: cmd/incus/network_load_balancer.go:459
-#: cmd/incus/network_load_balancer.go:544
-#: cmd/incus/network_load_balancer.go:712
-#: cmd/incus/network_load_balancer.go:844
-#: cmd/incus/network_load_balancer.go:932
-#: cmd/incus/network_load_balancer.go:1008
-#: cmd/incus/network_load_balancer.go:1121
-#: cmd/incus/network_load_balancer.go:1195
-#: cmd/incus/network_load_balancer.go:1305
+#: cmd/incus/network_load_balancer.go:363
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:550
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:850
+#: cmd/incus/network_load_balancer.go:940
+#: cmd/incus/network_load_balancer.go:1017
+#: cmd/incus/network_load_balancer.go:1132
+#: cmd/incus/network_load_balancer.go:1207
+#: cmd/incus/network_load_balancer.go:1317
 msgid "Missing listen address"
 msgstr ""
 
@@ -5220,10 +5252,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
-#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
-#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
-#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
-#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:419
+#: cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:674
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:842
+#: cmd/incus/network_acl.go:982 cmd/incus/network_acl.go:1069
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5234,83 +5266,83 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1367
-#: cmd/incus/network.go:1445 cmd/incus/network.go:1511
-#: cmd/incus/network.go:1603 cmd/incus/network_forward.go:204
-#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
-#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
-#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
-#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
+#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
+#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1374
+#: cmd/incus/network.go:1452 cmd/incus/network.go:1518
+#: cmd/incus/network.go:1610 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:356
+#: cmd/incus/network_forward.go:475 cmd/incus/network_forward.go:560
+#: cmd/incus/network_forward.go:735 cmd/incus/network_forward.go:866
+#: cmd/incus/network_forward.go:961 cmd/incus/network_forward.go:1044
 #: cmd/incus/network_load_balancer.go:207
 #: cmd/incus/network_load_balancer.go:288
-#: cmd/incus/network_load_balancer.go:357
-#: cmd/incus/network_load_balancer.go:455
-#: cmd/incus/network_load_balancer.go:540
-#: cmd/incus/network_load_balancer.go:708
-#: cmd/incus/network_load_balancer.go:840
-#: cmd/incus/network_load_balancer.go:928
-#: cmd/incus/network_load_balancer.go:1004
-#: cmd/incus/network_load_balancer.go:1117
-#: cmd/incus/network_load_balancer.go:1191
-#: cmd/incus/network_load_balancer.go:1301 cmd/incus/network_peer.go:205
-#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
-#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
-#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network_load_balancer.go:359
+#: cmd/incus/network_load_balancer.go:461
+#: cmd/incus/network_load_balancer.go:546
+#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:846
+#: cmd/incus/network_load_balancer.go:936
+#: cmd/incus/network_load_balancer.go:1013
+#: cmd/incus/network_load_balancer.go:1128
+#: cmd/incus/network_load_balancer.go:1203
+#: cmd/incus/network_load_balancer.go:1313 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:368
+#: cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:597
+#: cmd/incus/network_peer.go:756 cmd/incus/network_peer.go:877
 msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
-#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
-#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
-#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
-#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
-#: cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:429 cmd/incus/network_zone.go:529
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:781
+#: cmd/incus/network_zone.go:895 cmd/incus/network_zone.go:975
+#: cmd/incus/network_zone.go:1124 cmd/incus/network_zone.go:1225
+#: cmd/incus/network_zone.go:1487 cmd/incus/network_zone.go:1564
+#: cmd/incus/network_zone.go:1621
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1045 cmd/incus/network_zone.go:1373
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
-#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
-#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
+#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
+#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
-#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
-#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
-#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
-#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
-#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
-#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
-#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
-#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
-#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
-#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
-#: cmd/incus/storage_volume.go:2914
+#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
+#: cmd/incus/storage.go:525 cmd/incus/storage.go:871 cmd/incus/storage.go:977
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
+#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
+#: cmd/incus/storage_bucket.go:588 cmd/incus/storage_bucket.go:676
+#: cmd/incus/storage_bucket.go:768 cmd/incus/storage_bucket.go:977
+#: cmd/incus/storage_bucket.go:1070 cmd/incus/storage_bucket.go:1171
+#: cmd/incus/storage_bucket.go:1250 cmd/incus/storage_bucket.go:1373
+#: cmd/incus/storage_bucket.go:1448 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
+#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
+#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
+#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1616
+#: cmd/incus/storage_volume.go:1914 cmd/incus/storage_volume.go:2008
+#: cmd/incus/storage_volume.go:2170 cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2508 cmd/incus/storage_volume.go:2609
+#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2847
+#: cmd/incus/storage_volume.go:2924
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
-#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
-#: cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
+#: cmd/incus/profile.go:680 cmd/incus/profile.go:996 cmd/incus/profile.go:1064
+#: cmd/incus/profile.go:1145
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
-#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
-#: cmd/incus/project.go:956 cmd/incus/project.go:1087
+#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
+#: cmd/incus/project.go:480 cmd/incus/project.go:765 cmd/incus/project.go:834
+#: cmd/incus/project.go:962 cmd/incus/project.go:1093
 msgid "Missing project name"
 msgstr ""
 
@@ -5322,11 +5354,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1824
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1362
+#: cmd/incus/storage_volume.go:1369
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5334,11 +5366,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:374
+#: cmd/incus/network_peer.go:376
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:996
+#: cmd/incus/network.go:1003
 msgid "Mode"
 msgstr ""
 
@@ -5363,8 +5395,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
+#: cmd/incus/network.go:569 cmd/incus/network.go:666
+#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5377,7 +5409,7 @@ msgstr "将下载多个文件, 但目标不是目录"
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1783 cmd/incus/storage_volume.go:1784
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5405,7 +5437,7 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1783
+#: cmd/incus/storage_volume.go:1790
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5414,11 +5446,11 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1082 cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_forward.go:1092 cmd/incus/network_load_balancer.go:1251
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1108
+#: cmd/incus/network_acl.go:1124
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5431,15 +5463,15 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
-#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
-#: cmd/incus/config_trust.go:621 cmd/incus/list.go:584
-#: cmd/incus/network.go:1101 cmd/incus/network_acl.go:168
+#: cmd/incus/cluster_group.go:505 cmd/incus/config_trust.go:434
+#: cmd/incus/config_trust.go:624 cmd/incus/list.go:584
+#: cmd/incus/network.go:1108 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
-#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
-#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
-#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:924
+#: cmd/incus/profile.go:753 cmd/incus/project.go:558 cmd/incus/project.go:700
+#: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:715
+#: cmd/incus/storage_bucket.go:522 cmd/incus/storage_bucket.go:923
+#: cmd/incus/storage_volume.go:1681 cmd/incus/storage_volume.go:2661
 msgid "NAME"
 msgstr ""
 
@@ -5447,11 +5479,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:558
+#: cmd/incus/project.go:564
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:557
+#: cmd/incus/project.go:563
 msgid "NETWORKS"
 msgstr ""
 
@@ -5468,9 +5500,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1150 cmd/incus/operation.go:200
-#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
-#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
+#: cmd/incus/network.go:1157 cmd/incus/operation.go:200
+#: cmd/incus/project.go:596 cmd/incus/project.go:605 cmd/incus/project.go:614
+#: cmd/incus/project.go:623 cmd/incus/project.go:632 cmd/incus/project.go:641
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5494,8 +5526,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1477
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
+#: cmd/incus/storage_volume.go:1534
 msgid "Name"
 msgstr ""
 
@@ -5555,8 +5587,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:634 cmd/incus/network.go:976
+#: cmd/incus/storage_volume.go:1424
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5566,59 +5598,71 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:430
+#: cmd/incus/network.go:437
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:490
+#: cmd/incus/network.go:497
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:428
+#: cmd/incus/network.go:435
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1455
+#: cmd/incus/network.go:1462
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:459
+#: cmd/incus/network_acl.go:467
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:844
+#: cmd/incus/network_acl.go:852
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:787
+#: cmd/incus/network_acl.go:795
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:467
+#: cmd/incus/network_acl.go:388
+msgid "Network ACL description"
+msgstr ""
+
+#: cmd/incus/network_zone.go:475
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:783
+#: cmd/incus/network_zone.go:791
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:409
+#: cmd/incus/network.go:351
+msgid "Network description"
+msgstr ""
+
+#: cmd/incus/network_forward.go:416
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:880
+#: cmd/incus/network_forward.go:887
 #, c-format
 msgid "Network forward %s deleted"
+msgstr ""
+
+#: cmd/incus/network_forward.go:335
+msgid "Network forward description"
 msgstr ""
 
 #: cmd/incus/network_integration.go:160
@@ -5636,55 +5680,55 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:413
+#: cmd/incus/network_load_balancer.go:419
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:861
+#: cmd/incus/network_load_balancer.go:867
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:60
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:443
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:887
+#: cmd/incus/network_peer.go:893
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:447
+#: cmd/incus/network_peer.go:453
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:445
+#: cmd/incus/network_peer.go:451
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:348
+#: cmd/incus/network.go:350
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:986
+#: cmd/incus/info.go:786 cmd/incus/network.go:993
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1154
+#: cmd/incus/network_zone.go:1170
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1481
+#: cmd/incus/network_zone.go:1497
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5697,7 +5741,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:56 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5706,7 +5750,7 @@ msgstr ""
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:846
+#: cmd/incus/config_trust.go:849
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
@@ -5716,27 +5760,27 @@ msgstr ""
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:571 cmd/incus/network.go:668
+#: cmd/incus/network.go:578 cmd/incus/network.go:675
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
+#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1317
+#: cmd/incus/network_load_balancer.go:1329
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1039
+#: cmd/incus/network_load_balancer.go:1048
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1093 cmd/incus/network_load_balancer.go:1250
+#: cmd/incus/network_forward.go:1103 cmd/incus/network_load_balancer.go:1262
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:1135
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5744,11 +5788,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1833
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1844
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5788,7 +5832,7 @@ msgstr ""
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1035
 msgid "OVN:"
 msgstr ""
 
@@ -5796,11 +5840,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3018
+#: cmd/incus/storage_volume.go:3028
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2396
+#: cmd/incus/storage_volume.go:2406
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5812,11 +5856,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1387
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:778 cmd/incus/network.go:1526
+#: cmd/incus/network.go:785 cmd/incus/network.go:1533
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5838,7 +5882,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1531
+#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5884,19 +5928,19 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:587 cmd/incus/project.go:554
+#: cmd/incus/list.go:587 cmd/incus/project.go:560
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1100
+#: cmd/incus/image.go:1116 cmd/incus/list.go:578 cmd/incus/network.go:1107
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
-#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
+#: cmd/incus/profile.go:754 cmd/incus/storage_bucket.go:521
+#: cmd/incus/storage_volume.go:1700 cmd/incus/top.go:77
 #: cmd/incus/warning.go:214
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439
+#: cmd/incus/config_trust.go:442
 msgid "PROJECTS"
 msgstr ""
 
@@ -5908,11 +5952,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:989
+#: cmd/incus/info.go:770 cmd/incus/network.go:996
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:990
+#: cmd/incus/info.go:771 cmd/incus/network.go:997
 msgid "Packets sent"
 msgstr ""
 
@@ -5943,6 +5987,10 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
+#: cmd/incus/network_peer.go:335
+msgid "Peer description"
+msgstr ""
+
 #: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
@@ -5965,6 +6013,10 @@ msgstr ""
 
 #: cmd/incus/admin_recover.go:101
 msgid "Pool name cannot be empty"
+msgstr ""
+
+#: cmd/incus/network_forward.go:924 cmd/incus/network_load_balancer.go:1095
+msgid "Port description"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:816
@@ -6005,17 +6057,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:422
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:354 cmd/incus/image.go:465
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
-#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
-#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
+#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
+#: cmd/incus/network.go:810 cmd/incus/network_acl.go:723
+#: cmd/incus/network_forward.go:798 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:778 cmd/incus/network_peer.go:811
+#: cmd/incus/network_zone.go:719 cmd/incus/network_zone.go:1422
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1315
+#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6070,36 +6122,40 @@ msgstr ""
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:423
+#: cmd/incus/profile.go:431
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:482
+#: cmd/incus/profile.go:490
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:914
+#: cmd/incus/profile.go:922
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:939
+#: cmd/incus/profile.go:947
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:998
+#: cmd/incus/profile.go:1006
 #, c-format
 msgid "Profile %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/profile.go:369
+msgid "Profile description"
 msgstr ""
 
 #: cmd/incus/image.go:161
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:56
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6120,19 +6176,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:184
+#: cmd/incus/project.go:190
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:277
+#: cmd/incus/project.go:283
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:774
+#: cmd/incus/project.go:780
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: cmd/incus/project.go:114
+msgid "Project description"
 msgstr ""
 
 #: cmd/incus/remote.go:124
@@ -6152,7 +6212,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "协议: %s"
 
-#: cmd/incus/config_trust.go:224
+#: cmd/incus/config_trust.go:226
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "提供的证书路径不存在: %s"
@@ -6205,15 +6265,15 @@ msgstr "查询路径必须以 / 开头"
 msgid "Query virtual machine images"
 msgstr "查询虚拟机镜像"
 
-#: cmd/incus/project.go:1145
+#: cmd/incus/project.go:1151
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:438
+#: cmd/incus/config_trust.go:441
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:917
+#: cmd/incus/storage_bucket.go:925
 msgid "ROLE"
 msgstr ""
 
@@ -6234,6 +6294,10 @@ msgstr "重新初始化为空白实例"
 #: cmd/incus/rebuild.go:26
 msgid "Rebuild instances"
 msgstr "重新初始化实例"
+
+#: cmd/incus/network_zone.go:1092
+msgid "Record description"
+msgstr ""
 
 #: cmd/incus/admin_recover.go:28
 #, fuzzy
@@ -6282,7 +6346,7 @@ msgstr "正在刷新镜像: %s"
 msgid "Remote %s already exists"
 msgstr "远程 %s 已存在"
 
-#: cmd/incus/project.go:1019 cmd/incus/project.go:1185 cmd/incus/remote.go:927
+#: cmd/incus/project.go:1025 cmd/incus/project.go:1191 cmd/incus/remote.go:927
 #: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -6323,14 +6387,14 @@ msgstr "是否可移除: %v"
 msgid "Remove %s (yes/no): "
 msgstr "移除 %s (yes/no): "
 
-#: cmd/incus/project.go:223
+#: cmd/incus/project.go:229
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr "移除项目 %s 及其所有内容 (实例, 镜像, 存储卷, 网络, ...) (yes/no): "
 
-#: cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:617
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "将一个集群成员从集群组移除"
@@ -6339,7 +6403,7 @@ msgstr "将一个集群成员从集群组移除"
 msgid "Remove a member from the cluster"
 msgstr "将一个成员从集群移除"
 
-#: cmd/incus/network_zone.go:1571
+#: cmd/incus/network_zone.go:1587
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "移除一条网络区域记录条目"
@@ -6348,24 +6412,24 @@ msgstr "移除一条网络区域记录条目"
 msgid "Remove aliases"
 msgstr "移除别名"
 
-#: cmd/incus/network_forward.go:994 cmd/incus/network_load_balancer.go:1155
+#: cmd/incus/network_forward.go:1004 cmd/incus/network_load_balancer.go:1167
 msgid "Remove all ports that match"
 msgstr "移除所有匹配的端口"
 
-#: cmd/incus/network_acl.go:1014
+#: cmd/incus/network_acl.go:1030
 msgid "Remove all rules that match"
 msgstr "移除所有匹配的规则"
 
-#: cmd/incus/network_load_balancer.go:968
+#: cmd/incus/network_load_balancer.go:977
 msgid "Remove backend from a load balancer"
 msgstr "从负载均衡器中移除后端"
 
-#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:976
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "从负载均衡器中移除后端"
 
-#: cmd/incus/network_zone.go:1572
+#: cmd/incus/network_zone.go:1588
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6373,21 +6437,21 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "移除实例的设备"
 
-#: cmd/incus/cluster_group.go:608
+#: cmd/incus/cluster_group.go:616
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:992 cmd/incus/network_forward.go:993
+#: cmd/incus/network_forward.go:1002 cmd/incus/network_forward.go:1003
 msgid "Remove ports from a forward"
 msgstr "从转发中移除端口"
 
-#: cmd/incus/network_load_balancer.go:1153
-#: cmd/incus/network_load_balancer.go:1154
+#: cmd/incus/network_load_balancer.go:1165
+#: cmd/incus/network_load_balancer.go:1166
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "从负载均衡器中移除端口"
 
-#: cmd/incus/profile.go:867 cmd/incus/profile.go:868
+#: cmd/incus/profile.go:875 cmd/incus/profile.go:876
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6399,7 +6463,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1012 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_acl.go:1028 cmd/incus/network_acl.go:1029
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6408,11 +6472,11 @@ msgstr ""
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:742 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:745 cmd/incus/config_trust.go:746
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:693 cmd/incus/cluster_group.go:694
+#: cmd/incus/cluster_group.go:701 cmd/incus/cluster_group.go:702
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -6420,12 +6484,12 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:367
-#: cmd/incus/image_alias.go:368
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:169 cmd/incus/image_alias.go:372
+#: cmd/incus/image_alias.go:373
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1876 cmd/incus/storage_volume.go:1877
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6437,7 +6501,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:746 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:754 cmd/incus/network_acl.go:755
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6445,15 +6509,15 @@ msgstr ""
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1412 cmd/incus/network.go:1413
+#: cmd/incus/network.go:1419 cmd/incus/network.go:1420
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:955 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:963 cmd/incus/profile.go:964
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:726 cmd/incus/project.go:727
+#: cmd/incus/project.go:732 cmd/incus/project.go:733
 msgid "Rename projects"
 msgstr ""
 
@@ -6461,16 +6525,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2719 cmd/incus/storage_volume.go:2720
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1931
+#: cmd/incus/storage_volume.go:1938
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2781
+#: cmd/incus/storage_volume.go:2791
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6511,7 +6575,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2806 cmd/incus/storage_volume.go:2807
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6520,7 +6584,7 @@ msgstr ""
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:179
+#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
@@ -6532,12 +6596,12 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:395
+#: cmd/incus/create.go:402
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:788 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:791 cmd/incus/config_trust.go:792
 msgid "Revoke certificate add token"
 msgstr ""
 
@@ -6545,13 +6609,17 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1037
+#: cmd/incus/storage_bucket.go:1046
 msgid "Role (admin or read-only)"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
+msgstr ""
+
+#: cmd/incus/network_acl.go:887
+msgid "Rule description"
 msgstr ""
 
 #: cmd/incus/remote_unix.go:36
@@ -6591,7 +6659,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:711
+#: cmd/incus/storage.go:718
 msgid "SOURCE"
 msgstr ""
 
@@ -6618,9 +6686,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:589 cmd/incus/network.go:1108
+#: cmd/incus/list.go:589 cmd/incus/network.go:1115
 #: cmd/incus/network_peer.go:132 cmd/incus/operation.go:153
-#: cmd/incus/storage.go:713 cmd/incus/warning.go:216
+#: cmd/incus/storage.go:720 cmd/incus/warning.go:216
 msgid "STATE"
 msgstr ""
 
@@ -6636,7 +6704,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:556
+#: cmd/incus/project.go:562
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6644,11 +6712,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:555
+#: cmd/incus/project.go:561
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1010
+#: cmd/incus/network.go:1017
 msgid "STP"
 msgstr ""
 
@@ -6656,11 +6724,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1039
+#: cmd/incus/storage_bucket.go:1048
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1117
+#: cmd/incus/storage_bucket.go:1131
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6697,7 +6765,7 @@ msgid "Server doesn't trust us after authentication"
 msgstr ""
 
 #: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
-#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:571
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -6715,7 +6783,7 @@ msgstr ""
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:962
+#: cmd/incus/cluster_group.go:970
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
@@ -6766,11 +6834,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:476
+#: cmd/incus/network_acl.go:484
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:477
+#: cmd/incus/network_acl.go:485
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6779,11 +6847,11 @@ msgid ""
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network.go:1472
+#: cmd/incus/network.go:1479
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1473
+#: cmd/incus/network.go:1480
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6792,11 +6860,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:511
+#: cmd/incus/network_forward.go:518
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:512
+#: cmd/incus/network_forward.go:519
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6819,11 +6887,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:498
+#: cmd/incus/network_load_balancer.go:504
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:499
+#: cmd/incus/network_load_balancer.go:505
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6832,11 +6900,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:550
+#: cmd/incus/network_peer.go:556
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:551
+#: cmd/incus/network_peer.go:557
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6845,11 +6913,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:484
+#: cmd/incus/network_zone.go:492
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:493
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6858,15 +6926,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1171 cmd/incus/network_zone.go:1172
+#: cmd/incus/network_zone.go:1187 cmd/incus/network_zone.go:1188
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1015
+#: cmd/incus/profile.go:1023
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1024
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6875,11 +6943,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:791
+#: cmd/incus/project.go:797
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:792
+#: cmd/incus/project.go:798
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6888,11 +6956,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:646
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:639
+#: cmd/incus/storage_bucket.go:647
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6901,11 +6969,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:825
+#: cmd/incus/storage.go:832
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:826
+#: cmd/incus/storage.go:833
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6914,11 +6982,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1949
+#: cmd/incus/storage_volume.go:1956
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1950
+#: cmd/incus/storage_volume.go:1957
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6960,7 +7028,7 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:965
+#: cmd/incus/cluster_group.go:973
 msgid "Set the key as a cluster group property"
 msgstr ""
 
@@ -6968,11 +7036,11 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:483
+#: cmd/incus/network_acl.go:491
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:519
+#: cmd/incus/network_forward.go:526
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -6980,43 +7048,43 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:506
+#: cmd/incus/network_load_balancer.go:512
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:558
+#: cmd/incus/network_peer.go:564
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1480
+#: cmd/incus/network.go:1487
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:492
+#: cmd/incus/network_zone.go:500
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1177
+#: cmd/incus/network_zone.go:1193
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1023
+#: cmd/incus/profile.go:1031
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:799
+#: cmd/incus/project.go:805
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:646
+#: cmd/incus/storage_bucket.go:654
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:833
+#: cmd/incus/storage.go:840
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1966
+#: cmd/incus/storage_volume.go:1973
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7044,7 +7112,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:749 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:757 cmd/incus/cluster_group.go:758
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -7104,7 +7172,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: cmd/incus/network.go:1568 cmd/incus/network.go:1569
+#: cmd/incus/network.go:1575 cmd/incus/network.go:1576
 msgid "Show network configurations"
 msgstr ""
 
@@ -7129,39 +7197,39 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:933
+#: cmd/incus/network_zone.go:941
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:942
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1104 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1112 cmd/incus/profile.go:1113
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:923 cmd/incus/project.go:924
+#: cmd/incus/project.go:929 cmd/incus/project.go:930
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:741
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1331 cmd/incus/storage_bucket.go:1332
+#: cmd/incus/storage_bucket.go:1345 cmd/incus/storage_bucket.go:1346
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:929 cmd/incus/storage.go:930
+#: cmd/incus/storage.go:936 cmd/incus/storage.go:937
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2112
+#: cmd/incus/storage_volume.go:2119
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7173,19 +7241,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2877
+#: cmd/incus/storage_volume.go:2887
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2886
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1316
+#: cmd/incus/storage_volume.go:1323
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1324
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7194,7 +7262,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1163 cmd/incus/project.go:1164
+#: cmd/incus/project.go:1169 cmd/incus/project.go:1170
 msgid "Show the current project"
 msgstr ""
 
@@ -7206,7 +7274,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1055
+#: cmd/incus/info.go:46 cmd/incus/project.go:1061
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7218,15 +7286,15 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:933
+#: cmd/incus/storage.go:940
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:487
+#: cmd/incus/storage.go:494
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:859 cmd/incus/config_trust.go:860
+#: cmd/incus/config_trust.go:862 cmd/incus/config_trust.go:863
 msgid "Show trust configurations"
 msgstr ""
 
@@ -7238,7 +7306,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:483 cmd/incus/storage.go:484
+#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -7260,15 +7328,19 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
+#: cmd/incus/storage_volume.go:2344
+msgid "Snapshot description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2333
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2053
+#: cmd/incus/storage_volume.go:2060
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1456
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
 msgid "Snapshots:"
 msgstr ""
 
@@ -7318,7 +7390,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:972
+#: cmd/incus/network.go:979
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -7353,22 +7425,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:179
+#: cmd/incus/storage_bucket.go:187
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:246
+#: cmd/incus/storage_bucket.go:254
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1115
+#: cmd/incus/storage_bucket.go:1129
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1181
+#: cmd/incus/storage_bucket.go:1195
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7387,22 +7459,26 @@ msgstr ""
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:194
+#: cmd/incus/storage.go:201
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:254
+#: cmd/incus/storage.go:261
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:192
+#: cmd/incus/storage.go:199
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:60 cmd/incus/import.go:34
+#: cmd/incus/storage.go:111
+msgid "Storage pool description"
+msgstr ""
+
+#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7411,12 +7487,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:671
+#: cmd/incus/storage_volume.go:678
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:745
+#: cmd/incus/storage_volume.go:752
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7429,7 +7505,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2523
+#: cmd/incus/storage_volume.go:2533
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7460,7 +7536,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:984 cmd/incus/project.go:985
+#: cmd/incus/project.go:990 cmd/incus/project.go:991
 msgid "Switch the current project"
 msgstr ""
 
@@ -7476,7 +7552,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2662
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7484,20 +7560,20 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:622
+#: cmd/incus/cluster.go:1112 cmd/incus/config_trust.go:625
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:241 cmd/incus/list.go:590 cmd/incus/network.go:1102
-#: cmd/incus/network.go:1303 cmd/incus/network_allocations.go:74
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:246 cmd/incus/list.go:590 cmd/incus/network.go:1109
+#: cmd/incus/network.go:1310 cmd/incus/network_allocations.go:74
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1673
+#: cmd/incus/operation.go:151 cmd/incus/storage_volume.go:1680
 #: cmd/incus/warning.go:217
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
 msgid "Taken at"
 msgstr ""
 
@@ -7571,7 +7647,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1003 cmd/incus/network_acl.go:1141
+#: cmd/incus/network_acl.go:1019 cmd/incus/network_acl.go:1157
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7593,7 +7669,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:469
+#: cmd/incus/create.go:476
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7601,7 +7677,7 @@ msgstr ""
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:943
+#: cmd/incus/cluster_group.go:951
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
@@ -7629,7 +7705,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:934
+#: cmd/incus/cluster_group.go:942
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
@@ -7649,12 +7725,12 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:472
+#: cmd/incus/network_load_balancer.go:478
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:892
+#: cmd/incus/network.go:899
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
@@ -7664,7 +7740,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:485
+#: cmd/incus/network_forward.go:492
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7674,7 +7750,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:524
+#: cmd/incus/network_peer.go:530
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7684,37 +7760,37 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1049
+#: cmd/incus/network_zone.go:1057
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:685
+#: cmd/incus/profile.go:693
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:487
+#: cmd/incus/project.go:493
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:444
+#: cmd/incus/storage_bucket.go:452
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:458
+#: cmd/incus/storage.go:465
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1292
+#: cmd/incus/storage_volume.go:1299
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1264
+#: cmd/incus/storage_volume.go:1271
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7765,12 +7841,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
+#: cmd/incus/network.go:583 cmd/incus/network.go:680
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:580 cmd/incus/network.go:677
+#: cmd/incus/network.go:587 cmd/incus/network.go:684
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -7820,11 +7896,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:471
+#: cmd/incus/create.go:478
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:470
+#: cmd/incus/create.go:477
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7840,7 +7916,7 @@ msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
 #: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/network.go:964 cmd/incus/storage.go:531
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -7848,7 +7924,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1441
+#: cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7864,7 +7940,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1787
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7894,7 +7970,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:997
+#: cmd/incus/network.go:1004
 msgid "Transmit policy"
 msgstr ""
 
@@ -7912,7 +7988,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:183
 msgid "Type of certificate"
 msgstr ""
 
@@ -7922,18 +7998,18 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:333
+#: cmd/incus/network_peer.go:334
 msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:980
+#: cmd/incus/storage_volume.go:1433
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1117
+#: cmd/incus/project.go:1123
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7945,7 +8021,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
+#: cmd/incus/project.go:1153 cmd/incus/storage_volume.go:1685
 msgid "USAGE"
 msgstr ""
 
@@ -7957,11 +8033,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1107 cmd/incus/network_acl.go:170
+#: cmd/incus/network.go:1114 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:72 cmd/incus/network_integration.go:452
-#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1677
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:756
+#: cmd/incus/project.go:566 cmd/incus/storage.go:719
+#: cmd/incus/storage_volume.go:1684
 msgid "USED BY"
 msgstr ""
 
@@ -7987,7 +8063,7 @@ msgstr ""
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:198
+#: cmd/incus/config_trust.go:200
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
@@ -7998,17 +8074,17 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
-#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
-#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:257 cmd/incus/list.go:649 cmd/incus/network.go:1127
-#: cmd/incus/network.go:1321 cmd/incus/network_allocations.go:90
+#: cmd/incus/cluster_group.go:521 cmd/incus/config_trust.go:458
+#: cmd/incus/config_trust.go:640 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:262 cmd/incus/list.go:649 cmd/incus/network.go:1134
+#: cmd/incus/network.go:1328 cmd/incus/network_allocations.go:90
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
-#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
-#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/profile.go:777 cmd/incus/project.go:581 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:735
+#: cmd/incus/storage_bucket.go:546 cmd/incus/storage_bucket.go:939
+#: cmd/incus/storage_volume.go:1718 cmd/incus/storage_volume.go:2677
 #: cmd/incus/top.go:96 cmd/incus/warning.go:245
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8024,7 +8100,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:940 cmd/incus/network_acl.go:1075
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1091
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8034,7 +8110,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1044
+#: cmd/incus/cluster_group.go:1052
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
@@ -8058,19 +8134,19 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:564 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:572 cmd/incus/network_acl.go:573
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1640 cmd/incus/network.go:1641
+#: cmd/incus/network.go:1647 cmd/incus/network.go:1648
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:621
+#: cmd/incus/network_forward.go:628
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:629
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -8078,51 +8154,51 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:608
+#: cmd/incus/network_load_balancer.go:614
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:609
+#: cmd/incus/network_load_balancer.go:615
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:652
+#: cmd/incus/network_peer.go:658
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:659
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:572 cmd/incus/network_zone.go:573
+#: cmd/incus/network_zone.go:580 cmd/incus/network_zone.go:581
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1260 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1276 cmd/incus/network_zone.go:1277
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1176 cmd/incus/profile.go:1177
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:879 cmd/incus/project.go:880
+#: cmd/incus/project.go:885 cmd/incus/project.go:886
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:801 cmd/incus/storage_bucket.go:802
+#: cmd/incus/storage_bucket.go:809 cmd/incus/storage_bucket.go:810
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1023 cmd/incus/storage.go:1024
+#: cmd/incus/storage.go:1030 cmd/incus/storage.go:1031
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2217
+#: cmd/incus/storage_volume.go:2224
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2218
+#: cmd/incus/storage_volume.go:2225
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8131,7 +8207,7 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1047
+#: cmd/incus/cluster_group.go:1055
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
@@ -8139,11 +8215,11 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:568
+#: cmd/incus/network_acl.go:576
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:625
+#: cmd/incus/network_forward.go:632
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -8151,43 +8227,43 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:612
+#: cmd/incus/network_load_balancer.go:618
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:656
+#: cmd/incus/network_peer.go:662
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1645
+#: cmd/incus/network.go:1652
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:576
+#: cmd/incus/network_zone.go:584
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1264
+#: cmd/incus/network_zone.go:1280
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1173
+#: cmd/incus/profile.go:1181
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:884
+#: cmd/incus/project.go:890
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:805
+#: cmd/incus/storage_bucket.go:813
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1028
+#: cmd/incus/storage.go:1035
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2230
+#: cmd/incus/storage_volume.go:2237
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8200,7 +8276,7 @@ msgstr ""
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:998
+#: cmd/incus/network.go:1005
 msgid "Up delay"
 msgstr ""
 
@@ -8228,16 +8304,16 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1021
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2979
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8260,7 +8336,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:234
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8275,15 +8351,15 @@ msgstr ""
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1022
+#: cmd/incus/network.go:1029
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1020
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1020
+#: cmd/incus/network.go:1027
 msgid "VLAN:"
 msgstr ""
 
@@ -8323,8 +8399,12 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1530
+#: cmd/incus/storage_volume.go:1537
 msgid "Volume Only"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:590
+msgid "Volume description"
 msgstr ""
 
 #: cmd/incus/info.go:307
@@ -8474,9 +8554,9 @@ msgstr ""
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1147 cmd/incus/operation.go:203
-#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
-#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
+#: cmd/incus/network.go:1154 cmd/incus/operation.go:203
+#: cmd/incus/project.go:598 cmd/incus/project.go:607 cmd/incus/project.go:616
+#: cmd/incus/project.go:625 cmd/incus/project.go:634 cmd/incus/project.go:643
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8505,7 +8585,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:858
+#: cmd/incus/network_zone.go:400
+msgid "Zone description"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:865
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8514,12 +8598,12 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
-#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
-#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1058 cmd/incus/network_acl.go:91
+#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:591 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1065 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:111 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
+#: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
+#: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8532,11 +8616,11 @@ msgstr ""
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:169
+#: cmd/incus/config_trust.go:170
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:787
+#: cmd/incus/cluster.go:778 cmd/incus/config_trust.go:790
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -8544,32 +8628,32 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:181
+#: cmd/incus/image_alias.go:186
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
-#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:614 cmd/incus/network_acl.go:809
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:1011
+#: cmd/incus/network_acl.go:883 cmd/incus/network_acl.go:1027
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:563
+#: cmd/incus/network_acl.go:305 cmd/incus/network_acl.go:571
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:475
+#: cmd/incus/network_acl.go:483
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:744
+#: cmd/incus/network_acl.go:752
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:378
+#: cmd/incus/network_acl.go:380
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
@@ -8577,54 +8661,54 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
-#: cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:622
+#: cmd/incus/network_zone.go:748
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:571
+#: cmd/incus/network_zone.go:315 cmd/incus/network_zone.go:579
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:483
+#: cmd/incus/network_zone.go:491
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:390
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:127
+#: cmd/incus/image_alias.go:132
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:64
+#: cmd/incus/image_alias.go:66
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:365
+#: cmd/incus/image_alias.go:370
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
-#: cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:743
+#: cmd/incus/config_trust.go:861
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
-#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
+#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:756
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:886 cmd/incus/cluster_group.go:1043
+#: cmd/incus/cluster_group.go:894 cmd/incus/cluster_group.go:1051
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:961
+#: cmd/incus/cluster_group.go:969
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:691
+#: cmd/incus/cluster_group.go:699
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -8648,7 +8732,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/launch.go:22
+#: cmd/incus/create.go:42 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8695,7 +8779,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:866
+#: cmd/incus/profile.go:107 cmd/incus/profile.go:874
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
@@ -8768,8 +8852,8 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
-#: cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:615
+#: cmd/incus/cluster_group.go:818
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -8814,14 +8898,14 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1257 cmd/incus/network.go:1567
+#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
+#: cmd/incus/network.go:1264 cmd/incus/network.go:1574
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:504
+#: cmd/incus/network.go:511
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -8829,63 +8913,63 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:834 cmd/incus/network.go:1639
+#: cmd/incus/network.go:841 cmd/incus/network.go:1646
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1471
+#: cmd/incus/network.go:1478
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
-#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:250
-#: cmd/incus/network_load_balancer.go:637
-#: cmd/incus/network_load_balancer.go:801
-#: cmd/incus/network_load_balancer.go:1275
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:674
+#: cmd/incus/network_forward.go:827 cmd/incus/network_load_balancer.go:250
+#: cmd/incus/network_load_balancer.go:643
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:1287
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:966
+#: cmd/incus/network_load_balancer.go:975
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:890
+#: cmd/incus/network_load_balancer.go:897
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
-#: cmd/incus/network_load_balancer.go:429
-#: cmd/incus/network_load_balancer.go:607
+#: cmd/incus/network_forward.go:432 cmd/incus/network_forward.go:627
+#: cmd/incus/network_load_balancer.go:435
+#: cmd/incus/network_load_balancer.go:613
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:510 cmd/incus/network_load_balancer.go:497
+#: cmd/incus/network_forward.go:517 cmd/incus/network_load_balancer.go:503
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
+#: cmd/incus/network_load_balancer.go:1089
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:910
+#: cmd/incus/network_forward.go:918
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1152
+#: cmd/incus/network_forward.go:1001 cmd/incus/network_load_balancer.go:1164
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:322 cmd/incus/network_load_balancer.go:326
+#: cmd/incus/network_forward.go:324 cmd/incus/network_load_balancer.go:327
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1410
+#: cmd/incus/network.go:1417
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -8893,25 +8977,25 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:698 cmd/incus/network_peer.go:834
+#: cmd/incus/network_peer.go:704 cmd/incus/network_peer.go:840
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:318
+#: cmd/incus/network_peer.go:319
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
+#: cmd/incus/network_peer.go:470 cmd/incus/network_peer.go:657
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:549
+#: cmd/incus/network_peer.go:555
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:601
+#: cmd/incus/network.go:608
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
@@ -8919,7 +9003,7 @@ msgstr ""
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:335
+#: cmd/incus/network.go:337
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -8927,63 +9011,63 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
+#: cmd/incus/storage.go:935 cmd/incus/storage_bucket.go:483
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1553
+#: cmd/incus/storage_bucket.go:1567
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3138
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
-#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
+#: cmd/incus/storage_bucket.go:739 cmd/incus/storage_bucket.go:887
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
-#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
-#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:808
+#: cmd/incus/storage_bucket.go:1034 cmd/incus/storage_bucket.go:1145
+#: cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1344
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:645
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1402
+#: cmd/incus/storage_bucket.go:1416
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:94
+#: cmd/incus/storage_bucket.go:96
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:98
+#: cmd/incus/storage.go:100
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:400 cmd/incus/storage.go:1022
+#: cmd/incus/storage.go:407 cmd/incus/storage.go:1029
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:824
+#: cmd/incus/storage.go:831
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1868
+#: cmd/incus/storage_volume.go:1875
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2555
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:760
+#: cmd/incus/storage_volume.go:767
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8991,52 +9075,52 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708
+#: cmd/incus/storage_volume.go:2718
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
+#: cmd/incus/storage_volume.go:2465 cmd/incus/storage_volume.go:2805
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962
+#: cmd/incus/storage_volume.go:2972
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2323
+#: cmd/incus/storage_volume.go:2331
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:577
+#: cmd/incus/storage_volume.go:578
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2885
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555
+#: cmd/incus/storage_volume.go:1562
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
-#: cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:2118
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2216
+#: cmd/incus/storage_volume.go:2223
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1948
+#: cmd/incus/storage_volume.go:1955
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1179
+#: cmd/incus/storage_volume.go:1186
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1781
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -9045,8 +9129,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
-#: cmd/incus/profile.go:1103
+#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
+#: cmd/incus/profile.go:1111
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9062,11 +9146,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:632 cmd/incus/profile.go:1167
+#: cmd/incus/profile.go:640 cmd/incus/profile.go:1175
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1014
+#: cmd/incus/profile.go:1022
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9074,7 +9158,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:961
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
@@ -9082,20 +9166,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
-#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
+#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
+#: cmd/incus/project.go:928 cmd/incus/project.go:989 cmd/incus/project.go:1057
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:435 cmd/incus/project.go:878
+#: cmd/incus/project.go:441 cmd/incus/project.go:884
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:790
+#: cmd/incus/project.go:796
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:724
+#: cmd/incus/project.go:730
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -9107,28 +9191,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:853
+#: cmd/incus/network_zone.go:861
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:940 cmd/incus/network_zone.go:1322
+#: cmd/incus/network_zone.go:1451
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:1259
+#: cmd/incus/network_zone.go:1004 cmd/incus/network_zone.go:1275
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1170
+#: cmd/incus/network_zone.go:1186
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1512 cmd/incus/network_zone.go:1570
+#: cmd/incus/network_zone.go:1528 cmd/incus/network_zone.go:1586
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072
+#: cmd/incus/network_zone.go:1082
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -9160,11 +9244,11 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:696 cmd/incus/remote.go:794
+#: cmd/incus/project.go:702 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:550
+#: cmd/incus/storage.go:557
 msgid "description"
 msgstr ""
 
@@ -9172,7 +9256,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:549
+#: cmd/incus/storage.go:556
 msgid "driver"
 msgstr ""
 
@@ -9222,7 +9306,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:191
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9264,7 +9348,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:44
+#: cmd/incus/create.go:45
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
@@ -9276,7 +9360,7 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104
 msgid ""
 "incus create storage s1 dir\n"
 "\n"
@@ -9411,7 +9495,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:381
+#: cmd/incus/network_acl.go:383
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9419,7 +9503,7 @@ msgid ""
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:338
+#: cmd/incus/network.go:340
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9431,7 +9515,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:325
+#: cmd/incus/network_forward.go:327
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9456,7 +9540,7 @@ msgid ""
 "yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:329
+#: cmd/incus/network_load_balancer.go:330
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9465,7 +9549,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:321
+#: cmd/incus/network_peer.go:322
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9481,7 +9565,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:391
+#: cmd/incus/network_zone.go:393
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9489,7 +9573,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1075
+#: cmd/incus/network_zone.go:1085
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9515,7 +9599,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:359
+#: cmd/incus/profile.go:361
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9535,13 +9619,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:500
+#: cmd/incus/profile.go:508
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:106
+#: cmd/incus/project.go:107
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9550,7 +9634,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:303
+#: cmd/incus/project.go:309
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9578,7 +9662,7 @@ msgid ""
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97
+#: cmd/incus/storage_bucket.go:99
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9588,31 +9672,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:263
+#: cmd/incus/storage_bucket.go:271
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1198
+#: cmd/incus/storage_bucket.go:1212
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1406
+#: cmd/incus/storage_bucket.go:1420
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1557
+#: cmd/incus/storage_bucket.go:1571
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1028
+#: cmd/incus/storage_bucket.go:1037
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9622,27 +9706,27 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1333
+#: cmd/incus/storage_bucket.go:1347
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:734
+#: cmd/incus/storage_bucket.go:742
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:272
+#: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:581
+#: cmd/incus/storage_volume.go:582
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9652,7 +9736,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962
+#: cmd/incus/storage_volume.go:969
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9662,7 +9746,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1195
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9672,7 +9756,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3132
+#: cmd/incus/storage_volume.go:3142
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9682,7 +9766,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1322
+#: cmd/incus/storage_volume.go:1329
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9692,7 +9776,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1958
+#: cmd/incus/storage_volume.go:1965
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9702,7 +9786,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2120
+#: cmd/incus/storage_volume.go:2127
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9716,7 +9800,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2327
+#: cmd/incus/storage_volume.go:2335
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9726,7 +9810,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2223
+#: cmd/incus/storage_volume.go:2230
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9736,7 +9820,7 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:547
+#: cmd/incus/storage.go:554
 msgid "info"
 msgstr ""
 
@@ -9744,11 +9828,11 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:548
+#: cmd/incus/storage.go:555
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/config_trust.go:499 cmd/incus/image.go:971 cmd/incus/image.go:976
 #: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
@@ -9761,7 +9845,7 @@ msgstr ""
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:552
+#: cmd/incus/storage.go:559
 msgid "space used"
 msgstr ""
 
@@ -9778,7 +9862,7 @@ msgstr ""
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:551
+#: cmd/incus/storage.go:558
 msgid "total space"
 msgstr ""
 
@@ -9786,7 +9870,7 @@ msgstr ""
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:546
+#: cmd/incus/storage.go:553
 msgid "used by"
 msgstr ""
 
@@ -9794,9 +9878,9 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:496
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -34,6 +34,11 @@ test_basic_usage() {
   incus image alias list | grep -qv foo  # the old name is gone
   incus image alias delete bar
 
+  # Test an alias with description
+  incus image alias create baz "${sum}" --description "Test description"
+  incus image alias list | grep -q 'Test description'
+  incus image alias delete baz
+
   # Test image list output formats (table & json)
   incus image list --format table | grep -q testimage
   incus image list --format json \
@@ -373,7 +378,7 @@ test_basic_usage() {
   kill_incus "${INCUS_ACTIVATION_DIR}"
 
   # Create and start a container
-  incus launch testimage foo
+  incus launch testimage foo --description "Test container"
   incus list | grep foo | grep RUNNING
   incus stop foo --force
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3449,8 +3449,9 @@ test_clustering_groups() {
   ! incus cluster group remove cluster:node1 default || false
 
   # Create new cluster group which should be empty
-  incus cluster group create cluster:foobar
+  incus cluster group create cluster:foobar --description "Test description"
   [ "$(incus query cluster:/1.0/cluster/groups/foobar | jq '.members | length')" -eq 0 ]
+  [ "$(incus query cluster:/1.0/cluster/groups/foobar | jq '.description == "Test description"')" = "true" ]
 
   # Copy both description and members from default group
   incus cluster group show cluster:default | incus cluster group edit cluster:foobar

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -148,6 +148,11 @@ test_config_profiles() {
   incus profile remove foo one
   [ "$(incus list -f json foo | jq -r '.[0].profiles | join(" ")')" = "" ]
 
+  # check that we can create a profile with a description
+  incus profile create foo --description bar
+  incus profile ls | grep -q bar
+  incus profile delete foo
+
   incus profile create stdintest
   echo "BADCONF" | incus profile set stdintest user.user_data -
   incus profile show stdintest | grep BADCONF

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -49,8 +49,11 @@ test_network() {
   incus network delete inct$$
 
   # edit network description
-  incus network create inct$$
+  incus network create inct$$ --description "Test description"
+  incus network list | grep -q 'Test description'
+  incus network show inct$$ | grep -q 'description: Test description'
   incus network show inct$$ | sed 's/^description:.*/description: foo/' | incus network edit inct$$
+  incus network list | grep -q 'foo'
   incus network show inct$$ | grep -q 'description: foo'
   incus network delete inct$$
 

--- a/test/suites/network_acl.sh
+++ b/test/suites/network_acl.sh
@@ -17,6 +17,10 @@ test_network_acl() {
   ! incus network acl ls | grep testacl || false
   ! incus network acl ls --project testproj | grep testacl || false
   incus project delete testproj
+  incus network acl create testacl --description "Test description"
+  incus network acl list | grep -q -F 'Test description'
+  incus network acl show testacl | grep -q -F 'description: Test description'
+  incus network acl delete testacl
 
   # ACL creation from stdin.
   cat <<EOF | incus network acl create testacl
@@ -88,10 +92,11 @@ EOF
  ! incus network acl rule add testacl ingress action=allow protocol=icmp4 icmp_code=256 || false # Invalid icmp combination
  ! incus network acl rule add testacl ingress action=allow protocol=icmp6 icmp_type=-1 || false # Invalid icmp combination
 
- incus network acl rule add testacl ingress action=allow source=192.168.1.2/32 protocol=tcp destination=192.168.1.1-192.168.1.3 destination_port="22, 2222-2223"
- ! incus network acl rule add testacl ingress action=allow source=192.168.1.2/32 protocol=tcp destination=192.168.1.1-192.168.1.3 destination_port=22,2222-2223 || false # Dupe rule detection
+ incus network acl rule add testacl ingress action=allow source=192.168.1.2/32 protocol=tcp destination=192.168.1.1-192.168.1.3 destination_port="22, 2222-2223" --description "Test ACL rule description"
+ ! incus network acl rule add testacl ingress action=allow source=192.168.1.2/32 protocol=tcp destination=192.168.1.1-192.168.1.3 destination_port=22,2222-2223 --description "Test ACL rule description" || false # Dupe rule detection
  incus network acl show testacl | grep "destination: 192.168.1.1-192.168.1.3"
  incus network acl show testacl | grep -c2 'state: enabled' # Default state enabled for new rules.
+ incus network acl show testacl | grep "description: Test ACL rule description"
 
  # ACL rule removal.
  incus network acl rule add testacl ingress action=allow source=192.168.1.3/32 protocol=tcp destination=192.168.1.1-192.168.1.3 destination_port=22,2222-2223 description="removal rule test"

--- a/test/suites/network_forward.sh
+++ b/test/suites/network_forward.sh
@@ -16,7 +16,7 @@ test_network_forward() {
   ! incus network forward create "${netName}" :: || false
 
   # Check creating empty forward doesn't create any firewall rules.
-  incus network forward create "${netName}" 198.51.100.1
+  incus network forward create "${netName}" 198.51.100.1 --description "Test network forward"
   if [ "$firewallDriver" = "xtables" ]; then
     ! iptables -w -t nat -S | grep -c "generated for Incus network-forward ${netName}" || false
   else
@@ -24,6 +24,10 @@ test_network_forward() {
     ! nft -nn list chain inet incus "fwdout.${netName}" || false
     ! nft -nn list chain inet incus "fwdpstrt.${netName}" || false
   fi
+
+  # Check that description is set
+  incus network forward list "${netName}" | grep -q -F "Test network forward"
+  incus network forward show "${netName}" 198.51.100.1 | grep -q -F "description: Test network forward"
 
   # Check forward is exported via BGP prefixes.
   incus query /internal/testing/bgp | grep "198.51.100.1/32"
@@ -63,7 +67,7 @@ test_network_forward() {
   ! incus network forward port add "${netName}" 198.51.100.1 tcp 80 192.0.2.3 80-81 || false
 
   # Check can add a port with a listener range and no target port (so it uses same range for target ports).
-  incus network forward port add "${netName}" 198.51.100.1 tcp 80-81 192.0.2.3
+  incus network forward port add "${netName}" 198.51.100.1 tcp 80-81 192.0.2.3 --description "Test network forward port"
   if [ "$firewallDriver" = "xtables" ]; then
     iptables -w -t nat -S | grep -- "-A PREROUTING -d 198.51.100.1/32 -p tcp -m tcp --dport 80:81 -m comment --comment \"generated for Incus network-forward ${netName}\" -j DNAT --to-destination 192.0.2.3"
     iptables -w -t nat -S | grep -- "-A OUTPUT -d 198.51.100.1/32 -p tcp -m tcp --dport 80:81 -m comment --comment \"generated for Incus network-forward ${netName}\" -j DNAT --to-destination 192.0.2.3"
@@ -73,6 +77,9 @@ test_network_forward() {
     nft -nn list chain inet incus "fwdout.${netName}" | grep "ip daddr 198.51.100.1 tcp dport 80-81 dnat ip to 192.0.2.3"
     nft -nn list chain inet incus "fwdpstrt.${netName}" | grep "ip saddr 192.0.2.3 ip daddr 192.0.2.3 tcp dport 80-81 masquerade"
   fi
+
+  # Check that description is set
+  incus network forward show "${netName}" 198.51.100.1 | grep -q -F 'description: Test network forward port'
 
   # Check can't add port with duplicate listen port.
   ! incus network forward port add "${netName}" 198.51.100.1 tcp 80 192.0.2.3 90 || false

--- a/test/suites/network_zone.sh
+++ b/test/suites/network_zone.sh
@@ -18,9 +18,13 @@ test_network_zone() {
   ! incus network zone create /incus.example.net || false
   incus network zone create incus.example.net/withslash
   incus network zone delete incus.example.net/withslash
-  incus network zone create incus.example.net
+  incus network zone create incus.example.net --description "Test network zone"
   incus network zone create 2.0.192.in-addr.arpa
   incus network zone create 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa
+
+  # Check that the description is set
+  incus network zone list | grep -q -F 'Test network zone'
+  incus network zone show incus.example.net | grep -q -F 'description: Test network zone'
 
   # Create project and forward zone in project.
   incus project create foo \
@@ -117,7 +121,7 @@ test_network_zone() {
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr 0.1.0.1.2.4.2.4.2.4.2.4.2.4.d.f.ip6.arpa | grep "300\s\+IN\s\+PTR\s\+c2.incus-foo.example.net."
 
   # Test extra records
-  incus network zone record create incus.example.net demo user.foo=bar
+  incus network zone record create incus.example.net demo user.foo=bar --description "Test network zone record"
   ! incus network zone record create incus.example.net demo user.foo=bar || false
   incus network zone record entry add incus.example.net demo A 1.1.1.1 --ttl 900
   incus network zone record entry add incus.example.net demo A 2.2.2.2
@@ -128,6 +132,8 @@ test_network_zone() {
   incus network zone record list incus.example.net
   dig "@${DNS_ADDR}" -p "${DNS_PORT}" axfr incus.example.net | grep -Fc demo.incus.example.net | grep -Fx 6
   incus network zone record entry remove incus.example.net demo A 1.1.1.1
+  incus network zone record list incus.example.net | grep -q -F "Test network zone record"
+  incus network zone record show incus.example.net demo | grep -q -F "description: Test network zone record"
 
   incus admin sql global 'select * from networks_zones_records'
   incus network zone record create incus-foo.example.net demo user.foo=bar --project foo

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -60,9 +60,15 @@ test_projects_crud() {
 
   incus project switch default
 
+  # Create a project with a description
+  incus project create baz --description "Test description"
+  incus project list | grep -q -F 'Test description'
+  incus project show baz | grep -q -F 'description: Test description'
+
   # Delete the projects
   incus project delete foo
   incus project delete bar
+  incus project delete baz
 
   # We're back to the default project
   [ "$(incus project get-current)" = "default" ]

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -14,11 +14,14 @@ test_storage() {
   local storage_pool storage_volume
   storage_pool="incustest-$(basename "${INCUS_DIR}")-pool"
   storage_volume="${storage_pool}-vol"
-  incus storage create "$storage_pool" "$incus_backend"
-  incus storage show "$storage_pool" | sed 's/^description:.*/description: foo/' | incus storage edit "$storage_pool"
+  incus storage create "$storage_pool" "$incus_backend" --description foo
   incus storage show "$storage_pool" | grep -q 'description: foo'
+  incus storage show "$storage_pool" | sed 's/^description:.*/description: bar/' | incus storage edit "$storage_pool"
+  incus storage show "$storage_pool" | grep -q 'description: bar'
 
-  incus storage volume create "$storage_pool" "$storage_volume"
+  # Create a storage volume with a description
+  incus storage volume create "$storage_pool" "$storage_volume" --description foo
+  incus storage volume show "$storage_pool" "$storage_volume" | grep -q 'description: foo'
 
   # Test setting description on a storage volume
   incus storage volume show "$storage_pool" "$storage_volume" | sed 's/^description:.*/description: bar/' | incus storage volume edit "$storage_pool" "$storage_volume"

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -80,18 +80,19 @@ test_storage_buckets() {
   ! incus storage bucket create "${poolName}" "foo bar" || false
 
   # Create bucket.
-  initCreds=$(incus storage bucket create "${poolName}" "${bucketPrefix}.foo" user.foo=comment)
+  initCreds=$(incus storage bucket create "${poolName}" "${bucketPrefix}.foo" user.foo=comment --description "Test description")
   initAccessKey=$(echo "${initCreds}" | awk '{ if ($2 == "access" && $3 == "key:") {print $4}}')
   initSecretKey=$(echo "${initCreds}" | awk '{ if ($2 == "secret" && $3 == "key:") {print $4}}')
   s3cmdrun "${incus_backend}" "${initAccessKey}" "${initSecretKey}" ls | grep -F "${bucketPrefix}.foo"
 
   incus storage bucket list "${poolName}" | grep -F "${bucketPrefix}.foo"
+  incus storage bucket list "${poolName}" | grep -F "Test description"
   incus storage bucket show "${poolName}" "${bucketPrefix}.foo"
 
   # Create bucket keys.
 
   # Create admin key with randomly generated credentials.
-  creds=$(incus storage bucket key create "${poolName}" "${bucketPrefix}.foo" admin-key --role=admin)
+  creds=$(incus storage bucket key create "${poolName}" "${bucketPrefix}.foo" admin-key --role=admin --description "Test description")
   adAccessKey=$(echo "${creds}" | awk '{ if ($1 == "Access" && $2 == "key:") {print $3}}')
   adSecretKey=$(echo "${creds}" | awk '{ if ($1 == "Secret" && $2 == "key:") {print $3}}')
 
@@ -102,6 +103,7 @@ test_storage_buckets() {
 
   incus storage bucket key list "${poolName}" "${bucketPrefix}.foo" | grep -F "admin-key"
   incus storage bucket key list "${poolName}" "${bucketPrefix}.foo" | grep -F "ro-key"
+  incus storage bucket key list "${poolName}" "${bucketPrefix}.foo" | grep -F "Test description"
   incus storage bucket key show "${poolName}" "${bucketPrefix}.foo" admin-key
   incus storage bucket key show "${poolName}" "${bucketPrefix}.foo" ro-key
 


### PR DESCRIPTION
Adds a `--description` CLI flag to the following commands:

- `config trust add-certificate`
- `cluster group create`
- `create`
- `image alias create`
- `launch`
- `network create`
- `network acl create`
- `network acl rule add`
- `network forward create`
- `network forward port add`
- `network load-balancer create`
- `network load-balancer backend add`
- `network load-balancer port add`
- `network peer create`
- `network zone create`
- `network zone record add`
- `profile create`
- `project create`
- `storage create`
- `storage bucket create`
- `storage bucket key create`
- `storage volume create`
- `storage volume snapshot create`
- `snapshot create`

The flag allow users to set a description on the resources when they create them, instead of having to update the description after the creation.

For the `snapshot create` and `storage volume snapshot create` commands, some changes were made to the API and the `incusd` daemon, since the `description` field was not supported on the server side. Additionally, the new description field is shown in the output of `incus storage volume snapshot list`, `incus snapshot list` and `incus info`.

Closes #1485 