### PR TITLE
incusd/storage/drivers: Force blkdiscard and ignore errors

### DIFF
--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -966,12 +966,9 @@ func clearDiskData(diskPath string, disk *os.File) error {
 	}
 
 	if linux.IsBlockdev(st.Mode()) {
-		// If dealing with a block device, discard its current content.
+		// If dealing with a block device, attempt to discard its current content.
 		// This saves space and avoids issues with leaving zero blocks to their original value.
-		_, err = subprocess.RunCommand("blkdiscard", diskPath)
-		if err != nil {
-			return err
-		}
+		_, _ = subprocess.RunCommand("blkdiscard", "-f", diskPath)
 	} else {
 		// Otherwise truncate the file.
 		err = disk.Truncate(0)


### PR DESCRIPTION
There can be partitions or other artifacts from snapshots which would normally trip blkdiscard. This is fine in our case and it should proceed regardless.

Also not all devices support discard, so treat it as non-fatal.