### PR TITLE
incusd/instance/drivers/qemu: Add IOMMU device

### DIFF
--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -311,6 +311,19 @@ func qemuCoreInfo() []cfg.Section {
 	}}
 }
 
+func qemuIOMMU(opts *qemuDevOpts) []cfg.Section {
+	entriesOpts := qemuDevEntriesOpts{
+		dev:     *opts,
+		pciName: "virtio-iommu-pci",
+	}
+
+	return []cfg.Section{{
+		Name:    `device "qemu_iommu"`,
+		Comment: "IOMMU driver",
+		Entries: qemuDeviceEntries(&entriesOpts),
+	}}
+}
+
 type qemuSevOpts struct {
 	cbitpos         int
 	reducedPhysBits int


### PR DESCRIPTION
This adds IOMMU support for guests that aren't running Windows and on platforms that support IOMMU and PCI.

Closes #1643