### PR TITLE
make `incus copy --device xx,type=none` drop remaining device properties

### DIFF
--- a/cmd/incus/copy.go
+++ b/cmd/incus/copy.go
@@ -206,6 +206,12 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 				continue
 			}
 
+			if m["type"] == "none" {
+				// When overriding with "none" type, clear the entire device.
+				entry.Devices[k] = map[string]string{"type": "none"}
+				continue
+			}
+
 			for key, value := range m {
 				entry.Devices[k][key] = value
 			}
@@ -295,6 +301,12 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		for k, m := range deviceMap {
 			if entry.Devices[k] == nil {
 				entry.Devices[k] = m
+				continue
+			}
+
+			if m["type"] == "none" {
+				// When overriding with "none" type, clear the entire device.
+				entry.Devices[k] = map[string]string{"type": "none"}
 				continue
 			}
 


### PR DESCRIPTION
Addresses topic discussed in #1751 - makes `type=none` drop any further device properties, except for type=none itself.