### PR TITLE
generate-database: Handle non tx DB connections

### DIFF
--- a/cmd/generate-database/db/constants.go
+++ b/cmd/generate-database/db/constants.go
@@ -8,4 +8,5 @@ var Imports = []string{
 	"database/sql",
 	"fmt",
 	"strings",
+	"github.com/mattn/go-sqlite3",
 }

--- a/internal/server/db/cluster/certificate_projects.mapper.go
+++ b/internal/server/db/cluster/certificate_projects.mapper.go
@@ -7,7 +7,10 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 var certificateProjectObjects = RegisterStmt(`
@@ -171,6 +174,13 @@ func CreateCertificateProjects(ctx context.Context, db dbtx, objects []Certifica
 
 		// Execute the statement.
 		_, err = stmt.Exec(args...)
+		var sqliteErr sqlite3.Error
+		if errors.As(err, &sqliteErr) {
+			if sqliteErr.Code == sqlite3.ErrConstraint {
+				return ErrConflict
+			}
+		}
+
 		if err != nil {
 			return fmt.Errorf("Failed to create \"certificates_projects\" entry: %w", err)
 		}

--- a/internal/server/db/cluster/certificate_projects.mapper.go
+++ b/internal/server/db/cluster/certificate_projects.mapper.go
@@ -96,6 +96,11 @@ func GetCertificateProjects(ctx context.Context, db dbtx, certificateID int) (_ 
 		_err = mapErr(_err, "Certificate_project")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return nil, fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	var err error
 
 	// Result slice.
@@ -159,6 +164,11 @@ func CreateCertificateProjects(ctx context.Context, db dbtx, objects []Certifica
 		_err = mapErr(_err, "Certificate_project")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	for _, object := range objects {
 		args := make([]any, 2)
 
@@ -196,6 +206,11 @@ func UpdateCertificateProjects(ctx context.Context, db dbtx, certificateID int, 
 	defer func() {
 		_err = mapErr(_err, "Certificate_project")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	// Delete current entry.
 	err := DeleteCertificateProjects(ctx, db, certificateID)

--- a/internal/server/db/cluster/cluster_groups.mapper.go
+++ b/internal/server/db/cluster/cluster_groups.mapper.go
@@ -349,6 +349,11 @@ func CreateClusterGroupConfig(ctx context.Context, db dbtx, clusterGroupID int64
 		_err = mapErr(_err, "Cluster_group")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	referenceID := int(clusterGroupID)
 	for key, value := range config {
 		insert := Config{

--- a/internal/server/db/cluster/cluster_groups.mapper.go
+++ b/internal/server/db/cluster/cluster_groups.mapper.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 var clusterGroupObjects = RegisterStmt(`
@@ -307,16 +309,6 @@ func CreateClusterGroup(ctx context.Context, db dbtx, object ClusterGroup) (_ in
 		_err = mapErr(_err, "Cluster_group")
 	}()
 
-	// Check if a cluster_group with the same key exists.
-	exists, err := ClusterGroupExists(ctx, db, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, ErrConflict
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -331,6 +323,13 @@ func CreateClusterGroup(ctx context.Context, db dbtx, object ClusterGroup) (_ in
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		if sqliteErr.Code == sqlite3.ErrConstraint {
+			return -1, ErrConflict
+		}
+	}
+
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"clusters_groups\" entry: %w", err)
 	}

--- a/internal/server/db/cluster/config.mapper.go
+++ b/internal/server/db/cluster/config.mapper.go
@@ -81,6 +81,11 @@ func GetConfig(ctx context.Context, db dbtx, parent string, filters ...ConfigFil
 		_err = mapErr(_err, "Config")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return nil, fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	var err error
 
 	// Result slice.
@@ -175,6 +180,11 @@ func UpdateConfig(ctx context.Context, db dbtx, parent string, referenceID int, 
 	defer func() {
 		_err = mapErr(_err, "Config")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	// Delete current entry.
 	err := DeleteConfig(ctx, db, parent, referenceID)

--- a/internal/server/db/cluster/devices.mapper.go
+++ b/internal/server/db/cluster/devices.mapper.go
@@ -81,6 +81,11 @@ func GetDevices(ctx context.Context, db dbtx, parent string, filters ...DeviceFi
 		_err = mapErr(_err, "Device")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return nil, fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	var err error
 
 	// Result slice.
@@ -175,6 +180,11 @@ func CreateDevices(ctx context.Context, db dbtx, parent string, objects map[stri
 		_err = mapErr(_err, "Device")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	deviceCreateLocal := strings.Replace(deviceCreate, "%s_id", fmt.Sprintf("%s_id", parent), -1)
 	fillParent := make([]any, strings.Count(deviceCreateLocal, "%s"))
 	for i := range fillParent {
@@ -217,6 +227,11 @@ func UpdateDevices(ctx context.Context, db dbtx, parent string, referenceID int,
 	defer func() {
 		_err = mapErr(_err, "Device")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	// Delete current entry.
 	err := DeleteDevices(ctx, db, parent, referenceID)

--- a/internal/server/db/cluster/instance_profiles.mapper.go
+++ b/internal/server/db/cluster/instance_profiles.mapper.go
@@ -7,7 +7,10 @@ package cluster
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 var instanceProfileObjects = RegisterStmt(`
@@ -192,6 +195,13 @@ func CreateInstanceProfiles(ctx context.Context, db dbtx, objects []InstanceProf
 
 		// Execute the statement.
 		_, err = stmt.Exec(args...)
+		var sqliteErr sqlite3.Error
+		if errors.As(err, &sqliteErr) {
+			if sqliteErr.Code == sqlite3.ErrConstraint {
+				return ErrConflict
+			}
+		}
+
 		if err != nil {
 			return fmt.Errorf("Failed to create \"instances_profiles\" entry: %w", err)
 		}

--- a/internal/server/db/cluster/instance_profiles.mapper.go
+++ b/internal/server/db/cluster/instance_profiles.mapper.go
@@ -49,6 +49,11 @@ func GetProfileInstances(ctx context.Context, db dbtx, profileID int) (_ []Insta
 		_err = mapErr(_err, "Instance_profile")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return nil, fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	var err error
 
 	// Result slice.
@@ -141,6 +146,11 @@ func GetInstanceProfiles(ctx context.Context, db dbtx, instanceID int) (_ []Prof
 		_err = mapErr(_err, "Instance_profile")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return nil, fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	var err error
 
 	// Result slice.
@@ -178,6 +188,11 @@ func CreateInstanceProfiles(ctx context.Context, db dbtx, objects []InstanceProf
 	defer func() {
 		_err = mapErr(_err, "Instance_profile")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	for _, object := range objects {
 		args := make([]any, 3)

--- a/internal/server/db/cluster/instances.mapper.go
+++ b/internal/server/db/cluster/instances.mapper.go
@@ -855,6 +855,11 @@ func CreateInstanceDevices(ctx context.Context, db dbtx, instanceID int64, devic
 		_err = mapErr(_err, "Instance")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	for key, device := range devices {
 		device.ReferenceID = int(instanceID)
 		devices[key] = device
@@ -874,6 +879,11 @@ func CreateInstanceConfig(ctx context.Context, db dbtx, instanceID int64, config
 	defer func() {
 		_err = mapErr(_err, "Instance")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	referenceID := int(instanceID)
 	for key, value := range config {

--- a/internal/server/db/cluster/networks_integrations.mapper.go
+++ b/internal/server/db/cluster/networks_integrations.mapper.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 var networkIntegrationObjects = RegisterStmt(`
@@ -283,16 +285,6 @@ func CreateNetworkIntegration(ctx context.Context, db dbtx, object NetworkIntegr
 		_err = mapErr(_err, "Network_integration")
 	}()
 
-	// Check if a network_integration with the same key exists.
-	exists, err := NetworkIntegrationExists(ctx, db, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, ErrConflict
-	}
-
 	args := make([]any, 3)
 
 	// Populate the statement arguments.
@@ -308,6 +300,13 @@ func CreateNetworkIntegration(ctx context.Context, db dbtx, object NetworkIntegr
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		if sqliteErr.Code == sqlite3.ErrConstraint {
+			return -1, ErrConflict
+		}
+	}
+
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"networks_integrations\" entry: %w", err)
 	}

--- a/internal/server/db/cluster/networks_integrations.mapper.go
+++ b/internal/server/db/cluster/networks_integrations.mapper.go
@@ -326,6 +326,11 @@ func CreateNetworkIntegrationConfig(ctx context.Context, db dbtx, networkIntegra
 		_err = mapErr(_err, "Network_integration")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	referenceID := int(networkIntegrationID)
 	for key, value := range config {
 		insert := Config{

--- a/internal/server/db/cluster/profiles.mapper.go
+++ b/internal/server/db/cluster/profiles.mapper.go
@@ -446,6 +446,11 @@ func CreateProfileDevices(ctx context.Context, db dbtx, profileID int64, devices
 		_err = mapErr(_err, "Profile")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	for key, device := range devices {
 		device.ReferenceID = int(profileID)
 		devices[key] = device
@@ -465,6 +470,11 @@ func CreateProfileConfig(ctx context.Context, db dbtx, profileID int64, config m
 	defer func() {
 		_err = mapErr(_err, "Profile")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	referenceID := int(profileID)
 	for key, value := range config {

--- a/internal/server/db/cluster/projects.mapper.go
+++ b/internal/server/db/cluster/projects.mapper.go
@@ -325,6 +325,11 @@ func CreateProjectConfig(ctx context.Context, db dbtx, projectID int64, config m
 		_err = mapErr(_err, "Project")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	referenceID := int(projectID)
 	for key, value := range config {
 		insert := Config{

--- a/internal/server/db/cluster/projects.mapper.go
+++ b/internal/server/db/cluster/projects.mapper.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 var projectObjects = RegisterStmt(`
@@ -283,16 +285,6 @@ func CreateProject(ctx context.Context, db dbtx, object Project) (_ int64, _err 
 		_err = mapErr(_err, "Project")
 	}()
 
-	// Check if a project with the same key exists.
-	exists, err := ProjectExists(ctx, db, object.Name)
-	if err != nil {
-		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
-	}
-
-	if exists {
-		return -1, ErrConflict
-	}
-
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
@@ -307,6 +299,13 @@ func CreateProject(ctx context.Context, db dbtx, object Project) (_ int64, _err 
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		if sqliteErr.Code == sqlite3.ErrConstraint {
+			return -1, ErrConflict
+		}
+	}
+
 	if err != nil {
 		return -1, fmt.Errorf("Failed to create \"projects\" entry: %w", err)
 	}

--- a/internal/server/db/cluster/snapshots.mapper.go
+++ b/internal/server/db/cluster/snapshots.mapper.go
@@ -418,6 +418,11 @@ func CreateInstanceSnapshotDevices(ctx context.Context, db dbtx, instanceSnapsho
 		_err = mapErr(_err, "Instance_snapshot")
 	}()
 
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
+
 	for key, device := range devices {
 		device.ReferenceID = int(instanceSnapshotID)
 		devices[key] = device
@@ -437,6 +442,11 @@ func CreateInstanceSnapshotConfig(ctx context.Context, db dbtx, instanceSnapshot
 	defer func() {
 		_err = mapErr(_err, "Instance_snapshot")
 	}()
+
+	_, ok := db.(interface{ Commit() error })
+	if !ok {
+		return fmt.Errorf("Committable DB connection (transaction) required")
+	}
 
 	referenceID := int(instanceSnapshotID)
 	for key, value := range config {


### PR DESCRIPTION
* Handle constraint error in Create methods
* Ensure a commit-able db connection (DB transaction) is passed to methods which perform multiple DB operations.