### PR TITLE
incusd/storage/drivers: Handle 4k sector sizes

### DIFF
--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -9,9 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
 
 	internalInstance "github.com/lxc/incus/v6/internal/instance"
 	"github.com/lxc/incus/v6/internal/linux"
@@ -887,23 +884,4 @@ func (d *lvm) deactivateVolume(vol Volume) (bool, error) {
 	}
 
 	return false, nil
-}
-
-func (d *lvm) getBlockSize(path string) (int, error) {
-	// Open the block device.
-	f, err := os.Open(path)
-	if err != nil {
-		return -1, err
-	}
-
-	defer func() { _ = f.Close() }()
-
-	// Query the physical block size.
-	var res int32
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(f.Fd()), unix.BLKPBSZGET, uintptr(unsafe.Pointer(&res)))
-	if errno != 0 {
-		return -1, fmt.Errorf("Failed to BLKPBSZGET: %w", unix.Errno(errno))
-	}
-
-	return int(res), nil
 }

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -70,18 +70,6 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				if err != nil {
 					return err
 				}
-
-				// Check the block size for image volumes.
-				if vol.volType == VolumeTypeImage {
-					blockSize, err := d.getBlockSize(devPath)
-					if err != nil {
-						return err
-					}
-
-					if blockSize != 512 {
-						return fmt.Errorf("Underlying storage uses %d bytes sector size when virtual machine images require 512 bytes", blockSize)
-					}
-				}
 			}
 
 			allowUnsafeResize := false


### PR DESCRIPTION
The way we run QEMU, we always provide 512 byte alignment to the VM, but if the underlying physical storage (on LVM typically) is 4k, we need to make sure that our call to sgdisk doesn't cause it to rewrite the partition table for a 4k alignment.