### PR TITLE
incus file edit extension

### DIFF
--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -412,7 +412,7 @@ func (c *cmdFileEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create temp file
-	f, err := os.CreateTemp("", "incus_file_edit_")
+	f, err := os.CreateTemp("", fmt.Sprintf("incus_file_edit_*%s", filepath.Ext(args[0])))
 	if err != nil {
 		return fmt.Errorf(i18n.G("Unable to create a temporary file: %v"), err)
 	}


### PR DESCRIPTION
Changes the `incus file edit` command to use the file extension of the edited file for the temp file, if there is any, so that editors can deduce the file type from it and use correct syntax highlighting.