### PR TITLE
incusd/main_nsexec: Fix change_namespaces fallback to handle multiple…

### DIFF
--- a/cmd/incusd/main_nsexec.go
+++ b/cmd/incusd/main_nsexec.go
@@ -231,19 +231,9 @@ static const struct ns_info {
 	{ "time",   CLONE_NEWTIME	},
 };
 
-static inline const char *namespace_flag_into_name(unsigned int flags)
-{
-	for (int i = 0; i < ARRAY_SIZE(ns_info); i++)
-		if (ns_info[i].clone_flag == flags)
-			return ns_info[i].proc_name;
-
-	return NULL;
-}
-
 bool change_namespaces(int pidfd, int nsfd, unsigned int flags)
 {
 	__do_close int fd = -EBADF;
-	const char *ns;
 
 	if (pidfd >= 0 && setns(pidfd, flags) == 0)
 		return true;
@@ -251,15 +241,18 @@ bool change_namespaces(int pidfd, int nsfd, unsigned int flags)
 	if (nsfd < 0)
 		return false;
 
-	ns = namespace_flag_into_name(flags);
-	if (!ns)
-		return false;
+	for (int i = 0; i < ARRAY_SIZE(ns_info); i++) {
+		if (flags & ns_info[i].clone_flag) {
+			fd = openat(nsfd, ns_info[i].proc_name, O_RDONLY | O_CLOEXEC);
+			if (fd < 0)
+				return false;
 
-	fd = openat(nsfd, ns, O_RDONLY | O_CLOEXEC);
-	if (fd < 0)
-		return false;
+			if (setns(fd, 0) < 0)
+				return false;
+		}
+	}
 
-	return setns(fd, 0) == 0;
+	return true;
 }
 
 static char *file_to_buf(char *path, ssize_t *length)


### PR DESCRIPTION
… namespaces

We have a few code paths that call change_namespaces with multiple namespaces in flags. This works fine for the single setns() call using a pidfd, but it causes the fallback logic on systems without pidfd setns support to completely fail.

So now, instead of expecting flags to include a single namespace flag, iterate over all supported flags and join as many namespaces as possible.

Closes #1660