### PR TITLE
incus/init: Add support for storage volumes in preseed init

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2693,3 +2693,6 @@ This adds support for device ACLs when attached to a bridged network.
 ## `instance_debug_memory`
 
 Add new memory dump API at `/1.0/instances/NAME/debug/memory`.
+
+## `init_preseed_storage_volumes`
+This API extension provides the ability to configure storage volumes in preseed init.

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -152,6 +152,11 @@ storage_pools:
   config:
     source: my-zfs-pool/my-zfs-dataset
 
+# Storage volumes
+storage_volumes:
+- name: my-vol
+  pool: data
+
 # Network devices
 networks:
 - name: incus-my-bridge

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1271,6 +1271,13 @@ definitions:
                     $ref: '#/definitions/StoragePoolsPost'
                 type: array
                 x-go-name: StoragePools
+            storage_volumes:
+                description: Storage Volumes to add
+                example: local dir storage volume
+                items:
+                    $ref: '#/definitions/InitStorageVolumesProjectPost'
+                type: array
+                x-go-name: StorageVolumes
         title: InitLocalPreseed represents initialization configuration.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
@@ -1315,6 +1322,55 @@ definitions:
             cluster:
                 $ref: '#/definitions/InitClusterPreseed'
         title: InitPreseed represents initialization configuration that can be supplied to `init`.
+        type: object
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    InitStorageVolumesProjectPost:
+        properties:
+            Pool:
+                description: Storage pool in which the volume will reside
+                example: '"default"'
+                type: string
+            Project:
+                description: Project in which the volume will reside
+                example: '"default"'
+                type: string
+            config:
+                additionalProperties:
+                    type: string
+                description: Storage volume configuration map (refer to doc/storage.md)
+                example:
+                    size: 50GiB
+                    zfs.remove_snapshots: "true"
+                type: object
+                x-go-name: Config
+            content_type:
+                description: Volume content type (filesystem or block)
+                example: filesystem
+                type: string
+                x-go-name: ContentType
+            description:
+                description: Description of the storage volume
+                example: My custom volume
+                type: string
+                x-go-name: Description
+            name:
+                description: Volume name
+                example: foo
+                type: string
+                x-go-name: Name
+            restore:
+                description: Name of a snapshot to restore
+                example: snap0
+                type: string
+                x-go-name: Restore
+            source:
+                $ref: '#/definitions/StorageVolumeSource'
+            type:
+                description: Volume type (container, custom, image or virtual-machine)
+                example: custom
+                type: string
+                x-go-name: Type
+        title: InitStorageVolumesProjectPost represents the fields of a new storage volume along with its associated pool.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     Instance:

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -459,6 +459,7 @@ var APIExtensions = []string{
 	"network_ovn_state_addresses",
 	"network_bridge_acl_devices",
 	"instance_debug_memory",
+	"init_preseed_storage_volumes",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/api/init.go
+++ b/shared/api/init.go
@@ -26,6 +26,12 @@ type InitLocalPreseed struct {
 	// Example: local dir storage pool
 	StoragePools []StoragePoolsPost `json:"storage_pools" yaml:"storage_pools"`
 
+	// Storage Volumes to add
+	// Example: local dir storage volume
+	//
+	// API extension: init_preseed_storage_volumes.
+	StorageVolumes []InitStorageVolumesProjectPost `json:"storage_volumes" yaml:"storage_volumes"`
+
 	// Profiles to add
 	// Example: "default" profile with a root disk device
 	Profiles []ProfilesPost `json:"profiles" yaml:"profiles"`
@@ -44,6 +50,23 @@ type InitNetworksProjectPost struct {
 	NetworksPost `yaml:",inline"`
 
 	// Project in which the network will reside
+	// Example: "default"
+	Project string
+}
+
+// InitStorageVolumesProjectPost represents the fields of a new storage volume along with its associated pool.
+//
+// swagger:model
+//
+// API extension: init_preseed_storage_volumes.
+type InitStorageVolumesProjectPost struct {
+	StorageVolumesPost `yaml:",inline"`
+
+	// Storage pool in which the volume will reside
+	// Example: "default"
+	Pool string
+
+	// Project in which the volume will reside
 	// Example: "default"
 	Project string
 }

--- a/test/suites/init_preseed.sh
+++ b/test/suites/init_preseed.sh
@@ -11,6 +11,7 @@ test_init_preseed() {
     INCUS_DIR=${INCUS_INIT_DIR}
 
     storage_pool="incustest-$(basename "${INCUS_DIR}")-data"
+    storage_volume="${storage_pool}-volume"
     # In case we're running against the ZFS backend, let's test
     # creating a zfs storage pool, otherwise just use dir.
     if [ "$incus_backend" = "zfs" ]; then
@@ -36,6 +37,9 @@ storage_pools:
   driver: $driver
   config:
     source: $source
+storage_volumes:
+- name: ${storage_volume}
+  pool: ${storage_pool}
 networks:
 - name: inct$$
   type: bridge
@@ -66,6 +70,7 @@ EOF
     incus network list | grep -q "inct$$"
     incus storage list | grep -q "${storage_pool}"
     incus storage show "${storage_pool}" | grep -q "$source"
+    incus storage volume list "${storage_pool}" | grep -q "${storage_volume}"
     incus profile list | grep -q "test-profile"
     incus profile show default | grep -q "pool: ${storage_pool}"
     incus profile show test-profile | grep -q "limits.memory: 2GiB"
@@ -74,6 +79,7 @@ EOF
     printf 'config: {}\ndevices: {}' | incus profile edit default
     incus profile delete test-profile
     incus network delete inct$$
+    incus storage volume delete "${storage_pool}" "${storage_volume}"
     incus storage delete "${storage_pool}"
 
     if [ "$incus_backend" = "zfs" ]; then


### PR DESCRIPTION
Add support for configuring storage volumes in preseed init.

In presed init we can now use something like:
```yaml
storage_volumes:
- name: my-vol
  pool: my-pool
  project:  my-project
```

to create a volume in a pool.

Loosely  related to #1590