### PR TITLE
Add option to configure DNS server for bridge and OVN networks

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -226,6 +226,7 @@ qgroups
 RADOS
 RBAC
 RBD
+RDNSS
 README
 reconfiguring
 requestor

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2735,3 +2735,8 @@ This allows specifying pairs of CIDR networks and gateway address to be announce
 Adds a new `LogicalSwitch` field to the `NetworkStateOVN` struct which is part of the `GET /1.0/networks/NAME/state` API.
 
 This is used to get the OVN logical switch name.
+
+## `network_dns_nameservers`
+
+Introduces the `dns.nameservers` configuration option on bridged and OVN networks.
+This allows specifying IPv4 and IPv6 DNS server addresses to be announced by the DHCP server and via Router Advertisements.

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -64,6 +64,7 @@ Key                                  | Type      | Condition             | Defau
 `bridge.external_interfaces`         | string    | -                     | -                         | Comma-separated list of unconfigured network interfaces to include in the bridge
 `bridge.hwaddr`                      | string    | -                     | -                         | MAC address for the bridge
 `bridge.mtu`                         | integer   | -                     | `1500`                    | Bridge MTU (default varies if tunnel in use)
+`dns.nameservers`                    | string    | -                     | IPv4 and IPv6 address     | DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and IPv6 addresses are also advertised as RDNSS via RA.
 `dns.domain`                         | string    | -                     | `incus`                   | Domain to advertise to DHCP clients and use for DNS resolution
 `dns.mode`                           | string    | -                     | `managed`                 | DNS registration mode: `none` for no DNS record, `managed` for Incus-generated static records or `dynamic` for client-generated records
 `dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -45,6 +45,7 @@ Key                                  | Type      | Condition             | Defau
 `bridge.external_interfaces`         | string    | -                     | -                         | Comma-separated list of unconfigured network interfaces to include in the bridge
 `bridge.hwaddr`                      | string    | -                     | -                         | MAC address for the bridge
 `bridge.mtu`                         | integer   | -                     | `1442`                    | Bridge MTU (default allows host to host Geneve tunnels)
+`dns.nameservers`                    | string    | -                     | Uplink DNS servers (IPv4 and IPv6 address if no uplink is configured) | DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and the first IPv6 address is also advertised as RDNSS via RA.
 `dns.domain`                         | string    | -                     | `incus`                   | Domain to advertise to DHCP clients and use for DNS resolution
 `dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value
 `dns.zone.forward`                   | string    | -                     | -                         | Comma-separated list of DNS zone names for forward DNS records

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -1262,14 +1262,18 @@ func (o *NB) UpdateLogicalSwitchDHCPv4Options(ctx context.Context, switchName OV
 
 	if opts.Router != nil {
 		dhcpOption.Options["router"] = opts.Router.String()
+	} else {
+		delete(dhcpOption.Options, "router")
 	}
 
 	if len(opts.DNSSearchList) > 0 {
 		// Special quoting to allow domain names.
 		dhcpOption.Options["domain_search_list"] = fmt.Sprintf(`"%s"`, strings.Join(opts.DNSSearchList, ","))
+	} else {
+		delete(dhcpOption.Options, "domain_search_list")
 	}
 
-	if opts.RecursiveDNSServer != nil {
+	if len(opts.RecursiveDNSServer) > 0 {
 		nsIPs := make([]string, 0, len(opts.RecursiveDNSServer))
 		for _, nsIP := range opts.RecursiveDNSServer {
 			if nsIP.To4() == nil {
@@ -1280,19 +1284,27 @@ func (o *NB) UpdateLogicalSwitchDHCPv4Options(ctx context.Context, switchName OV
 		}
 
 		dhcpOption.Options["dns_server"] = fmt.Sprintf("{%s}", strings.Join(nsIPs, ","))
+	} else {
+		delete(dhcpOption.Options, "dns_server")
 	}
 
 	if opts.DomainName != "" {
 		// Special quoting to allow domain names.
 		dhcpOption.Options["domain_name"] = fmt.Sprintf(`"%s"`, opts.DomainName)
+	} else {
+		delete(dhcpOption.Options, "domain_name")
 	}
 
 	if opts.MTU > 0 {
 		dhcpOption.Options["mtu"] = fmt.Sprintf("%d", opts.MTU)
+	} else {
+		delete(dhcpOption.Options, "mtu")
 	}
 
 	if opts.Netmask != "" {
 		dhcpOption.Options["netmask"] = opts.Netmask
+	} else {
+		delete(dhcpOption.Options, "netmask")
 	}
 
 	if opts.StaticRoutes != "" {
@@ -1364,6 +1376,8 @@ func (o *NB) UpdateLogicalSwitchDHCPv6Options(ctx context.Context, switchName OV
 	if len(opts.DNSSearchList) > 0 {
 		// Special quoting to allow domain names.
 		dhcpOption.Options["domain_search"] = fmt.Sprintf(`"%s"`, strings.Join(opts.DNSSearchList, ","))
+	} else {
+		delete(dhcpOption.Options, "domain_search")
 	}
 
 	if opts.RecursiveDNSServer != nil {
@@ -1377,6 +1391,8 @@ func (o *NB) UpdateLogicalSwitchDHCPv6Options(ctx context.Context, switchName OV
 		}
 
 		dhcpOption.Options["dns_server"] = fmt.Sprintf("{%s}", strings.Join(nsIPs, ","))
+	} else {
+		delete(dhcpOption.Options, "dns_server")
 	}
 
 	// Prepare the changes.

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -468,6 +468,7 @@ var APIExtensions = []string{
 	"security_iommu",
 	"network_ipv4_dhcp_routes",
 	"network_state_ovn_ls",
+	"network_dns_nameservers",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds two options, `ipv4.dhcp.dns` and `ipv6.dhcp.dns` for both bridge and OVN networks. The values of these options are used as option 6 in dhcp4 and option 23 in dhcp6 respectively, i.e. advertising DNS servers to DHCP clients. The values in `ipv6.dhcp.dns` are also sent as RDNSS in router advertisements by dnsmasq on bridge interfaces, and the first value is configured for router advertisements in OVN (it only supports a single RDNSS value for RA).

If the options are not set, then the current behaviour (dnsmasq advertises itself and OVN networks use whatever their uplink provides) is used.