### PR TITLE
Expand block reset logic

### DIFF
--- a/internal/linux/discard.go
+++ b/internal/linux/discard.go
@@ -1,0 +1,222 @@
+package linux
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/lxc/incus/v6/shared/subprocess"
+)
+
+// ClearBlock fully resets a block device or disk file using the most efficient mechanism available.
+// For files, it will truncate them down to zero and back to their original size.
+// For blocks, it will attempt a variety of discard options, validating the result with marker files and eventually fallback to full zero-ing.
+func ClearBlock(blockPath string) error {
+	// Open the block device for checking.
+	fd, err := os.OpenFile(blockPath, os.O_RDWR, 0644)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// If the file is missing, there is nothing to clear.
+			return nil
+		}
+
+		return err
+	}
+
+	defer fd.Close()
+
+	// Get the size of the file/block.
+	size, err := fd.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+
+	// Get all the stat data.
+	st, err := fd.Stat()
+	if err != nil {
+		return err
+	}
+
+	if !IsBlockdev(st.Mode()) {
+		// For files, truncate them.
+		err := fd.Truncate(0)
+		if err != nil {
+			return err
+		}
+
+		err = fd.Truncate(size)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Blocks are trickier to reset with options varying based on disk features.
+	// We use a set of 3 markers to validate whether it was reset.
+	marker := []byte("INCUS")
+	markerOffsetStart := int64(0)
+	markerOffsetMiddle := size / 2
+	markerOffsetEnd := size - 10
+
+	writeMarkers := func(fd *os.File) error {
+		for _, offset := range []int64{markerOffsetStart, markerOffsetMiddle, markerOffsetEnd} {
+			// Write the marker at the set offset.
+			n, err := fd.WriteAt(marker, offset)
+			if err != nil {
+				return err
+			}
+
+			if n != len(marker) {
+				return fmt.Errorf("Only managed to write %d bytes out of %d of the %d offset marker", n, len(marker), offset)
+			}
+		}
+
+		return nil
+	}
+
+	checkMarkers := func(fd *os.File) (int, error) {
+		found := 0
+
+		for _, offset := range []int64{markerOffsetStart, markerOffsetMiddle, markerOffsetEnd} {
+			fmt.Printf("offset=%d\n", offset)
+			buf := make([]byte, 5)
+
+			// Read the marker from the offset.
+			n, err := fd.ReadAt(buf, offset)
+			if err != nil {
+				return found, err
+			}
+
+			if n != len(marker) {
+				return found, fmt.Errorf("Only managed to read %d bytes out of %d of the %d offset marker", n, len(marker), offset)
+			}
+
+			// Check if we found it.
+			if string(buf) == string(marker) {
+				found++
+			}
+		}
+
+		return found, nil
+	}
+
+	// Write and check an initial set of markers.
+	err = writeMarkers(fd)
+	if err != nil {
+		return err
+	}
+
+	found, err := checkMarkers(fd)
+	if err != nil {
+		return err
+	}
+
+	if found != 3 {
+		return fmt.Errorf("Some of our initial markers weren't written properly")
+	}
+
+	// Start clearing the block.
+	_ = fd.Close()
+
+	// Attempt a secure discard run.
+	_, err = subprocess.RunCommand("blkdiscard", "-f", "-s", blockPath)
+	if err == nil {
+		// Check if the markers are gone.
+		fd, err := os.Open(blockPath)
+		if err != nil {
+			return err
+		}
+
+		defer fd.Close()
+
+		found, err = checkMarkers(fd)
+		if err != nil {
+			return err
+		}
+
+		if found == 0 {
+			// All markers are gone, secure discard succeeded.
+			return nil
+		}
+
+		// Some markers were found, go to the next clearing option.
+		_ = fd.Close()
+	}
+
+	// Attempt a regular discard run.
+	_, err = subprocess.RunCommand("blkdiscard", "-f", blockPath)
+	if err == nil {
+		// Check if the markers are gone.
+		fd, err := os.Open(blockPath)
+		if err != nil {
+			return err
+		}
+
+		defer fd.Close()
+
+		found, err = checkMarkers(fd)
+		if err != nil {
+			return err
+		}
+
+		if found == 0 {
+			// All markers are gone, regular discard succeeded.
+			return nil
+		}
+
+		// Some markers were found, go to the next clearing option.
+		_ = fd.Close()
+	}
+
+	// Attempt device zero-ing.
+	_, err = subprocess.RunCommand("blkdiscard", "-f", "-z", blockPath)
+	if err == nil {
+		// Check if the markers are gone.
+		fd, err := os.Open(blockPath)
+		if err != nil {
+			return err
+		}
+
+		defer fd.Close()
+
+		found, err = checkMarkers(fd)
+		if err != nil {
+			return err
+		}
+
+		if found == 0 {
+			// All markers are gone, device zero-ing succeeded.
+			return nil
+		}
+
+		// Some markers were found, go to the next clearing option.
+		_ = fd.Close()
+	}
+
+	// All fast discard attempts have failed, proceed with manual zero-ing.
+	zero, err := os.Open("/dev/zero")
+	if err != nil {
+		return err
+	}
+
+	defer zero.Close()
+
+	fd, err = os.OpenFile(blockPath, os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	defer fd.Close()
+
+	n, err := io.CopyN(fd, zero, size)
+	if err != nil {
+		return err
+	}
+
+	if n != size {
+		return fmt.Errorf("Only managed to reset %d bytes out of %d", n, size)
+	}
+
+	return nil
+}

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -957,38 +957,3 @@ func roundAbove(above, val int64) int64 {
 
 	return rounded
 }
-
-// clearDiskData resets a disk file or device to a zero value.
-func clearDiskData(diskPath string, disk *os.File) error {
-	st, err := disk.Stat()
-	if err != nil {
-		return err
-	}
-
-	if linux.IsBlockdev(st.Mode()) {
-		// If dealing with a block device, attempt to discard its current content.
-		// This saves space and avoids issues with leaving zero blocks to their original value.
-		_, err = subprocess.RunCommand("blkdiscard", "-f", diskPath)
-		if err != nil {
-			logger.Debugf("Unable to clear disk data on %q: %v", diskPath, err)
-		}
-	} else {
-		// Otherwise truncate the file.
-		err = disk.Truncate(0)
-		if err != nil {
-			return err
-		}
-
-		err = disk.Truncate(st.Size())
-		if err != nil {
-			return err
-		}
-
-		_, err = disk.Seek(0, 0)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
In Incus 6.8 (and 6.0.3), we started performing block discarding prior to writing the initial volume data. This is primarily useful on thick LVM volumes and in some other situations where an existing volume is being reset (some snapshot operations, volume refreshes, ...) in order to avoid prior data from showing up in the resulting volume.

It's particularly problematic on thick LVM as someone unaware of LVM's design may find themselves getting access to deleted data from another instance, effectively causing a data leakage. That's part of LVM's design for thick volumes as they are just an offset on the underlying PVs and not something unique to Incus, but still something that may catch some users off guard.

Our initial implementation of the reset logic works perfectly for file backed storage and appears to work as expected on the majority of storage options tested.

However we've had reports of some environments, primarily multi-device VGs or devices with broken block discard support where the current approach is insufficient.

With this PR, we end up with a much more thorough implementation of block device resetting as we now:
 - Reset file storage the same way we used to
 - Write marker files throughout the device to confirm proper reset
 - Issue a secure discard request and check if successful by checking that the markers are gone
 - If not, issue a regular discard request and again check for our markers
 - If still present, issue a block level zeroing request and check for the markers once again
 - At last, if still not reset, perform a full zero-ing of the device

This should catch all cases and goes from safest and easiest all the way to safe but extremely slow as the ultimate fallback.

Reported-by: Takero Funaki <flintglass@gmail.com>