### PR TITLE
incusd/instance/qemu: Fix device_id warning on 9.2.x

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4287,6 +4287,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 	qemuDev["serial"] = fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName)
 
 	if bus == "virtio-scsi" {
+		qemuDev["device_id"] = d.blockNodeName(escapedDeviceName)
 		qemuDev["channel"] = 0
 		qemuDev["lun"] = 1
 		qemuDev["bus"] = "qemu_scsi.0"


### PR DESCRIPTION
Closes #1536