### PR TITLE
Add filtering to all API collections

### DIFF
--- a/cmd/incusd/network_acls.go
+++ b/cmd/incusd/network_acls.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/incus/v6/internal/filter"
 	"github.com/lxc/incus/v6/internal/server/auth"
 	clusterRequest "github.com/lxc/incus/v6/internal/server/cluster/request"
 	"github.com/lxc/incus/v6/internal/server/db"
@@ -71,6 +72,11 @@ var networkACLLogCmd = APIEndpoint{
 //      description: Retrieve network ACLs from all projects
 //      type: boolean
 //      example: true
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
 //  responses:
 //    "200":
 //      description: API endpoints
@@ -107,52 +113,58 @@ var networkACLLogCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/network-acls?recursion=1 network-acls network_acls_get_recursion1
 //
-//	Get the network ACLs
+//  Get the network ACLs
 //
-//	Returns a list of network ACLs (structs).
+//  Returns a list of network ACLs (structs).
 //
-//	---
-//	produces:
-//	  - application/json
-//	parameters:
-//	  - in: query
-//	    name: project
-//	    description: Project name
-//	    type: string
-//	    example: default
-//	  - in: query
-//	    name: all-projects
-//	    description: Retrieve network ACLs from all projects
-//	    type: boolean
-//	    example: true
-//	responses:
-//	  "200":
-//	    description: API endpoints
-//	    schema:
-//	      type: object
-//	      description: Sync response
-//	      properties:
-//	        type:
-//	          type: string
-//	          description: Response type
-//	          example: sync
-//	        status:
-//	          type: string
-//	          description: Status description
-//	          example: Success
-//	        status_code:
-//	          type: integer
-//	          description: Status code
-//	          example: 200
-//	        metadata:
-//	          type: array
-//	          description: List of network ACLs
-//	          items:
-//	            $ref: "#/definitions/NetworkACL"
-//	  "403":
-//	    $ref: "#/responses/Forbidden"
-//	  "500":
-//	    $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: all-projects
+//      description: Retrieve network ACLs from all projects
+//      type: boolean
+//      example: true
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of network ACLs
+//            items:
+//              $ref: "#/definitions/NetworkACL"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
+
 func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -163,6 +175,15 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 
 	recursion := localUtil.IsRecursionRequest(r)
 	allProjects := util.IsTrue(r.FormValue("all-projects"))
+
+	// Parse filter value.
+	filterStr := r.FormValue("filter")
+	clauses, err := filter.Parse(filterStr, filter.QueryOperatorSet())
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Invalid filter: %w", err))
+	}
+
+	mustLoadObjects := recursion || (clauses != nil && len(clauses.Clauses) > 0)
 
 	var aclNames map[string][]string
 
@@ -197,17 +218,15 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resultString := []string{}
-	resultMap := []api.NetworkACL{}
+	linkResults := make([]string, 0)
+	fullResults := make([]api.NetworkACL, 0)
 	for projectName, acls := range aclNames {
 		for _, aclName := range acls {
 			if !userHasPermission(auth.ObjectNetworkACL(projectName, aclName)) {
 				continue
 			}
 
-			if !recursion {
-				resultString = append(resultString, fmt.Sprintf("/%s/network-acls/%s", version.APIVersion, aclName))
-			} else {
+			if mustLoadObjects {
 				netACL, err := acl.LoadByName(s, projectName, aclName)
 				if err != nil {
 					continue
@@ -216,16 +235,29 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 				netACLInfo := netACL.Info()
 				netACLInfo.UsedBy, _ = netACL.UsedBy() // Ignore errors in UsedBy, will return nil.
 
-				resultMap = append(resultMap, *netACLInfo)
+				if clauses != nil && len(clauses.Clauses) > 0 {
+					match, err := filter.Match(*netACLInfo, *clauses)
+					if err != nil {
+						return response.SmartError(err)
+					}
+
+					if !match {
+						continue
+					}
+				}
+
+				fullResults = append(fullResults, *netACLInfo)
 			}
+
+			linkResults = append(linkResults, fmt.Sprintf("/%s/network-acls/%s", version.APIVersion, aclName))
 		}
 	}
 
 	if !recursion {
-		return response.SyncResponse(true, resultString)
+		return response.SyncResponse(true, linkResults)
 	}
 
-	return response.SyncResponse(true, resultMap)
+	return response.SyncResponse(true, fullResults)
 }
 
 // swagger:operation POST /1.0/network-acls network-acls network_acls_post

--- a/cmd/incusd/network_peers.go
+++ b/cmd/incusd/network_peers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/incus/v6/internal/filter"
 	"github.com/lxc/incus/v6/internal/server/auth"
 	"github.com/lxc/incus/v6/internal/server/db"
 	"github.com/lxc/incus/v6/internal/server/lifecycle"
@@ -54,6 +55,11 @@ var networkPeerCmd = APIEndpoint{
 //      description: Project name
 //      type: string
 //      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
 //  responses:
 //    "200":
 //      description: API endpoints
@@ -90,47 +96,53 @@ var networkPeerCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/networks/{networkName}/peers?recursion=1 network-peers network_peer_get_recursion1
 //
-//	Get the network peers
+//  Get the network peers
 //
-//	Returns a list of network peers (structs).
+//  Returns a list of network peers (structs).
 //
-//	---
-//	produces:
-//	  - application/json
-//	parameters:
-//	  - in: query
-//	    name: project
-//	    description: Project name
-//	    type: string
-//	    example: default
-//	responses:
-//	  "200":
-//	    description: API endpoints
-//	    schema:
-//	      type: object
-//	      description: Sync response
-//	      properties:
-//	        type:
-//	          type: string
-//	          description: Response type
-//	          example: sync
-//	        status:
-//	          type: string
-//	          description: Status description
-//	          example: Success
-//	        status_code:
-//	          type: integer
-//	          description: Status code
-//	          example: 200
-//	        metadata:
-//	          type: array
-//	          description: List of network peers
-//	          items:
-//	            $ref: "#/definitions/NetworkPeer"
-//	  "403":
-//	    $ref: "#/responses/Forbidden"
-//	  "500":
-//	    $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of network peers
+//            items:
+//              $ref: "#/definitions/NetworkPeer"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
+
 func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -158,11 +170,25 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network driver %q does not support peering", n.Type()))
 	}
 
-	if localUtil.IsRecursionRequest(r) {
-		var records map[int64]*api.NetworkPeer
+	recursion := localUtil.IsRecursionRequest(r)
+
+	// Parse filter value.
+	filterStr := r.FormValue("filter")
+	clauses, err := filter.Parse(filterStr, filter.QueryOperatorSet())
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Invalid filter: %w", err))
+	}
+
+	mustLoadObjects := recursion || (clauses != nil && len(clauses.Clauses) > 0)
+
+	fullResults := make([]api.NetworkPeer, 0)
+	linkResults := make([]string, 0)
+
+	if mustLoadObjects {
+		var peers map[int64]*api.NetworkPeer
 
 		err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			records, err = tx.GetNetworkPeers(ctx, n.ID())
+			peers, err = tx.GetNetworkPeers(ctx, n.ID())
 
 			return err
 		})
@@ -170,32 +196,45 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(fmt.Errorf("Failed loading network peers: %w", err))
 		}
 
-		peers := make([]*api.NetworkPeer, 0, len(records))
-		for _, record := range records {
-			record.UsedBy, _ = n.PeerUsedBy(record.Name)
-			peers = append(peers, record)
+		for _, peer := range peers {
+			peer.UsedBy, _ = n.PeerUsedBy(peer.Name)
+
+			if clauses != nil && len(clauses.Clauses) > 0 {
+				match, err := filter.Match(*peer, *clauses)
+				if err != nil {
+					return response.SmartError(err)
+				}
+
+				if !match {
+					continue
+				}
+			}
+
+			fullResults = append(fullResults, *peer)
+			linkResults = append(linkResults, fmt.Sprintf("/%s/networks/%s/peers/%s", version.APIVersion, url.PathEscape(n.Name()), url.PathEscape(peer.Name)))
+		}
+	} else {
+		var peerNames map[int64]string
+
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			peerNames, err = tx.GetNetworkPeerNames(ctx, n.ID())
+
+			return err
+		})
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed loading network peers: %w", err))
 		}
 
-		return response.SyncResponse(true, peers)
+		for _, peerName := range peerNames {
+			linkResults = append(linkResults, fmt.Sprintf("/%s/networks/%s/peers/%s", version.APIVersion, url.PathEscape(n.Name()), url.PathEscape(peerName)))
+		}
 	}
 
-	var peerNames map[int64]string
-
-	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		peerNames, err = tx.GetNetworkPeerNames(ctx, n.ID())
-
-		return err
-	})
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed loading network peers: %w", err))
+	if recursion {
+		return response.SyncResponse(true, fullResults)
 	}
 
-	peerURLs := make([]string, 0, len(peerNames))
-	for _, peerName := range peerNames {
-		peerURLs = append(peerURLs, fmt.Sprintf("/%s/networks/%s/peers/%s", version.APIVersion, url.PathEscape(n.Name()), url.PathEscape(peerName)))
-	}
-
-	return response.SyncResponse(true, peerURLs)
+	return response.SyncResponse(true, linkResults)
 }
 
 // swagger:operation POST /1.0/networks/{networkName}/peers network-peers network_peers_post

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2707,3 +2707,6 @@ Adds support for specifying the VRF to add the routes to.
 A new category of configuration options, `smbios11.XYZ` has been added
 which allows passing key/value pairs through `SMBIOS Type 11` on systems that
 support it.
+
+## `api_filtering_extended`
+This extends the API filtering mechanism to all API collections.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -171,8 +171,6 @@ by the object itself.
 To filter your results on certain values, filter is implemented for collections.
 A `filter` argument can be passed to a GET query against a collection.
 
-Filtering is available for the instance, image and storage volume endpoints.
-
 There is no default value for filter which means that all results found will
 be returned. The following is the language used for the filter argument:
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -6959,6 +6959,12 @@ paths:
         get:
             description: Returns a list of trusted certificates (URLs).
             operationId: certificates_get
+            parameters:
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -7172,6 +7178,12 @@ paths:
         get:
             description: Returns a list of trusted certificates (structs).
             operationId: certificates_get_recursion1
+            parameters:
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -10791,6 +10803,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11057,6 +11074,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11140,6 +11162,12 @@ paths:
         get:
             description: Returns a list of network integrations (URLs).
             operationId: network_integrations_get
+            parameters:
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11339,6 +11367,12 @@ paths:
         get:
             description: Returns a list of network integrations (structs).
             operationId: network_integrations_get_recursion1
+            parameters:
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11387,6 +11421,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11594,6 +11633,11 @@ paths:
                   example: default
                   in: query
                   name: project
+                  type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
                   type: string
             produces:
                 - application/json
@@ -11803,6 +11847,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11851,6 +11900,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -11899,6 +11953,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -12253,6 +12312,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -12461,6 +12525,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -12503,6 +12572,11 @@ paths:
                   example: default
                   in: query
                   name: project
+                  type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
                   type: string
             produces:
                 - application/json
@@ -12752,6 +12826,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -12794,6 +12873,11 @@ paths:
                   example: default
                   in: query
                   name: project
+                  type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
                   type: string
             produces:
                 - application/json
@@ -13005,6 +13089,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -13053,6 +13142,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -13397,6 +13491,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -13641,6 +13740,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -13678,6 +13782,12 @@ paths:
         get:
             description: Returns a list of projects (URLs).
             operationId: projects_get
+            parameters:
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -13954,6 +14064,12 @@ paths:
         get:
             description: Returns a list of projects (structs).
             operationId: projects_get_recursion1
+            parameters:
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -14036,6 +14152,11 @@ paths:
                   example: default
                   in: query
                   name: project
+                  type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
                   type: string
             produces:
                 - application/json
@@ -14484,6 +14605,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -15045,6 +15171,11 @@ paths:
                   in: query
                   name: all-projects
                   type: boolean
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
+                  type: string
             produces:
                 - application/json
             responses:
@@ -16216,6 +16347,11 @@ paths:
                   example: default
                   in: query
                   name: project
+                  type: string
+                - description: Collection filter
+                  example: default
+                  in: query
+                  name: filter
                   type: string
             produces:
                 - application/json

--- a/internal/filter/value.go
+++ b/internal/filter/value.go
@@ -14,8 +14,6 @@ func ValueOf(obj any, field string) any {
 	key := parts[0]
 	rest := strings.Join(parts[1:], ".")
 
-	var parent any
-
 	if value.Kind() == reflect.Map {
 		switch reflect.TypeOf(obj).Elem().Kind() {
 		case reflect.String:
@@ -40,7 +38,10 @@ func ValueOf(obj any, field string) any {
 		yaml := fieldType.Tag.Get("yaml")
 
 		if yaml == ",inline" {
-			parent = fieldValue.Interface()
+			v := ValueOf(fieldValue.Interface(), field)
+			if v != nil {
+				return v
+			}
 		}
 
 		yamlKey, _, _ := strings.Cut(yaml, ",")
@@ -52,10 +53,6 @@ func ValueOf(obj any, field string) any {
 
 			return ValueOf(v, rest)
 		}
-	}
-
-	if parent != nil {
-		return ValueOf(parent, field)
 	}
 
 	return nil

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -463,6 +463,7 @@ var APIExtensions = []string{
 	"init_preseed_profile_project",
 	`instance_nic_routed_host_address`,
 	"instance_smbios11",
+	"api_filtering_extended",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/filtering.sh
+++ b/test/suites/filtering.sh
@@ -16,6 +16,14 @@ test_filtering() {
 
     incus init testimage c1
     incus init testimage c2
+    incus project create foo
+    incus profile create foo
+    incus network zone create foo
+    incus network zone record create foo foo
+    incus network zone record create foo bar
+    incus network zone create bar
+    incus network integration create foo ovn
+    incus network integration create bar ovn
 
     count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/instances" --data-urlencode "recursion=0" --data-urlencode "filter=name eq c1" | jq ".metadata | length")
     [ "${count}" = "1" ] || false
@@ -32,8 +40,32 @@ test_filtering() {
     count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/images" --data-urlencode "recursion=1" --data-urlencode "filter=properties.os eq Ubuntu" | jq ".metadata | length")
     [ "${count}" = "0" ] || false
 
+    count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/images" --data-urlencode "recursion=0" --data-urlencode "filter=properties.os eq BusyBox" | jq ".metadata | length")
+    [ "${count}" = "1" ] || false
+
+    count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/projects" --data-urlencode "recursion=0" --data-urlencode "filter=name eq foo" | jq ".metadata | length")
+    [ "${count}" = "1" ] || false
+
+    count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/profiles" --data-urlencode "recursion=0" --data-urlencode "filter=name eq foo" | jq ".metadata | length")
+    [ "${count}" = "1" ] || false
+
+    count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/network-zones" --data-urlencode "recursion=0" --data-urlencode "filter=name eq foo" | jq ".metadata | length")
+    [ "${count}" = "1" ] || false
+
+    count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/network-zones/foo/records" --data-urlencode "recursion=0" --data-urlencode "filter=name eq foo" | jq ".metadata | length")
+    [ "${count}" = "1" ] || false
+
+    count=$(curl -G --unix-socket "$INCUS_DIR/unix.socket" "incus/1.0/network-integrations" --data-urlencode "recursion=0" --data-urlencode "filter=name eq foo" | jq ".metadata | length")
+    [ "${count}" = "1" ] || false
+
     incus delete c1
     incus delete c2
+    incus project delete foo
+    incus profile delete foo
+    incus network zone delete foo
+    incus network zone delete bar
+    incus network integration delete foo
+    incus network integration delete bar
   )
 
   kill_incus "${INCUS_FILTERING_DIR}"


### PR DESCRIPTION
This PR aims to make odata-like filtering available for all collection endpoints (see #1674). 

So far I have only implemented it for `/1.0/networks`, could someone take a quick look and tell me if the way I'm doing this is alright, before I work on the other endpoints?

Closes #1674 