### PR TITLE
Check if disk is remote when migrating with an extra disk

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -7049,6 +7049,11 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 			return fmt.Errorf("Failed loading storage pool: %w", err)
 		}
 
+		// Check that we're on shared storage.
+		if !diskPool.Driver().Info().Remote {
+			continue
+		}
+
 		// Setup the volume entry.
 		extraSourceArgs := &localMigration.VolumeSourceArgs{
 			ClusterMove: true,
@@ -7567,6 +7572,11 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			diskPool, err := storagePools.LoadByName(d.state, dev.Config["pool"])
 			if err != nil {
 				return fmt.Errorf("Failed loading storage pool: %w", err)
+			}
+
+			// Check that we're on shared storage.
+			if !diskPool.Driver().Info().Remote {
+				continue
 			}
 
 			// Setup the volume entry.


### PR DESCRIPTION
This additional check ensures that migrations are not performed on local disks. On remote disks, the migration effectively only mounts the disk on the target node.

Fixes: #1657