### PR TITLE
incusd/instance/drivers: Improve NUMA balancing

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -1913,9 +1913,9 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Assign a NUMA node if needed.
+	// Assign NUMA node(s) if needed.
 	if d.expandedConfig["limits.cpu.nodes"] == "balanced" {
-		err := d.setNUMANode()
+		err := d.balanceNUMANodes()
 		if err != nil {
 			return "", nil, err
 		}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1205,9 +1205,9 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 
 	defer op.Done(err)
 
-	// Assign a NUMA node if needed.
+	// Assign NUMA node(s) if needed.
 	if d.expandedConfig["limits.cpu.nodes"] == "balanced" {
-		err := d.setNUMANode()
+		err := d.balanceNUMANodes()
 		if err != nil {
 			op.Done(err)
 			return err


### PR DESCRIPTION
This PR fixes the assignment of `volatile.cpu.nodes` when `limits.cpu` is used alongside `limits.cpu.nodes=balanced`, and `limits.cpu` exceeds the number of CPUs available per NUMA node.

Previously, `volatile.cpu.nodes` was always set to a single NUMA node, even when more were required. With this fix, it can now span multiple NUMA nodes when necessary.