### PR TITLE
Fix DNS for isolated OVN networks

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2660,6 +2660,8 @@ func (n *ovn) setup(update bool) error {
 
 		if uplinkNet != nil {
 			opts.RecursiveDNSServer = uplinkNet.dnsIPv4
+		} else {
+			opts.RecursiveDNSServer = []net.IP{routerIntPortIPv4}
 		}
 
 		err = n.ovnnb.UpdateLogicalSwitchDHCPv4Options(context.TODO(), n.getIntSwitchName(), dhcpv4UUID, dhcpV4Subnet, opts)
@@ -2677,6 +2679,8 @@ func (n *ovn) setup(update bool) error {
 
 		if uplinkNet != nil {
 			opts.RecursiveDNSServer = uplinkNet.dnsIPv6
+		} else {
+			opts.RecursiveDNSServer = []net.IP{routerIntPortIPv6}
 		}
 
 		err = n.ovnnb.UpdateLogicalSwitchDHCPv6Options(context.TODO(), n.getIntSwitchName(), dhcpv6UUID, dhcpV6Subnet, opts)
@@ -2698,6 +2702,8 @@ func (n *ovn) setup(update bool) error {
 		var recursiveDNSServer net.IP
 		if uplinkNet != nil && len(uplinkNet.dnsIPv6) > 0 {
 			recursiveDNSServer = uplinkNet.dnsIPv6[0] // OVN only supports 1 RA DNS server.
+		} else {
+			recursiveDNSServer = routerIntPortIPv6
 		}
 
 		err = n.ovnnb.UpdateLogicalRouterPort(context.TODO(), n.getRouterIntPortName(), &networkOVN.OVNIPv6RAOpts{


### PR DESCRIPTION
Currently DHCP in OVN networks is configured to advertise the uplink DNS address, if an uplink exists. OVN networks with the `network=none` option don't get any DNS server over DHCP. 

Since OVN has its own DNS server, we can just use the OVN router IP. 

I don't understand why this isn't used in general, and how the uplink DNS even gets the correct information, but at least for isolated networks I think it makes sense to use OVN for the DNS server.