### PR TITLE
incus-user: keep track of socket path used to connect to the server

### DIFF
--- a/cmd/incus-user/main_daemon.go
+++ b/cmd/incus-user/main_daemon.go
@@ -63,6 +63,14 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Unable to connect to the daemon: %w", err)
 	}
 
+	cinfo, err := client.GetConnectionInfo()
+	if err != nil {
+		return fmt.Errorf("Failed to obtain connection info: %w", err)
+	}
+
+	// Keep track of the socket path we used to succefully connect to the server
+	serverUnixPath := cinfo.SocketPath
+
 	// Validate the configuration.
 	ok, err := serverIsConfigured(client)
 	if err != nil {
@@ -187,6 +195,6 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		go proxyConnection(conn)
+		go proxyConnection(conn, serverUnixPath)
 	}
 }

--- a/cmd/incus-user/proxy.go
+++ b/cmd/incus-user/proxy.go
@@ -49,7 +49,7 @@ func tlsConfig(uid uint32) (*tls.Config, error) {
 	return localtls.GetTLSConfigMem(tlsClientCert, tlsClientKey, "", tlsServerCert, false)
 }
 
-func proxyConnection(conn *net.UnixConn) {
+func proxyConnection(conn *net.UnixConn, serverUnixPath string) {
 	defer func() {
 		_ = conn.Close()
 
@@ -92,7 +92,7 @@ func proxyConnection(conn *net.UnixConn) {
 	}
 
 	// Connect to the daemon.
-	unixAddr, err := net.ResolveUnixAddr("unix", internalUtil.VarPath("unix.socket"))
+	unixAddr, err := net.ResolveUnixAddr("unix", serverUnixPath)
 	if err != nil {
 		log.Errorf("Unable to resolve the target server: %v", err)
 		return


### PR DESCRIPTION
 The logic used to figure out the correct Unix socket path for access to
 the demon in `client.ConnectIncusUnix()` was fixed in in
 d8b78d5007c01d07b8e7fba78aceb917fbfcf879 to account for use of
 /run/incus/unix.socket as an alternative socket location. However, the
 proxying code of incus-user was not updated when the fix was
 introduced. As a result, even if initial connection to the server and
 the configuration queries were successful, the actual attempt to proxy
 a client request would fail while trying to connect to
 /var/lib/incus/unix.socket regardless of prior findings.