### PR TITLE
fix: Don't attempt to download signatures for oci

### DIFF
--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -185,6 +185,7 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		"skopeo",
 		"--insecure-policy",
 		"copy",
+		"--remove-signatures",
 		fmt.Sprintf("%s/%s", strings.Replace(r.httpHost, "https://", "docker://", -1), info.Alias),
 		fmt.Sprintf("oci:%s:latest", filepath.Join(ociPath, "oci")))
 	if err != nil {


### PR DESCRIPTION
Currently, incus uses skopeo to copy a docker image to an oci formatted file tree. The OCI:/ endpoint does not support copying signatures. Several projects are using cosign or gpg to sign their images which the OCI:/ endpoint does not support. This adds the flag to skopeo to not attempt to copy the unsupported signatures as a bandaid until a different method that supports signatures is identified.