### PR TITLE
Add project support to storage pools in preseed init

### DIFF
--- a/cmd/incus/admin_init_auto.go
+++ b/cmd/incus/admin_init_auto.go
@@ -106,7 +106,10 @@ func (c *cmdAdminInit) RunAuto(cmd *cobra.Command, args []string, d incus.Instan
 			pool.Name = c.flagStoragePool
 		}
 
-		config.StoragePools = []api.StoragePoolsPost{pool}
+		config.StoragePools = []api.InitStoragePoolsProjectPost{{
+			StoragePoolsPost: pool,
+			Project:          api.ProjectDefaultName,
+		}}
 
 		// Profile entry
 		config.Profiles = []api.InitProfileProjectPost{{

--- a/cmd/incus/admin_init_dump.go
+++ b/cmd/incus/admin_init_dump.go
@@ -55,6 +55,7 @@ func (c *cmdAdminInit) RunDump(d incus.InstanceServer) error {
 		storagePoolsPost.Description = storagePool.Description
 		storagePoolsPost.Name = storagePool.Name
 		storagePoolsPost.Driver = storagePool.Driver
+		storagePoolsPost.Project = api.ProjectDefaultName
 
 		config.StoragePools = append(config.StoragePools, storagePoolsPost)
 	}

--- a/cmd/incus/admin_init_dump.go
+++ b/cmd/incus/admin_init_dump.go
@@ -50,7 +50,7 @@ func (c *cmdAdminInit) RunDump(d incus.InstanceServer) error {
 	}
 
 	for _, storagePool := range storagePools {
-		storagePoolsPost := api.StoragePoolsPost{}
+		storagePoolsPost := api.InitStoragePoolsProjectPost{}
 		storagePoolsPost.Config = storagePool.Config
 		storagePoolsPost.Description = storagePool.Description
 		storagePoolsPost.Name = storagePool.Name

--- a/cmd/incus/admin_init_interactive.go
+++ b/cmd/incus/admin_init_interactive.go
@@ -35,7 +35,7 @@ func (c *cmdAdminInit) RunInteractive(cmd *cobra.Command, args []string, d incus
 	config := api.InitPreseed{}
 	config.Server.Config = map[string]string{}
 	config.Server.Networks = []api.InitNetworksProjectPost{}
-	config.Server.StoragePools = []api.StoragePoolsPost{}
+	config.Server.StoragePools = []api.InitStoragePoolsProjectPost{}
 	config.Server.Profiles = []api.InitProfileProjectPost{
 		{
 			ProfilesPost: api.ProfilesPost{
@@ -574,7 +574,7 @@ func (c *cmdAdminInit) askStoragePool(config *api.InitPreseed, d incus.InstanceS
 				pool.Config["source"] = source
 			}
 
-			config.Server.StoragePools = append(config.Server.StoragePools, pool)
+			config.Server.StoragePools = append(config.Server.StoragePools, api.InitStoragePoolsProjectPost{StoragePoolsPost: pool})
 			break
 		}
 
@@ -587,7 +587,7 @@ func (c *cmdAdminInit) askStoragePool(config *api.InitPreseed, d incus.InstanceS
 
 			if btrfsSubvolume {
 				pool.Config["source"] = internalUtil.VarPath("storage-pools", pool.Name)
-				config.Server.StoragePools = append(config.Server.StoragePools, pool)
+				config.Server.StoragePools = append(config.Server.StoragePools, api.InitStoragePoolsProjectPost{StoragePoolsPost: pool})
 				break
 			}
 		}
@@ -603,7 +603,7 @@ func (c *cmdAdminInit) askStoragePool(config *api.InitPreseed, d incus.InstanceS
 
 				if zfsDataset {
 					pool.Config["source"] = "rpool/incus"
-					config.Server.StoragePools = append(config.Server.StoragePools, pool)
+					config.Server.StoragePools = append(config.Server.StoragePools, api.InitStoragePoolsProjectPost{StoragePoolsPost: pool})
 					break
 				}
 			}
@@ -758,7 +758,7 @@ and make sure that your user can see and run the "thin_check" command before run
 			}
 		}
 
-		config.Server.StoragePools = append(config.Server.StoragePools, pool)
+		config.Server.StoragePools = append(config.Server.StoragePools, api.InitStoragePoolsProjectPost{StoragePoolsPost: pool})
 		break
 	}
 

--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -946,7 +946,10 @@ func clusterInitMember(d incus.InstanceServer, client incus.InstanceServer, memb
 			post.Config[config.Key] = config.Value
 		}
 
-		data.StoragePools = append(data.StoragePools, post)
+		data.StoragePools = append(data.StoragePools, api.InitStoragePoolsProjectPost{
+			StoragePoolsPost: post,
+			Project:          api.ProjectDefaultName,
+		})
 	}
 
 	projects, err := client.GetProjects()

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1268,7 +1268,7 @@ definitions:
                 description: Storage Pools to add
                 example: local dir storage pool
                 items:
-                    $ref: '#/definitions/StoragePoolsPost'
+                    $ref: '#/definitions/InitStoragePoolsProjectPost'
                 type: array
                 x-go-name: StoragePools
             storage_volumes:
@@ -1367,6 +1367,39 @@ definitions:
                 type: string
                 x-go-name: Name
         title: InitProfileProjectPost represents the fields of a new profile along with its associated project.
+        type: object
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    InitStoragePoolsProjectPost:
+        properties:
+            Project:
+                description: Project in which the network will reside
+                example: '"default"'
+                type: string
+            config:
+                additionalProperties:
+                    type: string
+                description: Storage pool configuration map (refer to doc/storage.md)
+                example:
+                    volume.block.filesystem: ext4
+                    volume.size: 50GiB
+                type: object
+                x-go-name: Config
+            description:
+                description: Description of the storage pool
+                example: Local SSD pool
+                type: string
+                x-go-name: Description
+            driver:
+                description: Storage pool driver (btrfs, ceph, cephfs, cephobject, dir, lvm, lvmcluster or zfs)
+                example: zfs
+                type: string
+                x-go-name: Driver
+            name:
+                description: Storage pool name
+                example: local
+                type: string
+                x-go-name: Name
+        title: InitStoragePoolsProjectPost represents the fields of a new storage pool along with its associated project.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     InitStorageVolumesProjectPost:

--- a/shared/api/init.go
+++ b/shared/api/init.go
@@ -24,7 +24,7 @@ type InitLocalPreseed struct {
 
 	// Storage Pools to add
 	// Example: local dir storage pool
-	StoragePools []StoragePoolsPost `json:"storage_pools" yaml:"storage_pools"`
+	StoragePools []InitStoragePoolsProjectPost `json:"storage_pools" yaml:"storage_pools"`
 
 	// Storage Volumes to add
 	// Example: local dir storage volume
@@ -39,6 +39,19 @@ type InitLocalPreseed struct {
 	// Projects to add
 	// Example: "default" project
 	Projects []ProjectsPost `json:"projects" yaml:"projects"`
+}
+
+// InitStoragePoolsProjectPost represents the fields of a new storage pool along with its associated project.
+//
+// swagger:model
+//
+// API extension: preseed.
+type InitStoragePoolsProjectPost struct {
+	StoragePoolsPost `yaml:",inline"`
+
+	// Project in which the network will reside
+	// Example: "default"
+	Project string
 }
 
 // InitNetworksProjectPost represents the fields of a new network along with its associated project.


### PR DESCRIPTION
### Add project support to storage pools in preseed init.

This allow to initialize `incus` with storage pools for different projects.
