### PR TITLE
Add project support to profiles in preseed init

### DIFF
--- a/cmd/incus/admin_init_auto.go
+++ b/cmd/incus/admin_init_auto.go
@@ -109,17 +109,20 @@ func (c *cmdAdminInit) RunAuto(cmd *cobra.Command, args []string, d incus.Instan
 		config.StoragePools = []api.StoragePoolsPost{pool}
 
 		// Profile entry
-		config.Profiles = []api.ProfilesPost{{
-			Name: "default",
-			ProfilePut: api.ProfilePut{
-				Devices: map[string]map[string]string{
-					"root": {
-						"type": "disk",
-						"path": "/",
-						"pool": pool.Name,
+		config.Profiles = []api.InitProfileProjectPost{{
+			ProfilesPost: api.ProfilesPost{
+				Name: "default",
+				ProfilePut: api.ProfilePut{
+					Devices: map[string]map[string]string{
+						"root": {
+							"type": "disk",
+							"path": "/",
+							"pool": pool.Name,
+						},
 					},
 				},
 			},
+			Project: api.ProjectDefaultName,
 		}}
 	}
 
@@ -170,17 +173,20 @@ func (c *cmdAdminInit) RunAuto(cmd *cobra.Command, args []string, d incus.Instan
 
 		// Add it to the profile
 		if config.Profiles == nil {
-			config.Profiles = []api.ProfilesPost{{
-				Name: "default",
-				ProfilePut: api.ProfilePut{
-					Devices: map[string]map[string]string{
-						"eth0": {
-							"type":    "nic",
-							"network": network.Name,
-							"name":    "eth0",
+			config.Profiles = []api.InitProfileProjectPost{{
+				ProfilesPost: api.ProfilesPost{
+					Name: "default",
+					ProfilePut: api.ProfilePut{
+						Devices: map[string]map[string]string{
+							"eth0": {
+								"type":    "nic",
+								"network": network.Name,
+								"name":    "eth0",
+							},
 						},
 					},
 				},
+				Project: api.ProjectDefaultName,
 			}}
 		} else {
 			config.Profiles[0].Devices["eth0"] = map[string]string{

--- a/cmd/incus/admin_init_dump.go
+++ b/cmd/incus/admin_init_dump.go
@@ -65,7 +65,7 @@ func (c *cmdAdminInit) RunDump(d incus.InstanceServer) error {
 	}
 
 	for _, profile := range profiles {
-		profilesPost := api.ProfilesPost{}
+		profilesPost := api.InitProfileProjectPost{}
 		profilesPost.Config = profile.Config
 		profilesPost.Description = profile.Description
 		profilesPost.Devices = profile.Devices

--- a/cmd/incus/admin_init_interactive.go
+++ b/cmd/incus/admin_init_interactive.go
@@ -36,13 +36,16 @@ func (c *cmdAdminInit) RunInteractive(cmd *cobra.Command, args []string, d incus
 	config.Server.Config = map[string]string{}
 	config.Server.Networks = []api.InitNetworksProjectPost{}
 	config.Server.StoragePools = []api.StoragePoolsPost{}
-	config.Server.Profiles = []api.ProfilesPost{
+	config.Server.Profiles = []api.InitProfileProjectPost{
 		{
-			Name: "default",
-			ProfilePut: api.ProfilePut{
-				Config:  map[string]string{},
-				Devices: map[string]map[string]string{},
+			ProfilesPost: api.ProfilesPost{
+				Name: "default",
+				ProfilePut: api.ProfilePut{
+					Config:  map[string]string{},
+					Devices: map[string]map[string]string{},
+				},
 			},
+			Project: api.ProjectDefaultName,
 		},
 	}
 

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2696,3 +2696,6 @@ Add new memory dump API at `/1.0/instances/NAME/debug/memory`.
 
 ## `init_preseed_storage_volumes`
 This API extension provides the ability to configure storage volumes in preseed init.
+
+## `init_preseed_profile_project`
+This API extension provides the ability to specify the project as part of profile definitions in preseed init.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1254,7 +1254,7 @@ definitions:
                 description: Profiles to add
                 example: '"default" profile with a root disk device'
                 items:
-                    $ref: '#/definitions/ProfilesPost'
+                    $ref: '#/definitions/InitProfileProjectPost'
                 type: array
                 x-go-name: Profiles
             projects:
@@ -1322,6 +1322,51 @@ definitions:
             cluster:
                 $ref: '#/definitions/InitClusterPreseed'
         title: InitPreseed represents initialization configuration that can be supplied to `init`.
+        type: object
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    InitProfileProjectPost:
+        properties:
+            Project:
+                description: Project in which the profile will reside
+                example: '"default"'
+                type: string
+            config:
+                additionalProperties:
+                    type: string
+                description: Instance configuration map (refer to doc/instances.md)
+                example:
+                    limits.cpu: "4"
+                    limits.memory: 4GiB
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the profile
+                example: Medium size instances
+                type: string
+                x-go-name: Description
+            devices:
+                additionalProperties:
+                    additionalProperties:
+                        type: string
+                    type: object
+                description: List of devices
+                example:
+                    eth0:
+                        name: eth0
+                        network: mybr0
+                        type: nic
+                    root:
+                        path: /
+                        pool: default
+                        type: disk
+                type: object
+                x-go-name: Devices
+            name:
+                description: The name of the new profile
+                example: foo
+                type: string
+                x-go-name: Name
+        title: InitProfileProjectPost represents the fields of a new profile along with its associated project.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     InitStorageVolumesProjectPost:

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -460,6 +460,7 @@ var APIExtensions = []string{
 	"network_bridge_acl_devices",
 	"instance_debug_memory",
 	"init_preseed_storage_volumes",
+	"init_preseed_profile_project",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/api/init.go
+++ b/shared/api/init.go
@@ -34,7 +34,7 @@ type InitLocalPreseed struct {
 
 	// Profiles to add
 	// Example: "default" profile with a root disk device
-	Profiles []ProfilesPost `json:"profiles" yaml:"profiles"`
+	Profiles []InitProfileProjectPost `json:"profiles" yaml:"profiles"`
 
 	// Projects to add
 	// Example: "default" project
@@ -50,6 +50,19 @@ type InitNetworksProjectPost struct {
 	NetworksPost `yaml:",inline"`
 
 	// Project in which the network will reside
+	// Example: "default"
+	Project string
+}
+
+// InitProfileProjectPost represents the fields of a new profile along with its associated project.
+//
+// swagger:model
+//
+// API extension: init_preseed_profile_project.
+type InitProfileProjectPost struct {
+	ProfilesPost `yaml:",inline"`
+
+	// Project in which the profile will reside
 	// Example: "default"
 	Project string
 }


### PR DESCRIPTION
Add project support to profiles in preseed init.
Allow initialize lxd with  profiles for different projects.

Because of the need to handle projects I have changed `createProfile` and `updateProfile` to `applyProfile` that checks if the profile already exists in the specific project.

Fixes #1590