### PR TITLE
Refactor scriptlet loader and improve checks

### DIFF
--- a/internal/server/scriptlet/load/load.go
+++ b/internal/server/scriptlet/load/load.go
@@ -1,13 +1,9 @@
 package load
 
 import (
-	"fmt"
-	"slices"
-	"sort"
 	"sync"
 
 	"go.starlark.net/starlark"
-	"go.starlark.net/syntax"
 )
 
 // nameInstancePlacement is the name used in Starlark for the instance placement scriptlet.
@@ -19,123 +15,8 @@ const prefixQEMU = "qemu"
 // nameAuthorization is the name used in Starlark for the Authorization scriptlet.
 const nameAuthorization = "authorization"
 
-// compile compiles a scriptlet.
-func compile(programName string, src string, preDeclared []string) (*starlark.Program, error) {
-	isPreDeclared := func(name string) bool {
-		return slices.Contains(preDeclared, name)
-	}
-
-	// Parse, resolve, and compile a Starlark source file.
-	_, mod, err := starlark.SourceProgramOptions(syntax.LegacyFileOptions(), programName, src, isPreDeclared)
-	if err != nil {
-		return nil, err
-	}
-
-	return mod, nil
-}
-
-// validate validates a scriptlet by compiling it and checking the presence of required functions.
-func validate(compiler func(string, string) (*starlark.Program, error), programName string, src string, requiredFunctions map[string][]string) error {
-	prog, err := compiler(programName, src)
-	if err != nil {
-		return err
-	}
-
-	thread := &starlark.Thread{Name: programName}
-	globals, err := prog.Init(thread, nil)
-	if err != nil {
-		return err
-	}
-
-	globals.Freeze()
-
-	var notFound []string
-	for funName, requiredArgs := range requiredFunctions {
-		// The function is missing if its name is not found in the globals.
-		funv := globals[funName]
-		if funv == nil {
-			notFound = append(notFound, funName)
-			continue
-		}
-
-		// The function is missing if its name is not bound to a function.
-		fun, ok := funv.(*starlark.Function)
-		if !ok {
-			notFound = append(notFound, funName)
-		}
-
-		// Get the function arguments.
-		argc := fun.NumParams()
-		var args []string
-		for i := range argc {
-			arg, _ := fun.Param(i)
-			args = append(args, arg)
-		}
-
-		// Return an error early if the function does not have the right arguments.
-		match := len(args) == len(requiredArgs)
-		if match {
-			sort.Strings(args)
-			sort.Strings(requiredArgs)
-			for i := range args {
-				if args[i] != requiredArgs[i] {
-					match = false
-					break
-				}
-			}
-		}
-
-		if !match {
-			return fmt.Errorf("The function %q defines arguments %q (expected: %q)", funName, args, requiredArgs)
-		}
-	}
-
-	switch len(notFound) {
-	case 0:
-		return nil
-	case 1:
-		return fmt.Errorf("The function %q is required but has not been found in the scriptlet", notFound[0])
-	default:
-		return fmt.Errorf("The functions %q are required but have not been found in the scriptlet", notFound)
-	}
-}
-
 var programsMu sync.Mutex
 var programs = make(map[string]*starlark.Program)
-
-// set compiles a scriptlet into memory. If empty src is provided the current program is deleted.
-func set(compiler func(string, string) (*starlark.Program, error), programName string, src string) error {
-	if src == "" {
-		programsMu.Lock()
-		delete(programs, programName)
-		programsMu.Unlock()
-	} else {
-		prog, err := compiler(programName, src)
-		if err != nil {
-			return err
-		}
-
-		programsMu.Lock()
-		programs[programName] = prog
-		programsMu.Unlock()
-	}
-
-	return nil
-}
-
-// program returns a precompiled scriptlet program.
-func program(name string, programName string) (*starlark.Program, *starlark.Thread, error) {
-	programsMu.Lock()
-	prog, found := programs[programName]
-	programsMu.Unlock()
-	if !found {
-		return nil, nil, fmt.Errorf("%s scriptlet not loaded", name)
-	}
-
-	thread := &starlark.Thread{Name: programName}
-
-	return prog, thread, nil
-}
 
 // InstancePlacementCompile compiles the instance placement scriptlet.
 func InstancePlacementCompile(name string, src string) (*starlark.Program, error) {

--- a/internal/server/scriptlet/load/load.go
+++ b/internal/server/scriptlet/load/load.go
@@ -37,8 +37,8 @@ func InstancePlacementCompile(name string, src string) (*starlark.Program, error
 
 // InstancePlacementValidate validates the instance placement scriptlet.
 func InstancePlacementValidate(src string) error {
-	return validate(InstancePlacementCompile, nameInstancePlacement, src, map[string][]string{
-		"instance_placement": {"request", "candidate_members"},
+	return validate(InstancePlacementCompile, nameInstancePlacement, src, declaration{
+		required("instance_placement"): {"request", "candidate_members"},
 	})
 }
 
@@ -80,8 +80,8 @@ func QEMUCompile(name string, src string) (*starlark.Program, error) {
 
 // QEMUValidate validates the QEMU scriptlet.
 func QEMUValidate(src string) error {
-	return validate(QEMUCompile, prefixQEMU, src, map[string][]string{
-		"qemu_hook": {"hook_name"},
+	return validate(QEMUCompile, prefixQEMU, src, declaration{
+		required("qemu_hook"): {"hook_name"},
 	})
 }
 
@@ -107,8 +107,10 @@ func AuthorizationCompile(name string, src string) (*starlark.Program, error) {
 
 // AuthorizationValidate validates the authorization scriptlet.
 func AuthorizationValidate(src string) error {
-	return validate(AuthorizationCompile, nameAuthorization, src, map[string][]string{
-		"authorize": {"details", "object", "entitlement"},
+	return validate(AuthorizationCompile, nameAuthorization, src, declaration{
+		required("authorize"):           {"details", "object", "entitlement"},
+		optional("get_instance_access"): {"project_name", "instance_name"},
+		optional("get_project_access"):  {"project_name"},
 	})
 }
 

--- a/internal/server/scriptlet/load/utils.go
+++ b/internal/server/scriptlet/load/utils.go
@@ -1,0 +1,125 @@
+package load
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+// compile compiles a scriptlet.
+func compile(programName string, src string, preDeclared []string) (*starlark.Program, error) {
+	isPreDeclared := func(name string) bool {
+		return slices.Contains(preDeclared, name)
+	}
+
+	// Parse, resolve, and compile a Starlark source file.
+	_, mod, err := starlark.SourceProgramOptions(syntax.LegacyFileOptions(), programName, src, isPreDeclared)
+	if err != nil {
+		return nil, err
+	}
+
+	return mod, nil
+}
+
+// validate validates a scriptlet by compiling it and checking the presence of required functions.
+func validate(compiler func(string, string) (*starlark.Program, error), programName string, src string, requiredFunctions map[string][]string) error {
+	prog, err := compiler(programName, src)
+	if err != nil {
+		return err
+	}
+
+	thread := &starlark.Thread{Name: programName}
+	globals, err := prog.Init(thread, nil)
+	if err != nil {
+		return err
+	}
+
+	globals.Freeze()
+
+	var notFound []string
+	for funName, requiredArgs := range requiredFunctions {
+		// The function is missing if its name is not found in the globals.
+		funv := globals[funName]
+		if funv == nil {
+			notFound = append(notFound, funName)
+			continue
+		}
+
+		// The function is missing if its name is not bound to a function.
+		fun, ok := funv.(*starlark.Function)
+		if !ok {
+			notFound = append(notFound, funName)
+		}
+
+		// Get the function arguments.
+		argc := fun.NumParams()
+		var args []string
+		for i := range argc {
+			arg, _ := fun.Param(i)
+			args = append(args, arg)
+		}
+
+		// Return an error early if the function does not have the right arguments.
+		match := len(args) == len(requiredArgs)
+		if match {
+			sort.Strings(args)
+			sort.Strings(requiredArgs)
+			for i := range args {
+				if args[i] != requiredArgs[i] {
+					match = false
+					break
+				}
+			}
+		}
+
+		if !match {
+			return fmt.Errorf("The function %q defines arguments %q (expected: %q)", funName, args, requiredArgs)
+		}
+	}
+
+	switch len(notFound) {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("The function %q is required but has not been found in the scriptlet", notFound[0])
+	default:
+		return fmt.Errorf("The functions %q are required but have not been found in the scriptlet", notFound)
+	}
+}
+
+// set compiles a scriptlet into memory. If empty src is provided the current program is deleted.
+func set(compiler func(string, string) (*starlark.Program, error), programName string, src string) error {
+	if src == "" {
+		programsMu.Lock()
+		delete(programs, programName)
+		programsMu.Unlock()
+	} else {
+		prog, err := compiler(programName, src)
+		if err != nil {
+			return err
+		}
+
+		programsMu.Lock()
+		programs[programName] = prog
+		programsMu.Unlock()
+	}
+
+	return nil
+}
+
+// program returns a precompiled scriptlet program.
+func program(name string, programName string) (*starlark.Program, *starlark.Thread, error) {
+	programsMu.Lock()
+	prog, found := programs[programName]
+	programsMu.Unlock()
+	if !found {
+		return nil, nil, fmt.Errorf("%s scriptlet not loaded", name)
+	}
+
+	thread := &starlark.Thread{Name: programName}
+
+	return prog, thread, nil
+}


### PR DESCRIPTION
The error generation function is pretty heavy, but I think the error messages are way nicer this way.

```
root@test-incus:~# incus config set authorization.scriptlet - <<EOF
def get_project_access(project):
  return ['ben']

get_instance_access = 3
EOF
Error: cannot set 'authorization.scriptlet' to 'def get_project_access(project):
  return ['ben']

get_instance_access = 3
': the function "authorize" is required but has not been found in the scriptlet; additionally, "get_instance_access" should define the scriptlet’s optional function of the same name (found a value of type int instead); finally, the optional function "get_project_access" defines arguments ["project"] (expected ["project_name"])
```