### PR TITLE
client: allow mDNS resolution when activating console

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -452,10 +451,10 @@ func (r *ProtocolIncus) rawWebsocket(url string) (*websocket.Conn, error) {
 
 	// Setup a new websocket dialer based on it
 	dialer := websocket.Dialer{
-		NetDialContext:   httpTransport.DialContext,
-		TLSClientConfig:  httpTransport.TLSClientConfig,
-		Proxy:            httpTransport.Proxy,
-		HandshakeTimeout: time.Second * 5,
+		NetDialTLSContext: httpTransport.DialTLSContext,
+		NetDialContext:    httpTransport.DialContext,
+		TLSClientConfig:   httpTransport.TLSClientConfig,
+		Proxy:             httpTransport.Proxy,
 	}
 
 	// Create temporary http.Request using the http url, not the ws one, so that we can add the client headers


### PR DESCRIPTION
Amends the WebSocket setup code to pass in any existing TLS dialling context, so the Dialer set up on Incus side, alongside with any custom TLS handling logic, including implicit mDNS support by resolving names at the OS level, works consistently

As discussed within #1514

Tested on macOS client vs remote Incus installation over TLS