### PR TITLE
Add additional check to Cancel method for ConsoleShow operation

### DIFF
--- a/cmd/incusd/instance_console.go
+++ b/cmd/incusd/instance_console.go
@@ -398,10 +398,11 @@ func (s *consoleWs) Cancel(op *operations.Operation) error {
 	conn := s.conns[-1]
 	s.connsLock.Unlock()
 
-	err := conn.Close()
-	if err != nil {
-		return err
+	if conn == nil {
+		return nil
 	}
+
+	_ = conn.Close()
 
 	// Close all dynamic connections.
 	for conn, console := range s.dynamic {


### PR DESCRIPTION
During operation cancellation, the connection may already be closed, so we should check if it's not `nil`. Additionally, errors at this stage are not a concern, as we are making a best-effort attempt to close everything.