### PR TITLE
Allow ICMP and low ports for unprivileged users in OCI containers

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2306,6 +2306,28 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 			volatileSet["volatile.container.oci"] = "true"
 		}
 
+		// Allow unprivileged users to use ping.
+		maxGid := int64(4294967295)
+
+		if !d.IsPrivileged() {
+			maxGid = 0
+			idMap, err := d.CurrentIdmap()
+			if err != nil {
+				return "", nil, err
+			}
+
+			for _, entry := range idMap.Entries {
+				if entry.NSID+entry.MapRange-1 > maxGid {
+					maxGid = entry.NSID + entry.MapRange - 1
+				}
+			}
+		}
+
+		err = lxcSetConfigItem(cc, "lxc.sysctl.net.ipv4.ping_group_range", fmt.Sprintf("0 %d", maxGid))
+		if err != nil {
+			return "", nil, err
+		}
+
 		// Configure the entry point.
 		if len(config.Process.Args) > 0 && slices.Contains([]string{"/init", "/sbin/init", "/s6-init"}, config.Process.Args[0]) {
 			// For regular init systems, call them directly as PID1.

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2328,6 +2328,12 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 			return "", nil, err
 		}
 
+		// Allow unprivileged users to use low ports.
+		err = lxcSetConfigItem(cc, "lxc.sysctl.net.ipv4.ip_unprivileged_port_start", "0")
+		if err != nil {
+			return "", nil, err
+		}
+
 		// Configure the entry point.
 		if len(config.Process.Args) > 0 && slices.Contains([]string{"/init", "/sbin/init", "/s6-init"}, config.Process.Args[0]) {
 			// For regular init systems, call them directly as PID1.


### PR DESCRIPTION
Docker uses the range `0 2147483647` for the ping group IDs, but that fails if not that many groups are available, and the default incus configuration only allocates 1000000000 IDs, so I opted for a more conservative `0 65536`.

I suppose ideally we would check what ID range is available and use that, but I couldn't figure out how.