### PR TITLE
client: Fix spelling errors found by codespell

### DIFF
--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -466,7 +466,7 @@ func (r *ProtocolIncus) GetInstanceFull(name string) (*api.InstanceFull, string,
 	instance := api.InstanceFull{}
 
 	if !r.HasExtension("instance_get_full") {
-		// Backware compatibility.
+		// Backward compatibility.
 		ct, _, err := r.GetInstance(name)
 		if err != nil {
 			return nil, "", err

--- a/client/incus_server.go
+++ b/client/incus_server.go
@@ -313,7 +313,7 @@ func (r *ProtocolIncus) ApplyServerPreseed(config api.InitPreseed) error {
 	// Apply networks in the default project before other projects config applied (so that if the projects
 	// depend on a network in the default project they can have their config applied successfully).
 	for i := range config.Server.Networks {
-		// Populate default project if not specified for backwards compatbility with earlier
+		// Populate default project if not specified for backwards compatibility with earlier
 		// preseed dump files.
 		if config.Server.Networks[i].Project == "" {
 			config.Server.Networks[i].Project = api.ProjectDefaultName

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -110,7 +110,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 
 		size, err := util.DownloadFileHash(context.TODO(), &httpClient, r.httpUserAgent, req.ProgressHandler, req.Canceler, filename, uri, hash, sha256.New(), target)
 		if err != nil {
-			// Handle cancelation
+			// Handle cancellation
 			if err.Error() == "net/http: request canceled" {
 				return -1, err
 			}


### PR DESCRIPTION
My plan is to fix all the reported errors and then add `codespell` to `static-analysis`; like any such tool it's imperfect, but I've generally found its maintainers to have pretty good judgement.  This is just a small initial PR to check that you're OK with using it in principle; if so then I'll send a larger PR (~2500 lines) to fix all the remaining errors and enable it as part of `make static-analysis`.  (If you'd rather not have it as an explicit lint step, then I guess most of the typos will be worth fixing anyway, so I can still send those.)