### PR TITLE
Fixed incus edk2 path overwrite issue

### DIFF
--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -200,7 +200,11 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 
 		var edk2Paths []string
 
-		edk2Path := edk2.GetenvEdk2Path()
+		edk2Path, err := edk2.GetenvEdk2Path()
+		if err != nil {
+			return "", err
+		}
+
 		if edk2Path != "" {
 			edk2Path, err := filepath.EvalSymlinks(edk2Path)
 			if err != nil {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -2159,7 +2159,7 @@ func (d *qemu) setupNvram() error {
 	d.logger.Debug("Generating NVRAM")
 
 	// Cleanup existing variables.
-	for _, firmwarePair := range edk2.GetAchitectureFirmwarePairs(d.architecture) {
+	for _, firmwarePair := range edk2.GetArchitectureFirmwarePairs(d.architecture) {
 		err := os.Remove(filepath.Join(d.Path(), filepath.Base(firmwarePair.Vars)))
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err

--- a/internal/server/instance/drivers/edk2/driver_edk2.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/osarch"
 	"github.com/lxc/incus/v6/shared/util"
 )
@@ -164,26 +163,31 @@ func GetArchitectureInstallations(hostArch int) []Installation {
 // specific host architecture. If the environment variable INCUS_EDK2_PATH
 // has been set it will override the default installation path when
 // constructing Code & Vars paths.
-func GetArchitectureFirmwarePairs(hostArch int) []FirmwarePair {
+func GetArchitectureFirmwarePairs(hostArch int) ([]FirmwarePair, error) {
 	firmwares := make([]FirmwarePair, 0)
 
 	for _, usage := range []FirmwareUsage{GENERIC, SECUREBOOT, CSM} {
-		firmwares = append(firmwares, GetArchitectureFirmwarePairsForUsage(hostArch, usage)...)
+		firmware, err := GetArchitectureFirmwarePairsForUsage(hostArch, usage)
+		if err != nil {
+			return nil, err
+		}
+
+		firmwares = append(firmwares, firmware...)
 	}
 
-	return firmwares
+	return firmwares, nil
 }
 
 // GetArchitectureFirmwarePairsForUsage creates an array of FirmwarePair
 // for a specific host architecture and usage combination. If the
 // environment variable INCUS_EDK2_PATH has been set it will override the
 // default installation path when constructing Code & Vars paths.
-func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) []FirmwarePair {
+func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) ([]FirmwarePair, error) {
 	firmwares := make([]FirmwarePair, 0)
 
 	incusEdk2Path, err := GetenvEdk2Path()
 	if err != nil {
-		logger.Warnf("err: %v", err)
+		return nil, err
 	}
 
 	for _, installation := range GetArchitectureInstallations(hostArch) {
@@ -216,7 +220,7 @@ func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) []F
 		}
 	}
 
-	return firmwares
+	return firmwares, nil
 }
 
 // GetenvEdk2Path returns the environment variable for overriding the path to use for EDK2 installations.

--- a/internal/server/instance/drivers/edk2/driver_edk2.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2.go
@@ -158,11 +158,11 @@ func GetArchitectureInstallations(hostArch int) []Installation {
 	return []Installation{}
 }
 
-// GetAchitectureFirmwarePairs creates an array of FirmwarePair for a
+// GetArchitectureFirmwarePairs creates an array of FirmwarePair for a
 // specific host architecture. If the environment variable INCUS_EDK2_PATH
 // has been set it will override the default installation path when
 // constructing Code & Vars paths.
-func GetAchitectureFirmwarePairs(hostArch int) []FirmwarePair {
+func GetArchitectureFirmwarePairs(hostArch int) []FirmwarePair {
 	firmwares := make([]FirmwarePair, 0)
 
 	for _, usage := range []FirmwareUsage{GENERIC, SECUREBOOT, CSM} {

--- a/internal/server/instance/drivers/edk2/driver_edk2_test.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2_test.go
@@ -1,0 +1,88 @@
+package edk2
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lxc/incus/v6/internal/server/util"
+)
+
+func tSetup(t *testing.T) func() {
+	t.Helper()
+	tmpdir, err := os.MkdirTemp("", "edk2*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	incusEdk2Path := filepath.Join(tmpdir, "ovmf")
+	err = os.MkdirAll(incusEdk2Path, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, fn := range []string{"OVMF_CODE.fd", "OVMF.fd", "OVMF_VARS.fd"} {
+		f, err := os.Create(filepath.Join(incusEdk2Path, fn))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = os.Setenv("INCUS_EDK2_PATH", incusEdk2Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		err = os.Unsetenv("INCUS_EDK2_PATH")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = os.RemoveAll(tmpdir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestGetEdk2Path(t *testing.T) {
+	incusEDK2Path, err := GetenvEdk2Path()
+	if err != nil || incusEDK2Path != "" {
+		t.Fatal(err, incusEDK2Path)
+	}
+
+	rb := tSetup(t)
+	defer rb()
+	incusEDK2Path, err = GetenvEdk2Path()
+	if err != nil || incusEDK2Path == "" {
+		t.Fatal(incusEDK2Path)
+	}
+}
+
+func TestArchitectureFirmwarePairs(t *testing.T) {
+	rb := tSetup(t)
+	defer rb()
+	architectures, err := util.GetArchitectures()
+	if err != nil || len(architectures) == 0 {
+		t.Fatal(err)
+	}
+
+	pairs := GetArchitectureFirmwarePairs(architectures[0])
+	if len(pairs) == 0 {
+		t.Fatal(pairs)
+	}
+
+	pair1 := pairs[0]
+	code, vars := pair1.Code, pair1.Vars
+	if !strings.HasSuffix(code, "ovmf/OVMF_CODE.fd") ||
+		!strings.HasSuffix(vars, "ovmf/OVMF_VARS.fd") {
+		t.Fatal(pair1)
+	}
+}

--- a/internal/server/instance/drivers/edk2/driver_edk2_test.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2_test.go
@@ -74,7 +74,11 @@ func TestArchitectureFirmwarePairs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pairs := GetArchitectureFirmwarePairs(architectures[0])
+	pairs, err := GetArchitectureFirmwarePairs(architectures[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if len(pairs) == 0 {
 		t.Fatal(pairs)
 	}


### PR DESCRIPTION
Current INCUS_EDK2_PATH once set, no matter it's directory exists or not, it will overwrite the buildin EDK2 Path. The fix added two conditions to overwrite:
1. buildit EDK2 Path directory not exist, and
2. INCUS_EDK2_PATH directory exists.

And a function naming issue is fixed too(GetAchitectureFirmwarePairs -> GetArchitectureFirmwarePairs).