### PR TITLE
incus/file: Properly handle relative source paths

### DIFF
--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -1180,8 +1180,14 @@ func (c *cmdFile) recursivePullFile(sftpConn *sftp.Client, p string, targetDir s
 
 func (c *cmdFile) recursivePushFile(sftpConn *sftp.Client, source string, target string) error {
 	source = filepath.Clean(source)
+
 	sourceDir, _ := filepath.Split(source)
 	sourceLen := len(sourceDir)
+
+	// Special handling for relative paths.
+	if source == ".." {
+		sourceLen = 1
+	}
 
 	sendFile := func(p string, fInfo os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
Not too sure why we were using Split rather than Dir given we were discarding the Base part of the path. But it looks like Split gets a bit confused by relative parent paths (..) whereas Dir doesn't.

Closes #1808