### PR TITLE
Fix incorrect volume group naming when `vg_name` is not specified

### DIFF
--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -38,6 +38,15 @@ const lvmEscapedHyphen = "--"
 // lvmThinpoolDefaultName is the default name for the thinpool volume.
 const lvmThinpoolDefaultName = "IncusThinPool"
 
+type lvmSourceType int
+
+const (
+	lvmSourceTypeUnknown lvmSourceType = iota
+	lvmSourceTypeDefault
+	lvmSourceTypePhysicalDevice
+	lvmSourceTypeVolumeGroup
+)
+
 // usesThinpool indicates whether the config specifies to use a thin pool or not.
 func (d *lvm) usesThinpool() bool {
 	// No thin pool on clustered LVM.
@@ -884,4 +893,19 @@ func (d *lvm) deactivateVolume(vol Volume) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// getSourceType determines the source type based on the config["source"] value.
+func (d *lvm) getSourceType() lvmSourceType {
+	defaultSource := loopFilePath(d.name)
+
+	if d.config["source"] == "" || d.config["source"] == defaultSource {
+		return lvmSourceTypeDefault
+	} else if filepath.IsAbs(d.config["source"]) {
+		return lvmSourceTypePhysicalDevice
+	} else if d.config["source"] != "" {
+		return lvmSourceTypeVolumeGroup
+	}
+
+	return lvmSourceTypeUnknown
 }


### PR DESCRIPTION
In the context of clustering, when `vg_name` is not specified, the name of the storage pool that the user wants to create is used as the volume group name. This approach is incorrect if the source is a volume group name, as it leads to a mismatch between the source (volume group name) and the storage pool name, causing issues.

To address this, we need to detect such cases. In other scenarios, such as when a physical device is specified as the source, the storage pool name provided by the user should be used as the volume group name.

To solve this issue, a helper method was implemented to determine the source type based on the value of `config["source"]`. This method works as follows:

If the source is empty, a loop file, or a physical device, the storage pool name is used as the volume group name.
If the source is a volume group name, then that name is used as the volume group name.
This helper method ensures consistent naming logic and is now used in both the `init()` and `Create()` methods.

Fixes: #1650