### PR TITLE
incusd/network/bridge: Fix deletion of tunnels and dummy devices

### DIFF
--- a/internal/server/device/nic_macvlan.go
+++ b/internal/server/device/nic_macvlan.go
@@ -219,7 +219,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	if d.inst.Type() == instancetype.VM {
 		// Enable all multicast processing which is required for IPv6 NDP functionality.
-		link.AllMutlicast = true
+		link.AllMulticast = true
 
 		// Bring the interface up on host side.
 		link.Up = true


### PR DESCRIPTION
The previous code relied purely on the name of the device to decide if a device should be deleted which was not correct and could result in the deletion of unwanted devices. The new code ensures that the device is part of the bridge and that its kind is correct before deleting it.