### PR TITLE
Handle live migration between QEMU versions

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1458,6 +1458,12 @@ The instance generation UUID changes whenever the instance's place in time moves
 It is globally unique across all servers and projects.
 ```
 
+```{config:option} volatile.vm.definition instance-volatile
+:shortdesc: "QEMU VM definition name (used for migration between versions)"
+:type: "string"
+
+```
+
 ```{config:option} volatile.vsock_id instance-volatile
 :shortdesc: "Instance `vsock ID` used as of last start"
 :type: "string"

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -1089,6 +1089,13 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  shortdesc: Whether to regenerate VM NVRAM the next time the instance starts
 	"volatile.apply_nvram": validate.Optional(validate.IsBool),
 
+	// gendoc:generate(entity=instance, group=volatile, key=volatile.vm.definition)
+	//
+	// ---
+	//  type: string
+	//  shortdesc: QEMU VM definition name (used for migration between versions)
+	"volatile.vm.definition": validate.Optional(validate.IsAny),
+
 	// gendoc:generate(entity=instance, group=volatile, key=volatile.vsock_id)
 	//
 	// ---

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1572,8 +1572,14 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		cpuType += "," + strings.Join(cpuExtensions, ",")
 	}
 
+	// Provide machine definition when restoring state.
+	var machineDefinition string
+	if stateful {
+		machineDefinition = d.localConfig["volatile.vm.definition"]
+	}
+
 	// Generate the QEMU configuration.
-	monHooks, err := d.generateQemuConfig(cpuInfo, mountInfo, qemuBus, vsockFD, devConfs, &fdFiles)
+	monHooks, err := d.generateQemuConfig(machineDefinition, cpuInfo, mountInfo, qemuBus, vsockFD, devConfs, &fdFiles)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -1822,6 +1828,23 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	if err != nil {
 		op.Done(err)
 		return err
+	}
+
+	// Record the QEMU machine definition.
+	if !stateful {
+		definition, err := monitor.MachineDefinition()
+		if err != nil {
+			op.Done(err)
+			return err
+		}
+
+		err = d.VolatileSet(map[string]string{
+			"volatile.vm.definition": definition,
+		})
+		if err != nil {
+			op.Done(err)
+			return err
+		}
 	}
 
 	// Don't allow the monitor to trigger a disconnection shutdown event until cleanly started so that the
@@ -3351,11 +3374,11 @@ func (d *qemu) isWindows() bool {
 }
 
 // generateQemuConfig generates the QEMU configuration.
-func (d *qemu) generateQemuConfig(cpuInfo *cpuTopology, mountInfo *storagePools.MountInfo, busName string, vsockFD int, devConfs []*deviceConfig.RunConfig, fdFiles *[]*os.File) ([]monitorHook, error) {
+func (d *qemu) generateQemuConfig(machineDefinition string, cpuInfo *cpuTopology, mountInfo *storagePools.MountInfo, busName string, vsockFD int, devConfs []*deviceConfig.RunConfig, fdFiles *[]*os.File) ([]monitorHook, error) {
 	var monHooks []monitorHook
 
 	isWindows := d.isWindows()
-	conf := qemuBase(&qemuBaseOpts{d.Architecture(), util.IsTrue(d.expandedConfig["security.iommu"])})
+	conf := qemuBase(&qemuBaseOpts{d.Architecture(), util.IsTrue(d.expandedConfig["security.iommu"]), machineDefinition})
 
 	err := d.addCPUMemoryConfig(&conf, cpuInfo)
 	if err != nil {

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -52,6 +52,7 @@ func qemuMachineType(architecture int) string {
 type qemuBaseOpts struct {
 	architecture int
 	iommu        bool
+	definition   string
 }
 
 func qemuBase(opts *qemuBaseOpts) []cfg.Section {
@@ -64,6 +65,10 @@ func qemuBase(opts *qemuBaseOpts) []cfg.Section {
 		gicVersion = "max"
 	case osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
 		capLargeDecr = "off"
+	}
+
+	if opts.definition != "" {
+		machineType = opts.definition
 	}
 
 	sections := []cfg.Section{{

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -144,6 +144,31 @@ func (m *Monitor) Status() (string, error) {
 	return resp.Return.Status, nil
 }
 
+// MachineDefinition returns the current QEMU machine definition name.
+func (m *Monitor) MachineDefinition() (string, error) {
+	// Prepare the request.
+	var req struct {
+		Path     string `json:"path"`
+		Property string `json:"property"`
+	}
+
+	req.Path = "/machine"
+	req.Property = "type"
+
+	// Prepare the response.
+	var resp struct {
+		Return string `json:"return"`
+	}
+
+	// Query the machine.
+	err := m.Run("qom-get", req, &resp)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(resp.Return, "-machine"), nil
+}
+
 // SendFile adds a new file descriptor to the QMP fd table associated to name.
 func (m *Monitor) SendFile(name string, file *os.File) error {
 	// Check if disconnected.

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1590,6 +1590,13 @@
 						}
 					},
 					{
+						"volatile.vm.definition": {
+							"longdesc": "",
+							"shortdesc": "QEMU VM definition name (used for migration between versions)",
+							"type": "string"
+						}
+					},
+					{
 						"volatile.vsock_id": {
 							"longdesc": "",
 							"shortdesc": "Instance `vsock ID` used as of last start",


### PR DESCRIPTION
When live-migrating to a newer QEMU, the base `q35` definition is likely to have evolved.
QEMU requires the source and target machine definition to match up, so keep track of the machine definition in a volatile key and ensure that the target starts with the correct machine definition.