### PR TITLE
Fix instance copy error when using '--refresh' flag

### DIFF
--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -1356,7 +1356,6 @@ func clusterCopyContainerInternal(ctx context.Context, s *state.State, r *http.R
 		pullReq := api.InstanceSnapshotPost{
 			Migration: true,
 			Live:      req.Source.Live,
-			Name:      req.Name,
 		}
 
 		op, err := client.MigrateInstanceSnapshot(cName, sName, pullReq)
@@ -1371,7 +1370,6 @@ func clusterCopyContainerInternal(ctx context.Context, s *state.State, r *http.R
 			Migration:    true,
 			Live:         req.Source.Live,
 			InstanceOnly: instanceOnly,
-			Name:         req.Name,
 		}
 
 		op, err := client.MigrateInstance(req.Source.Source, pullReq)


### PR DESCRIPTION
Copying an instance with the `--refresh` flag sometimes fails due to instance name validation errors.

Do not set the `Name` field in `api.InstancePost` or `api.InstanceSnapshotPost` structs, as this field is meant only for renaming instances.

Fixes: #1629