### PR TITLE
incusd/main_cluster: Tweak to have help refer to correct command name

### DIFF
--- a/cmd/incus/admin_cluster.go
+++ b/cmd/incus/admin_cluster.go
@@ -51,5 +51,5 @@ You can invoke it through "incusd cluster".`))
 		os.Exit(1)
 	}
 
-	_ = doExec(path, append([]string{"incusd", "cluster"}, args...), env)
+	_ = doExec(path, append([]string{"incusd", "admin", "cluster"}, args...), env)
 }

--- a/cmd/incusd/main.go
+++ b/cmd/incusd/main.go
@@ -85,6 +85,11 @@ func main() {
 	// Workaround for main command
 	app.Args = cobra.ArbitraryArgs
 
+	// Workaround for being called through "incus admin cluster".
+	if len(os.Args) >= 3 && os.Args[0] == "incusd" && os.Args[1] == "admin" && os.Args[2] == "cluster" {
+		app.Use = "incus"
+	}
+
 	// Global flags
 	globalCmd := cmdGlobal{cmd: app}
 	daemonCmd.global = &globalCmd
@@ -185,7 +190,10 @@ func main() {
 	waitreadyCmd := cmdWaitready{global: &globalCmd}
 	app.AddCommand(waitreadyCmd.Command())
 
-	// cluster sub-command
+	// cluster sub-command (also admin cluster)
+	adminCmd := cmdAdmin{global: &globalCmd}
+	app.AddCommand(adminCmd.Command())
+
 	clusterCmd := cmdCluster{global: &globalCmd}
 	app.AddCommand(clusterCmd.Command())
 

--- a/cmd/incusd/main_cluster.go
+++ b/cmd/incusd/main_cluster.go
@@ -28,10 +28,31 @@ import (
 	"github.com/lxc/incus/v6/shared/termios"
 )
 
+type cmdAdmin struct {
+	global *cmdGlobal
+}
+
+// Command returns a cobra command for inclusion.
+func (c *cmdAdmin) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Hidden = true
+	cmd.Use = "admin"
+
+	// Cluster
+	clusterCmd := cmdCluster{global: c.global}
+	cmd.AddCommand(clusterCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	return cmd
+}
+
 type cmdCluster struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra command for inclusion.
 func (c *cmdCluster) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "cluster"


### PR DESCRIPTION
"incusd cluster" is typically called by a re-exec of "incus admin cluster".

This was leading to help messages referring to "incusd cluster XYZ" rather than "incus admin cluster XYZ". This commit now adds a bit more logic to detect this situation and correctly alter the command name.