### PR TITLE
Do not download instance types if cache loadable

### DIFF
--- a/cmd/incusd/instance_instance_types.go
+++ b/cmd/incusd/instance_instance_types.go
@@ -153,7 +153,19 @@ func instanceRefreshTypes(ctx context.Context, s *state.State) error {
 
 	// Set an initial value from the cache
 	if instanceTypes == nil {
-		_ = instanceLoadCache()
+		instanceTypes = map[string]map[string]*instanceType{}
+	}
+
+	if len(instanceTypes) == 0 {
+		err := instanceLoadCache()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Allow disabling instance type download.
+	if util.IsTrue(os.Getenv("INCUS_SKIP_INSTANCE_TYPES")) {
+		return nil
 	}
 
 	// Get the list of instance type sources

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -40,3 +40,4 @@ Name                            | Description
 `INCUS_SECURITY_APPARMOR`       | If set to `false`, forces AppArmor off
 `INCUS_UI`                      | Path to the web UI to serve through the web server
 `INCUS_USBIDS_PATH`             | Path to the hwdata `usb.ids` file
+`INCUS_SKIP_INSTANCE_TYPES`     | If set to `true`, skip downloading instance type definitions

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -19,11 +19,11 @@ Name                            | Description
 Name                            | Description
 :---                            | :----
 `EDITOR`                        | What text editor to use
-`VISUAL`                        | What text editor to use (if `EDITOR` isn't set)
 `INCUS_CONF`                    | Path to the client configuration directory
 `INCUS_GLOBAL_CONF`             | Path to the global client configuration directory
-`INCUS_REMOTE`                  | Name of the remote to use (overrides configured default remote)
 `INCUS_PROJECT`                 | Name of the project to use (overrides configured default project)
+`INCUS_REMOTE`                  | Name of the remote to use (overrides configured default remote)
+`VISUAL`                        | What text editor to use (if `EDITOR` isn't set)
 
 ## Server environment variable
 
@@ -33,11 +33,11 @@ Name                            | Description
 `INCUS_CLUSTER_UPDATE`          | Script to call on a cluster update
 `INCUS_DEVMONITOR_DIR`          | Path to be monitored by the device monitor. This is primarily for testing
 `INCUS_DOCUMENTATION`           | Path to the documentation to serve through the web server
+`INCUS_EDK2_PATH`               | Path to EDK2 firmware build including `*_CODE.fd` and `*_VARS.fd`
 `INCUS_EXEC_PATH`               | Full path to the Incus binary (used when forking subcommands)
 `INCUS_IDMAPPED_MOUNTS_DISABLE` | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `INCUS_LXC_TEMPLATE_CONFIG`     | Path to the LXC template configuration directory
-`INCUS_EDK2_PATH`               | Path to EDK2 firmware build including `*_CODE.fd` and `*_VARS.fd`
 `INCUS_SECURITY_APPARMOR`       | If set to `false`, forces AppArmor off
+`INCUS_SKIP_INSTANCE_TYPES`     | If set to `true`, skip downloading instance type definitions
 `INCUS_UI`                      | Path to the web UI to serve through the web server
 `INCUS_USBIDS_PATH`             | Path to the hwdata `usb.ids` file
-`INCUS_SKIP_INSTANCE_TYPES`     | If set to `true`, skip downloading instance type definitions


### PR DESCRIPTION
and environment INCUS_SKIP_INSTANCE_TYPES set to true, because most enterprise
environment has no internet access, so they can put instance types in cache and
set `INCUS_SKIP_INSTANCE_TYPES = true`.