### PR TITLE
cmd/storage:  incorrect CLI syntax in storage pool creation examples

### DIFF
--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -101,9 +101,9 @@ func (c *cmdStorageCreate) Command() *cobra.Command {
 	cmd.Short = i18n.G("Create storage pools")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create storage pools`))
-	cmd.Example = cli.FormatSection("", i18n.G(`incus create storage s1 dir
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage create s1 dir
 
-incus create storage s1 dir < config.yaml
+incus storage create s1 dir < config.yaml
     Create a storage pool using the content of config.yaml.
 	`))
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -628,12 +628,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, quelle=%q)"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -791,7 +791,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1204,8 +1204,8 @@ msgstr ""
 "Ungültige Gerätüberschreibungs-Syntax, erwartet wird <Gerät>,"
 "<Schlüssel>=<Wert>: %s"
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1562,12 +1562,12 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1576,16 +1576,16 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1604,17 +1604,17 @@ msgstr "Clustering aktiviert"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1676,12 +1676,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
@@ -2030,15 +2031,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -2209,64 +2210,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2279,13 +2274,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2333,19 +2334,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2474,7 +2475,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2754,17 +2755,18 @@ msgstr "Alternatives config Verzeichnis."
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2835,13 +2837,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2858,13 +2860,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Fehler beim Löschen der Parameter: %v"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Fehler beim Löschen des Parameters: %v"
@@ -3098,8 +3100,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 #, fuzzy
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -3113,12 +3115,12 @@ msgstr "ZUERST BEOBACHTET"
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, fuzzy, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "SSH handshake mit Client %q gescheitert: %v"
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -3133,12 +3135,12 @@ msgstr "Check ob Instanz existiert fehlgeschlagen \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3168,7 +3170,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3208,7 +3210,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3223,12 +3225,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3337,12 +3339,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3440,7 +3442,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to update cluster member state: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3469,7 +3471,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -3562,16 +3564,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3864,22 +3866,22 @@ msgstr "Name"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4121,12 +4123,12 @@ msgstr ""
 msgid "Instance description"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -4140,7 +4142,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4244,7 +4246,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -4369,8 +4371,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5286,12 +5288,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5313,7 +5315,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5769,15 +5771,15 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing network integration name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5819,24 +5821,24 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5918,7 +5920,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5983,13 +5985,14 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6467,8 +6470,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6504,7 +6507,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Administrator Passwort für %s: "
@@ -6593,7 +6596,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6601,13 +6604,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6803,7 +6807,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -7242,17 +7246,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -7379,7 +7383,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7707,7 +7711,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -8219,12 +8223,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -8232,12 +8236,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8694,8 +8698,8 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8731,24 +8735,25 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -9316,7 +9321,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -9808,7 +9813,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -9931,9 +9936,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -10136,8 +10141,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10725,15 +10730,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -10763,7 +10759,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -11183,6 +11179,21 @@ msgstr ""
 "    Zeigt die Eigenschaften eines storage bucket namens \"data\" im pool "
 "\"default\"."
 
+#: cmd/incus/storage.go:104
+#, fuzzy
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+"incus storage volume create p1 v1\n"
+"\n"
+"incus storage volume create p1 v1 < config.yaml\n"
+"\tErstellt ein storage volume mit dem Namen \"v1\" im pool \"p1\" mit den "
+"Konfigurationsdetails aus der Datei \"config.yaml\"."
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -11343,16 +11354,16 @@ msgstr "bitte nutzen Sie ìncus profile`"
 msgid "space used"
 msgstr "Speicherplatz in Benutzung"
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr "sshfs wurde gestoppt"
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs mounted %q auf %q"
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs wurde nicht gefunden. Versuchen Sie stattdessen SSH SFTP Modus mit dem "
@@ -11421,19 +11432,6 @@ msgstr "ja"
 #~ "Provide the type of the storage volume if it is not custom.\n"
 #~ "Supported types are custom, image, container and virtual-machine."
 #~ msgstr "Profil %s erstellt\n"
-
-#~ msgid ""
-#~ "incus storage volume create p1 v1\n"
-#~ "\n"
-#~ "incus storage volume create p1 v1 < config.yaml\n"
-#~ "\tCreate storage volume v1 for pool p1 with configuration from "
-#~ "config.yaml."
-#~ msgstr ""
-#~ "incus storage volume create p1 v1\n"
-#~ "\n"
-#~ "incus storage volume create p1 v1 < config.yaml\n"
-#~ "\tErstellt ein storage volume mit dem Namen \"v1\" im pool \"p1\" mit den "
-#~ "Konfigurationsdetails aus der Datei \"config.yaml\"."
 
 #, fuzzy
 #~ msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -623,12 +623,12 @@ msgstr "%s (%d más)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -778,7 +778,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1151,8 +1151,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1500,12 +1500,12 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1514,16 +1514,16 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1542,17 +1542,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1606,12 +1606,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1945,15 +1946,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -2121,64 +2122,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2191,13 +2186,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2245,19 +2246,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2376,7 +2377,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2643,17 +2644,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2719,13 +2721,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2742,13 +2744,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2928,8 +2930,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -2941,12 +2943,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2961,12 +2963,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2996,7 +2998,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -3036,7 +3038,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -3051,12 +3053,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -3165,12 +3167,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3268,7 +3270,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3297,7 +3299,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -3387,16 +3389,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3681,22 +3683,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3937,11 +3939,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance description"
 msgstr "Descripción"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3956,7 +3958,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4058,7 +4060,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -4178,8 +4180,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5091,12 +5093,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5116,7 +5118,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5547,15 +5549,15 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing network integration name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5597,24 +5599,24 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5693,7 +5695,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -5755,13 +5757,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6227,8 +6230,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6264,7 +6267,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Contraseña admin para %s:"
@@ -6351,7 +6354,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6359,13 +6362,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6556,7 +6560,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6984,17 +6988,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7111,7 +7115,7 @@ msgstr "Perfil %s creado"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7427,7 +7431,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7919,12 +7923,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7932,11 +7936,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8386,8 +8390,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8422,24 +8426,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8977,7 +8982,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -9275,7 +9280,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9349,9 +9354,9 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -9485,8 +9490,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9889,15 +9894,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9927,7 +9923,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -10255,6 +10251,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -10384,16 +10389,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -634,12 +634,12 @@ msgstr "%s (%s) (%d disponible)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (principal=%q, source=%q)"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge"
@@ -783,7 +783,7 @@ msgstr "Vous devez fournir le nom d'un membre appartenant à un cluster"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1180,8 +1180,8 @@ msgstr ""
 "Mauvais appareil remplacez la syntaxe, syntaxe attendue <appareil>,"
 "<clé>=<valeur>: %s"
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1537,12 +1537,12 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1551,16 +1551,16 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1579,17 +1579,17 @@ msgstr "Clustering activé"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1649,12 +1649,13 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -2036,15 +2037,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "ADRESSE CIBLE PAR DÉFAUT"
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2222,64 +2223,58 @@ msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2292,13 +2287,19 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2346,19 +2347,19 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2482,7 +2483,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr "Dossier dans lequel exécuter la commande (/root par défaut)"
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 "Désactivez l'authentification lorsque vous utilisez SSH SFTP en mode écoute"
@@ -2760,17 +2761,18 @@ msgstr "Clé de configuration invalide"
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2853,13 +2855,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "Erreur lors de la récupération des alias : %w"
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2876,13 +2878,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
@@ -3126,8 +3128,8 @@ msgstr "DOMAINE D'ÉCHEC"
 msgid "FILENAME"
 msgstr "NOM"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -3140,12 +3142,12 @@ msgstr "PREMIÈRE VUE"
 msgid "FQDN"
 msgstr "FQDN (nom de domaine pleinement qualifié)"
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "Échec de l'authentification SSH avec le client %q : %v"
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "Échec de l'acceptation du canal client %q : %v"
@@ -3162,12 +3164,12 @@ msgstr ""
 "Échec de la vérification de l'existence de l'instantané d'instance \"%s:"
 "%s\" : %w"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "Échec de la connexion au SFTP de l'instance pour le client %q : %v"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Échec de la connexion au SFTP de l'instance : %w"
@@ -3200,7 +3202,7 @@ msgstr "Échec de la suppression de l'instance %q dans le projet %q : %w"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Échec de la suppression du volume source après la copie : %w"
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec de la génération de la clé hôte SSH : %w"
@@ -3241,7 +3243,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec du chargement du pool de stockage %q : %w"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec de l'analyse de la clé d'hôte SSH : %w"
@@ -3256,12 +3258,12 @@ msgstr "Échec de l'analyse de la réponse de validation : %w"
 msgid "Failed starting command: %w"
 msgstr "Échec de l'exécution de la commande : %w"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec du démarrage de sshfs : %w"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec de l'acceptation de la connexion entrante : %w"
@@ -3373,12 +3375,12 @@ msgstr "Échec de la recherche du projet : %w"
 msgid "Failed to join cluster: %w"
 msgstr "Échec de l'adhésion au cluster : %w"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec de la mise en écoute des demandes de connexion : %w"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, fuzzy, c-format
 msgid "Failed to load configuration: %s"
 msgstr "Échec du chargement de la configuration : %s"
@@ -3479,7 +3481,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr "Échec de la mise à jour de l'état du membre du cluster : %w"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "Échec du parcours des fichiers du répertoire %s : %s"
@@ -3509,7 +3511,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Fetch instance backup file: %w"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr "Le filtrage n'est pas encore pris en charge"
@@ -3624,16 +3626,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3935,22 +3937,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "La copie d'E/S de SSH vers l'instance a échoué : %v"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "La copie d'E/S de l'instance vers SSH a échoué : %v"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "La copie d'E/S de l'instance vers sshfs a échoué : %v"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "La copie d'E/S de sshfs vers l'instance a échoué : %v"
@@ -4212,12 +4214,12 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance description"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "Instance déconnectée pour le client %q"
@@ -4232,7 +4234,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 #, fuzzy
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -4340,7 +4342,7 @@ msgstr "Entrée invalide, veuillez entrer un entier positif"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -4466,8 +4468,8 @@ msgstr "LIMITE"
 msgid "LISTEN ADDRESS"
 msgstr "ADRESSE D’ÉCOUTE"
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5443,12 +5445,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5470,7 +5472,7 @@ msgstr "Création du conteneur"
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5920,15 +5922,15 @@ msgstr "Nom du réseau"
 msgid "Missing network integration name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5971,24 +5973,24 @@ msgstr "Nom du réseau"
 msgid "Missing peer name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -6073,7 +6075,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -6138,13 +6140,14 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr "NOM"
 
@@ -6634,8 +6637,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6672,7 +6675,7 @@ msgstr "Options :"
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Mot de passe administrateur pour %s : "
@@ -6760,7 +6763,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6768,13 +6771,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -6970,7 +6974,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -7429,17 +7433,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -7563,7 +7567,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7892,7 +7896,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -8412,12 +8416,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -8426,11 +8430,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8899,8 +8903,8 @@ msgstr "Création du conteneur"
 msgid "USB devices:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8936,24 +8940,25 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -9519,7 +9524,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -10029,7 +10034,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10170,9 +10175,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -10375,8 +10380,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10995,15 +11000,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -11033,7 +11029,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -11383,6 +11379,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -11513,16 +11518,16 @@ msgstr "veuillez utiliser `incus profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr "sshfs s'est arrêté"
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs monté %q sur %q"
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs non trouvé. Essayez le mode SSH SFTP en utilisant l'option --listen"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -386,12 +386,12 @@ msgstr "%s (%s) (%d tersedia)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, sumber=%q)"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s bukan direktori"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' bukan tipe berkas yang didukung"
@@ -531,7 +531,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr "ALAMAT"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -895,8 +895,8 @@ msgstr "Cadangan:"
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1237,12 +1237,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1251,16 +1251,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1279,17 +1279,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Kolom"
 
@@ -1339,12 +1339,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1666,15 +1667,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "DESKRIPSI"
 
@@ -1831,64 +1832,58 @@ msgid "Delete warning"
 msgstr "Hapus peringatan"
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -1901,13 +1896,19 @@ msgstr "Hapus peringatan"
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -1955,19 +1956,19 @@ msgstr "Hapus peringatan"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2081,7 +2082,7 @@ msgstr "Impor direktori tidak tersedia di platform ini"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "Nonaktifkan autentikasi saat menggunakan pendengar SSH SFTP"
 
@@ -2335,17 +2336,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2411,13 +2413,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2434,13 +2436,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2613,8 +2615,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NAMA_BERKAS"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr "SIDIKJARI"
 
@@ -2626,12 +2628,12 @@ msgstr "PERTAMA TERLIHAT"
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2646,12 +2648,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2681,7 +2683,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2721,7 +2723,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2736,12 +2738,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2850,12 +2852,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2953,7 +2955,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2982,7 +2984,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3071,16 +3073,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3343,22 +3345,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3590,11 +3592,11 @@ msgstr ""
 msgid "Instance description"
 msgstr "deskripsi"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3608,7 +3610,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3708,7 +3710,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3824,8 +3826,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -4721,12 +4723,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -4746,7 +4748,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5152,15 +5154,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5199,24 +5201,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5290,7 +5292,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5350,13 +5352,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -5820,8 +5823,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -5857,7 +5860,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5943,7 +5946,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5951,13 +5954,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6144,7 +6148,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6552,17 +6556,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6676,7 +6680,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6977,7 +6981,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7451,12 +7455,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7464,11 +7468,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7915,8 +7919,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -7950,24 +7954,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8479,7 +8484,7 @@ msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>] [<path>]"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -8722,7 +8727,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8782,9 +8787,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8895,8 +8900,8 @@ msgstr "[<remote>:]<jaringan> [kunci=nilai...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operasi>"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
@@ -9244,15 +9249,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9282,7 +9278,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9610,6 +9606,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -9739,16 +9744,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2025-03-18 14:07+0000\n"
+        "POT-Creation-Date: 2025-03-18 20:18-0300\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -360,12 +360,12 @@ msgstr  ""
 msgid   "%s (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -502,7 +502,7 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid   "ALIAS"
 msgstr  ""
 
@@ -853,7 +853,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389 cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61 cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64 cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509 cmd/incus/network.go:1602 cmd/incus/network.go:1674 cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011 cmd/incus/network_load_balancer.go:259 cmd/incus/network_load_balancer.go:341 cmd/incus/network_load_balancer.go:517 cmd/incus/network_load_balancer.go:652 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:906 cmd/incus/network_load_balancer.go:984 cmd/incus/network_load_balancer.go:1098 cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110 cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843 cmd/incus/storage.go:945 cmd/incus/storage.go:1038 cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582 cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976 cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335 cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884 cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140 cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347 cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731 cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897 cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61 cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64 cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011 cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509 cmd/incus/network.go:1602 cmd/incus/network.go:1674 cmd/incus/network_load_balancer.go:259 cmd/incus/network_load_balancer.go:341 cmd/incus/network_load_balancer.go:517 cmd/incus/network_load_balancer.go:652 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:906 cmd/incus/network_load_balancer.go:984 cmd/incus/network_load_balancer.go:1098 cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110 cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843 cmd/incus/storage.go:945 cmd/incus/storage.go:1038 cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976 cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335 cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884 cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140 cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347 cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731 cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897 cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1186,7 +1186,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096 cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424 cmd/incus/config_trust.go:617 cmd/incus/image.go:1093 cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:694 cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096 cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424 cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211 cmd/incus/image.go:1093 cmd/incus/list.go:134 cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115 cmd/incus/network.go:1101 cmd/incus/network.go:1307 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916 cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid   "Columns"
 msgstr  ""
 
@@ -1231,7 +1231,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356 cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726 cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375 cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322 cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356 cmd/incus/image.go:464 cmd/incus/network_acl.go:726 cmd/incus/network_forward.go:801 cmd/incus/network.go:809 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375 cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1541,7 +1541,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511 cmd/incus/config_trust.go:442 cmd/incus/image.go:1122 cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132 cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933 cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511 cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251 cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137 cmd/incus/network.go:1132 cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933 cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932 cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1696,7 +1696,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377 cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924 cmd/incus/network.go:1082 cmd/incus/network.go:1285 cmd/incus/network.go:1443 cmd/incus/network.go:1503 cmd/incus/network.go:1599 cmd/incus/network.go:1671 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255 cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386 cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577 cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033 cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:333 cmd/incus/network_load_balancer.go:441 cmd/incus/network_load_balancer.go:509 cmd/incus/network_load_balancer.go:619 cmd/incus/network_load_balancer.go:649 cmd/incus/network_load_balancer.go:814 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:903 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1095 cmd/incus/network_load_balancer.go:1170 cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253 cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663 cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321 cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628 cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950 cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285 cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462 cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538 cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30 cmd/incus/operation.go:63 cmd/incus/operation.go:114 cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359 cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642 cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970 cmd/incus/profile.go:1030 cmd/incus/profile.go:1119 cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105 cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443 cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802 cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995 cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514 cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941 cmd/incus/storage.go:1035 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580 cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769 cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964 cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324 cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569 cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881 cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124 cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287 cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472 cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567 cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815 cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982 cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268 cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361 cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255 cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386 cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577 cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033 cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339 cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610 cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924 cmd/incus/network.go:1082 cmd/incus/network.go:1285 cmd/incus/network.go:1443 cmd/incus/network.go:1503 cmd/incus/network.go:1599 cmd/incus/network.go:1671 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:333 cmd/incus/network_load_balancer.go:441 cmd/incus/network_load_balancer.go:509 cmd/incus/network_load_balancer.go:619 cmd/incus/network_load_balancer.go:649 cmd/incus/network_load_balancer.go:814 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:903 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1095 cmd/incus/network_load_balancer.go:1170 cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253 cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663 cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321 cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628 cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950 cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285 cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462 cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538 cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30 cmd/incus/operation.go:63 cmd/incus/operation.go:114 cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359 cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642 cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970 cmd/incus/profile.go:1030 cmd/incus/profile.go:1119 cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105 cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443 cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802 cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995 cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514 cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577 cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941 cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580 cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769 cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964 cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324 cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569 cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881 cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124 cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287 cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472 cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567 cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815 cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982 cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268 cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -1788,7 +1788,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -2032,7 +2032,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125 cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454 cmd/incus/config_trust.go:642 cmd/incus/image.go:1140 cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147 cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151 cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777 cmd/incus/snapshot.go:350 cmd/incus/storage.go:733 cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941 cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125 cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454 cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260 cmd/incus/image.go:1140 cmd/incus/list.go:640 cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151 cmd/incus/network.go:1147 cmd/incus/network.go:1345 cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151 cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777 cmd/incus/snapshot.go:350 cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941 cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92 cmd/incus/warning.go:241
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2092,7 +2092,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577 cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907 cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052 cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606 cmd/incus/network.go:1577 cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718 cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052 cmd/incus/storage_volume.go:2095
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2107,7 +2107,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025 cmd/incus/network.go:1571 cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666 cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632 cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254 cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901 cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025 cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600 cmd/incus/network.go:1571 cmd/incus/network_integration.go:666 cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632 cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254 cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901 cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2272,7 +2272,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124 cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249 cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2284,12 +2284,12 @@ msgstr  ""
 msgid   "FQDN"
 msgstr  ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2304,12 +2304,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2339,7 +2339,7 @@ msgstr  ""
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2379,7 +2379,7 @@ msgstr  ""
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2394,12 +2394,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2508,12 +2508,12 @@ msgstr  ""
 msgid   "Failed to join cluster: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid   "Failed to load configuration: %s"
 msgstr  ""
@@ -2608,7 +2608,7 @@ msgstr  ""
 msgid   "Failed to update cluster member state: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2637,7 +2637,7 @@ msgstr  ""
 msgid   "Fetch instance backup file: %w"
 msgstr  ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137 cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225 cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2713,7 +2713,7 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151 cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616 cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135 cmd/incus/network.go:1102 cmd/incus/network.go:1306 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871 cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151 cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616 cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114 cmd/incus/network.go:1102 cmd/incus/network.go:1306 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871 cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914 cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr  ""
 
@@ -2967,22 +2967,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -3209,11 +3209,11 @@ msgstr  ""
 msgid   "Instance description"
 msgstr  ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -3227,7 +3227,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -3325,7 +3325,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -3437,7 +3437,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334 cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147 cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528 cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140 cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147 cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528 cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid   "LOCATION"
 msgstr  ""
 
@@ -4295,12 +4295,12 @@ msgstr  ""
 msgid   "Logical switch"
 msgstr  ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid   "Login with username %q and password %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid   "Login without username and password"
 msgstr  ""
 
@@ -4320,7 +4320,7 @@ msgstr  ""
 msgid   "Lower devices"
 msgstr  ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid   "MAC ADDRESS"
 msgstr  ""
 
@@ -4680,7 +4680,7 @@ msgstr  ""
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475 cmd/incus/network.go:1541 cmd/incus/network.go:1633 cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048 cmd/incus/network_load_balancer.go:211 cmd/incus/network_load_balancer.go:292 cmd/incus/network_load_balancer.go:363 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:550 cmd/incus/network_load_balancer.go:718 cmd/incus/network_load_balancer.go:850 cmd/incus/network_load_balancer.go:940 cmd/incus/network_load_balancer.go:1017 cmd/incus/network_load_balancer.go:1132 cmd/incus/network_load_balancer.go:1207 cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209 cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601 cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048 cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475 cmd/incus/network.go:1541 cmd/incus/network.go:1633 cmd/incus/network_load_balancer.go:211 cmd/incus/network_load_balancer.go:292 cmd/incus/network_load_balancer.go:363 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:550 cmd/incus/network_load_balancer.go:718 cmd/incus/network_load_balancer.go:850 cmd/incus/network_load_balancer.go:940 cmd/incus/network_load_balancer.go:1017 cmd/incus/network_load_balancer.go:1132 cmd/incus/network_load_balancer.go:1207 cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209 cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601 cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
 msgid   "Missing network name"
 msgstr  ""
 
@@ -4696,7 +4696,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981 cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233 cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428 cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985 cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233 cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428 cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985 cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -4764,7 +4764,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -4816,7 +4816,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115 cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438 cmd/incus/config_trust.go:632 cmd/incus/list.go:589 cmd/incus/network.go:1127 cmd/incus/network_acl.go:172 cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932 cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115 cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438 cmd/incus/config_trust.go:632 cmd/incus/list.go:589 cmd/incus/network_acl.go:172 cmd/incus/network.go:1127 cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932 cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931 cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
 msgid   "NAME"
 msgstr  ""
 
@@ -5266,7 +5266,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126 cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136 cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178 cmd/incus/network.go:1126 cmd/incus/network_zone.go:136 cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79 cmd/incus/warning.go:218
 msgid   "PROJECT"
 msgstr  ""
 
@@ -5299,7 +5299,7 @@ msgstr  ""
 msgid   "Password for %s: "
 msgstr  ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid   "Password rejected for %q"
 msgstr  ""
@@ -5383,11 +5383,11 @@ msgstr  ""
 msgid   "Press CTRL-C to exit"
 msgstr  ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:357 cmd/incus/image.go:465 cmd/incus/network.go:810 cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376 cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323 cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:357 cmd/incus/image.go:465 cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802 cmd/incus/network.go:810 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323 cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5572,7 +5572,7 @@ msgstr  ""
 msgid   "Push files into instances"
 msgstr  ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -5966,17 +5966,17 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid   "SSH SFTP listening on %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -6087,7 +6087,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -6355,7 +6355,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -6818,7 +6818,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130 cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128 cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78 cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135 cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250 cmd/incus/image.go:1130 cmd/incus/list.go:595 cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128 cmd/incus/network.go:1333 cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135 cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid   "TYPE"
 msgstr  ""
 
@@ -6826,11 +6826,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -7248,7 +7248,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139 cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723 cmd/incus/storage_volume.go:1688
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76 cmd/incus/network.go:1133 cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139 cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723 cmd/incus/storage_volume.go:1688
 msgid   "USED BY"
 msgstr  ""
 
@@ -7279,12 +7279,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131 cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462 cmd/incus/config_trust.go:648 cmd/incus/image.go:1148 cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153 cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157 cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783 cmd/incus/snapshot.go:356 cmd/incus/storage.go:739 cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947 cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131 cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462 cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266 cmd/incus/image.go:1148 cmd/incus/list.go:655 cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157 cmd/incus/network.go:1153 cmd/incus/network.go:1351 cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157 cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783 cmd/incus/snapshot.go:356 cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947 cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98 cmd/incus/warning.go:249
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7771,7 +7771,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074 cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31 cmd/incus/network.go:1079 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70 cmd/incus/webui.go:17
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074 cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31 cmd/incus/network_acl.go:91 cmd/incus/network.go:1079 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -7999,7 +7999,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -8055,7 +8055,7 @@ msgstr  ""
 msgid   "[<remote>:]<network integration> <type>"
 msgstr  ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283 cmd/incus/network.go:1597 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97 cmd/incus/network_peer.go:84
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283 cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97 cmd/incus/network_peer.go:84
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
@@ -8151,7 +8151,7 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
@@ -8477,14 +8477,6 @@ msgid   "incus create images:ubuntu/22.04 u1\n"
         "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr  ""
 
-#: cmd/incus/storage.go:104
-msgid   "incus create storage s1 dir\n"
-        "\n"
-        "incus create storage s1 dir < config.yaml\n"
-        "    Create a storage pool using the content of config.yaml.\n"
-        "	"
-msgstr  ""
-
 #: cmd/incus/debug.go:48
 msgid   "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
         "    Creates an ELF format memory dump of the vm1 instance."
@@ -8510,7 +8502,7 @@ msgid   "incus file create foo/bar\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid   "incus file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
@@ -8778,6 +8770,14 @@ msgid   "incus storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
+#: cmd/incus/storage.go:104
+msgid   "incus storage create s1 dir\n"
+        "\n"
+        "incus storage create s1 dir < config.yaml\n"
+        "    Create a storage pool using the content of config.yaml.\n"
+        "	"
+msgstr  ""
+
 #: cmd/incus/storage.go:279
 msgid   "incus storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
@@ -8886,16 +8886,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -627,12 +627,12 @@ msgstr "%s (altri %d)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -777,7 +777,7 @@ msgstr "Il nome del container è: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1149,8 +1149,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1492,12 +1492,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1506,16 +1506,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1534,17 +1534,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1595,12 +1595,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1935,15 +1936,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -2111,64 +2112,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2181,13 +2176,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2235,19 +2236,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2365,7 +2366,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2634,17 +2635,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2710,13 +2712,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2733,13 +2735,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2918,8 +2920,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2931,12 +2933,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2951,12 +2953,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2986,7 +2988,7 @@ msgstr "Accetta certificato"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -3026,7 +3028,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -3041,12 +3043,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -3155,12 +3157,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3258,7 +3260,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3287,7 +3289,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -3378,16 +3380,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3669,22 +3671,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3921,11 +3923,11 @@ msgstr "Il nome del container è: %s"
 msgid "Instance description"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3939,7 +3941,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4041,7 +4043,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -4161,8 +4163,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5075,12 +5077,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5102,7 +5104,7 @@ msgstr "Creazione del container in corso"
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5535,15 +5537,15 @@ msgstr "Il nome del container è: %s"
 msgid "Missing network integration name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5585,24 +5587,24 @@ msgstr "Il nome del container è: %s"
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5681,7 +5683,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -5743,13 +5745,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6213,8 +6216,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6250,7 +6253,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Password amministratore per %s: "
@@ -6336,7 +6339,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6344,13 +6347,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6538,7 +6542,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6965,17 +6969,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7092,7 +7096,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7404,7 +7408,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7896,12 +7900,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7910,11 +7914,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8366,8 +8370,8 @@ msgstr "Creazione del container in corso"
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8403,24 +8407,25 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8956,7 +8961,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -9254,7 +9259,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -9328,9 +9333,9 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -9464,8 +9469,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
@@ -9868,15 +9873,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9906,7 +9902,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -10234,6 +10230,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -10364,16 +10369,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-12-14 14:00+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -620,12 +620,12 @@ msgstr "%s (%s) (%d個使用可能)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（バックエンド=%q, ソース=%q）"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -767,7 +767,7 @@ msgstr "クラスターメンバー名が必要です"
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1156,8 +1156,8 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1509,12 +1509,12 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1523,16 +1523,16 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1551,17 +1551,17 @@ msgstr "クラスタリングが有効になりました"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1619,12 +1619,13 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1969,15 +1970,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2140,64 +2141,58 @@ msgid "Delete warning"
 msgstr "警告を削除します"
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2210,13 +2205,19 @@ msgstr "警告を削除します"
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2264,19 +2265,19 @@ msgstr "警告を削除します"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2399,7 +2400,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2692,17 +2693,18 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2778,13 +2780,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "エイリアスの取得に失敗しました: %w"
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2801,13 +2803,13 @@ msgid "Error unsetting properties: %v"
 msgstr "プロパティの削除でエラーが発生しました: %v"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
@@ -3025,8 +3027,8 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -3038,12 +3040,12 @@ msgstr "FIRST SEEN"
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -3058,12 +3060,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -3093,7 +3095,7 @@ msgstr "インスタンス %q （プロジェクト %q 内）の削除に失敗�
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー後のソースボリュームの削除に失敗しました: %w"
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -3133,7 +3135,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed loading storage pool %q: %w"
 msgstr "ストレージプール %q の取得に失敗しました: %w"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -3148,12 +3150,12 @@ msgstr "バリデーションレスポンスの読み取りに失敗しました
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -3262,12 +3264,12 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to join cluster: %w"
 msgstr "クラスターへの join に失敗しました: %w"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr "設定のロードに失敗しました: %s"
@@ -3365,7 +3367,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to update cluster member state: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -3394,7 +3396,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Fetch instance backup file: %w"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -3500,16 +3502,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3793,22 +3795,22 @@ msgstr "名前"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -4059,11 +4061,11 @@ msgstr "インスタンスのみ"
 msgid "Instance description"
 msgstr "説明"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -4077,7 +4079,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -4181,7 +4183,7 @@ msgstr "入力が無効です。正の値を入力してください"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -4303,8 +4305,8 @@ msgstr "LIMIT"
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5898,12 +5900,12 @@ msgstr "論理ルーター"
 msgid "Logical switch"
 msgstr "論理ルーター"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr "ユーザー名 %q とパスワード %q でログイン"
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr "ユーザー名、パスワードを使用せずにログイン"
 
@@ -5923,7 +5925,7 @@ msgstr "Lower device"
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
@@ -6353,15 +6355,15 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 msgid "Missing network integration name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -6400,24 +6402,24 @@ msgstr "ネットワークゾーンレコード名を指定する必要があり
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -6500,7 +6502,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -6576,13 +6578,14 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr "NAME"
 
@@ -7065,8 +7068,8 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -7103,7 +7106,7 @@ msgstr "パーティション:"
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "%s のパスワード: "
@@ -7190,7 +7193,7 @@ msgstr "ソート方法を変更するには 's' + ENTER を押してくださ�
 msgid "Press CTRL-C to exit"
 msgstr "終了するには CTRL-C を押してください"
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -7198,13 +7201,14 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -7393,7 +7397,7 @@ msgstr "ファイル %s を %s から取得します: %%s"
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -7826,17 +7830,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr "SSH SFTP は %v でリッスンしています"
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -7957,7 +7961,7 @@ msgstr "クラスターメンバーの設定を行います"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -8348,7 +8352,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr "インスタンスプロパティとして設定します"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -8842,12 +8846,12 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -8855,11 +8859,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -9379,8 +9383,8 @@ msgstr "device"
 msgid "USB devices:"
 msgstr "上位デバイス"
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -9415,24 +9419,25 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -9994,7 +9999,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -10249,7 +10254,7 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -10315,9 +10320,9 @@ msgstr "[<remote>:]<network> <new-name>"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
@@ -10437,8 +10442,8 @@ msgstr "[<remote>:]<network> [key=value...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
@@ -10852,18 +10857,6 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage.go:104
-#, fuzzy
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-"lxc storage edit [<remote>:]<pool> < pool.yaml\n"
-"    pool.yaml の内容でストレージプールを更新します。"
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -10906,7 +10899,7 @@ msgstr ""
 "\t   インスタンス foo 内に、ターゲットが baz であるシンボリックリンク /bar を"
 "作成します。"
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 #, fuzzy
 msgid ""
 "incus file mount foo/root fooroot\n"
@@ -11427,6 +11420,18 @@ msgstr ""
 "lxc storage bucket show default data\n"
 "    \"default\" プール内の \"data\" というバケットのプロパティを表示します。"
 
+#: cmd/incus/storage.go:104
+#, fuzzy
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+"lxc storage edit [<remote>:]<pool> < pool.yaml\n"
+"    pool.yaml の内容でストレージプールを更新します。"
+
 #: cmd/incus/storage.go:279
 #, fuzzy
 msgid ""
@@ -11600,16 +11605,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -390,12 +390,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -534,7 +534,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr ""
 
@@ -897,8 +897,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1236,12 +1236,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1250,16 +1250,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1278,17 +1278,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1338,12 +1338,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1665,15 +1666,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1830,64 +1831,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -1900,13 +1895,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -1954,19 +1955,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2080,7 +2081,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2334,17 +2335,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2410,13 +2412,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2433,13 +2435,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2612,8 +2614,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2625,12 +2627,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2645,12 +2647,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2680,7 +2682,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2720,7 +2722,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2735,12 +2737,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2849,12 +2851,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2952,7 +2954,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2981,7 +2983,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3070,16 +3072,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3343,22 +3345,22 @@ msgstr "navn"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3588,11 +3590,11 @@ msgstr ""
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3606,7 +3608,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3706,7 +3708,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3821,8 +3823,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -4717,12 +4719,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -4742,7 +4744,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5148,15 +5150,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5195,24 +5197,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5286,7 +5288,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5346,13 +5348,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -5813,8 +5816,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -5850,7 +5853,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5934,7 +5937,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5942,13 +5945,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6539,17 +6543,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6663,7 +6667,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6964,7 +6968,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7436,12 +7440,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7449,11 +7453,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7900,8 +7904,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -7935,24 +7939,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8462,7 +8467,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -8704,7 +8709,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8764,9 +8769,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8877,8 +8882,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9226,15 +9231,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9264,7 +9260,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9592,6 +9588,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -9721,16 +9726,16 @@ msgstr "vennligst bruk `incus profile`"
 msgid "space used"
 msgstr "brukt plass"
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr "sshfs har stoppet"
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 "
 "<nlincus@users.noreply.hosted.weblate.org>\n"
@@ -644,12 +644,12 @@ msgstr "%s (%s) (%d beschikbaar)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, source=%q)"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s is geen directory"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' is geen ondersteund bestandstype"
@@ -794,7 +794,7 @@ msgstr "Een clusterlid (cluster member) naam (name) moet worden meegegeven"
 msgid "ADDRESS"
 msgstr "ADRES"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1179,8 +1179,8 @@ msgstr "Backups:"
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1520,12 +1520,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1534,16 +1534,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1562,17 +1562,17 @@ msgstr "Clustering aan"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Kolommen"
 
@@ -1630,12 +1630,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1957,15 +1958,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2122,64 +2123,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2192,13 +2187,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2246,19 +2247,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2372,7 +2373,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2626,17 +2627,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2702,13 +2704,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2725,13 +2727,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2904,8 +2906,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2917,12 +2919,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2937,12 +2939,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2972,7 +2974,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -3012,7 +3014,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -3027,12 +3029,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -3141,12 +3143,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3244,7 +3246,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3273,7 +3275,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3362,16 +3364,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3634,22 +3636,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3879,11 +3881,11 @@ msgstr ""
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3897,7 +3899,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3997,7 +3999,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -4112,8 +4114,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5008,12 +5010,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5033,7 +5035,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5439,15 +5441,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr "Netwerk integratie naam mist"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5486,24 +5488,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5577,7 +5579,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5637,13 +5639,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6104,8 +6107,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6141,7 +6144,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6225,7 +6228,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6233,13 +6236,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6424,7 +6428,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6830,17 +6834,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6954,7 +6958,7 @@ msgstr "Definieer een cluster groep configuratie sleutels (keys)"
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7257,7 +7261,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7729,12 +7733,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7742,11 +7746,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8193,8 +8197,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8228,24 +8232,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8756,7 +8761,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -8998,7 +9003,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9058,9 +9063,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -9171,8 +9176,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9520,15 +9525,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9558,7 +9554,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9886,6 +9882,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -10022,16 +10027,16 @@ msgstr "gebruik `incus profile`"
 msgid "space used"
 msgstr "ruimte gebruikt"
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr "sshfs is gestopt"
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs koppelen van %q op %q"
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr "sshfs niet gevonden. Probeer SSH SFTP methode via de --listen optie"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -383,12 +383,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr ""
 
@@ -890,8 +890,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1229,12 +1229,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1243,16 +1243,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1271,17 +1271,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1331,12 +1331,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1658,15 +1659,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1823,64 +1824,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -1893,13 +1888,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -1947,19 +1948,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2073,7 +2074,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2327,17 +2328,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2403,13 +2405,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2426,13 +2428,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2605,8 +2607,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2618,12 +2620,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2638,12 +2640,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2673,7 +2675,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2713,7 +2715,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2728,12 +2730,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2842,12 +2844,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2945,7 +2947,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2974,7 +2976,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3063,16 +3065,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3335,22 +3337,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3580,11 +3582,11 @@ msgstr ""
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3598,7 +3600,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3698,7 +3700,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3813,8 +3815,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -4709,12 +4711,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -4734,7 +4736,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5140,15 +5142,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5187,24 +5189,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5278,7 +5280,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5338,13 +5340,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -5805,8 +5808,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -5842,7 +5845,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5926,7 +5929,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5934,13 +5937,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6125,7 +6129,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6531,17 +6535,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6655,7 +6659,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6956,7 +6960,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7428,12 +7432,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7441,11 +7445,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7892,8 +7896,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -7927,24 +7931,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8454,7 +8459,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -8696,7 +8701,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8756,9 +8761,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8869,8 +8874,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9218,15 +9223,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9256,7 +9252,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9584,6 +9580,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -9713,16 +9718,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -619,12 +619,12 @@ msgstr "%s (%d mais)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -779,7 +779,7 @@ msgstr "Nome de membro do cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1162,8 +1162,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1509,12 +1509,12 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1523,16 +1523,16 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1551,17 +1551,17 @@ msgstr "Clustering ativado"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1623,12 +1623,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1971,15 +1972,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2153,64 +2154,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2223,13 +2218,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2277,19 +2278,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2408,7 +2409,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2685,17 +2686,18 @@ msgstr "Editar configurações de perfil como YAML"
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2761,13 +2763,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2784,13 +2786,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2967,8 +2969,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2980,12 +2982,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -3000,12 +3002,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -3035,7 +3037,7 @@ msgstr "Aceitar certificado"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -3075,7 +3077,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -3090,12 +3092,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -3204,12 +3206,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3307,7 +3309,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3336,7 +3338,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3426,16 +3428,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3724,22 +3726,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3976,11 +3978,11 @@ msgstr ""
 msgid "Instance description"
 msgstr "Descrição"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3994,7 +3996,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4096,7 +4098,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -4216,8 +4218,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5126,12 +5128,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5153,7 +5155,7 @@ msgstr "Editar arquivos no container"
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5592,15 +5594,15 @@ msgstr "Nome de membro do cluster"
 msgid "Missing network integration name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5642,24 +5644,24 @@ msgstr "Nome de membro do cluster"
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5737,7 +5739,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -5800,13 +5802,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6274,8 +6277,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6311,7 +6314,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6398,7 +6401,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6406,13 +6409,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6605,7 +6609,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -7045,17 +7049,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7172,7 +7176,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7494,7 +7498,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7996,12 +8000,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -8009,12 +8013,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8465,8 +8469,8 @@ msgstr "Editar arquivos no container"
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8502,24 +8506,25 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -9064,7 +9069,7 @@ msgstr "Criar perfis"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -9335,7 +9340,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -9406,9 +9411,9 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -9531,8 +9536,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9911,15 +9916,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9949,7 +9945,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -10277,6 +10273,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -10406,16 +10411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -643,12 +643,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -798,7 +798,7 @@ msgstr "Копирование образа: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -1174,8 +1174,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1518,12 +1518,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1532,16 +1532,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1560,17 +1560,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1620,12 +1620,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1967,15 +1968,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2145,64 +2146,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2215,13 +2210,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2269,19 +2270,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2398,7 +2399,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2669,17 +2670,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2745,13 +2747,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2768,13 +2770,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2959,8 +2961,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2972,12 +2974,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2992,12 +2994,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -3027,7 +3029,7 @@ msgstr "Принять сертификат"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -3067,7 +3069,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -3082,12 +3084,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -3196,12 +3198,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3299,7 +3301,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3328,7 +3330,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3418,16 +3420,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3714,22 +3716,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3968,11 +3970,11 @@ msgstr "Имя контейнера: %s"
 msgid "Instance description"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3987,7 +3989,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4089,7 +4091,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -4208,8 +4210,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5125,12 +5127,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5152,7 +5154,7 @@ msgstr "Копирование образа: %s"
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5594,15 +5596,15 @@ msgstr "Имя контейнера: %s"
 msgid "Missing network integration name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5644,24 +5646,24 @@ msgstr "Имя контейнера: %s"
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5740,7 +5742,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5802,13 +5804,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6282,8 +6285,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6319,7 +6322,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Пароль администратора для %s: "
@@ -6404,7 +6407,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6412,13 +6415,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6603,7 +6607,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -7033,17 +7037,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7160,7 +7164,7 @@ msgstr "Копирование образа: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7478,7 +7482,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7979,12 +7983,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7992,11 +7996,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8447,8 +8451,8 @@ msgstr "Копирование образа: %s"
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8483,24 +8487,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -9046,7 +9051,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -9516,7 +9521,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -9632,9 +9637,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -9837,8 +9842,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10406,15 +10411,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -10444,7 +10440,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -10772,6 +10768,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -10901,16 +10906,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -383,12 +383,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr ""
 
@@ -890,8 +890,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1229,12 +1229,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1243,16 +1243,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1271,17 +1271,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1331,12 +1331,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1658,15 +1659,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1823,64 +1824,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -1893,13 +1888,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -1947,19 +1948,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2073,7 +2074,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2327,17 +2328,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2403,13 +2405,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2426,13 +2428,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2605,8 +2607,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2618,12 +2620,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2638,12 +2640,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2673,7 +2675,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2713,7 +2715,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2728,12 +2730,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2842,12 +2844,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2945,7 +2947,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2974,7 +2976,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3063,16 +3065,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3335,22 +3337,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3580,11 +3582,11 @@ msgstr ""
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3598,7 +3600,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3698,7 +3700,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3813,8 +3815,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -4709,12 +4711,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -4734,7 +4736,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5140,15 +5142,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5187,24 +5189,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5278,7 +5280,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5338,13 +5340,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -5805,8 +5808,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -5842,7 +5845,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5926,7 +5929,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5934,13 +5937,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6125,7 +6129,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6531,17 +6535,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6655,7 +6659,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6956,7 +6960,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7428,12 +7432,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7441,11 +7445,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7892,8 +7896,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -7927,24 +7931,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8454,7 +8459,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -8696,7 +8701,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8756,9 +8761,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8869,8 +8874,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9218,15 +9223,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9256,7 +9252,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9584,6 +9580,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -9713,16 +9718,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2025-03-01 08:01+0000\n"
 "Last-Translator: Loge X <wazolm5643@163.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -628,12 +628,12 @@ msgstr "%s（%s）（%d个可用）"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（后端=%q，来源=%q）"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是目录"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "“%s”不是受支持的文件类型"
@@ -772,7 +772,7 @@ msgstr "必须提供集群成员名称"
 msgid "ADDRESS"
 msgstr "地址"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr "别名"
 
@@ -1153,8 +1153,8 @@ msgstr "备份："
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "设备覆盖语法错误，应为“<设备>,<键>=<值>”：%s"
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1492,12 +1492,12 @@ msgstr "已从组 %s 中移除集群成员 %s"
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1506,16 +1506,16 @@ msgstr "已从组 %s 中移除集群成员 %s"
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1534,17 +1534,17 @@ msgstr "已启用集群"
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr "列"
 
@@ -1600,12 +1600,13 @@ msgstr "配置选项的格式应为 KEY=VALUE"
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1944,15 +1945,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "默认目标地址"
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr "描述"
 
@@ -2109,64 +2110,58 @@ msgid "Delete warning"
 msgstr "删除警告"
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -2179,13 +2174,19 @@ msgstr "删除警告"
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -2233,19 +2234,19 @@ msgstr "删除警告"
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2359,7 +2360,7 @@ msgstr "目录导入在此平台上不可用"
 msgid "Directory to run the command in (default /root)"
 msgstr "运行命令的目录（默认/根目录）"
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "使用 SSH SFTP 监听器时禁用身份验证"
 
@@ -2634,17 +2635,18 @@ msgstr "将信任配置编辑为 YAML"
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr "“%s”中的空列条目（冗余、前导或尾随命令）"
@@ -2718,13 +2720,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "检索别名时出错：%w"
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2741,13 +2743,13 @@ msgid "Error unsetting properties: %v"
 msgstr "取消设置属性时出错：%v"
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "取消设置属性时出错：%v"
@@ -2953,8 +2955,8 @@ msgstr "故障域"
 msgid "FILENAME"
 msgstr "文件名"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr "指纹"
 
@@ -2966,12 +2968,12 @@ msgstr "首次发现"
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "与客户端 %q 的 SSH 握手失败：%v"
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "接受通道客户端 %q 失败：%v"
@@ -2986,12 +2988,12 @@ msgstr "检查实例是否存在“%s:%s”失败：%w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "检查实例快照是否存在“%s:%s”失败：%w"
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "连接到客户端 %q 的实例 SFTP 失败：%v"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "连接到实例 SFTP 失败：%w"
@@ -3021,7 +3023,7 @@ msgstr "在项目 %q 中删除实例 %q 失败：%w"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "复制后删除源卷失败：%w"
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "生成 SSH 主机密钥失败：%w"
@@ -3061,7 +3063,7 @@ msgstr "加载覆盖设备的配置文件 %q 失败：%w"
 msgid "Failed loading storage pool %q: %w"
 msgstr "加载存储池 %q 失败：%w"
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "解析 SSH 主机密钥失败：%w"
@@ -3076,12 +3078,12 @@ msgstr "解析验证响应失败：%w"
 msgid "Failed starting command: %w"
 msgstr "启动命令失败：%w"
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "启动 sshfs 失败：%w"
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "接受传入连接失败：%w"
@@ -3190,12 +3192,12 @@ msgstr "找不到项目：%w"
 msgid "Failed to join cluster: %w"
 msgstr "加入集群失败：%w"
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "监听连接失败：%w"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr "加载配置失败：%s"
@@ -3293,7 +3295,7 @@ msgstr "无法与集群建立信任关系：%w"
 msgid "Failed to update cluster member state: %w"
 msgstr "更新群集成员状态失败：%w"
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "为 %s 遍历路径失败：%s"
@@ -3322,7 +3324,7 @@ msgstr "快速模式（等价于 --columns=nsacPt）"
 msgid "Fetch instance backup file: %w"
 msgstr "获取实例备份文件：%w"
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr "尚不支持筛选"
@@ -3424,16 +3426,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3704,22 +3706,22 @@ msgstr "主机名"
 msgid "Hugepages:\n"
 msgstr "大页内存：\n"
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "从 SSH 到实例的 I/O 复制操作失败：%v"
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "从实例到 SSH 的 I/O 复制操作失败：%v"
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3949,11 +3951,11 @@ msgstr ""
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3967,7 +3969,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4067,7 +4069,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -4182,8 +4184,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -5078,12 +5080,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -5103,7 +5105,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5509,15 +5511,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5556,24 +5558,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5648,7 +5650,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr "将下载多个文件, 但目标不是目录"
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5708,13 +5710,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -6175,8 +6178,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -6212,7 +6215,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6296,7 +6299,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6304,13 +6307,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6495,7 +6499,7 @@ msgstr "正在从 %[2]s 拉取 %[1]s: %%s"
 msgid "Push files into instances"
 msgstr "向实例推送文件"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, fuzzy, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "正在向 %[2]s 推送 %[1]s: %%s"
@@ -6910,17 +6914,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7034,7 +7038,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7335,7 +7339,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7807,12 +7811,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7820,12 +7824,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "目标路径和 --listen 标记不能一起使用"
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8272,8 +8276,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -8307,24 +8311,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8834,7 +8839,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -9076,7 +9081,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9136,9 +9141,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -9249,8 +9254,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9598,15 +9603,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9636,7 +9632,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9964,6 +9960,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -10093,16 +10098,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-18 14:07+0000\n"
+"POT-Creation-Date: 2025-03-18 20:18-0300\n"
 "PO-Revision-Date: 2024-12-30 10:00+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -386,12 +386,12 @@ msgstr "%s (%s) (%d 可用)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (後端=%q, 來源=%q)"
 
-#: cmd/incus/file.go:1304
+#: cmd/incus/file.go:1310
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是目錄"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1199
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' 不是受支援的檔案類型"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image_alias.go:248 cmd/incus/image.go:1126
 msgid "ALIAS"
 msgstr ""
 
@@ -893,8 +893,8 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:416 cmd/incus/network_acl.go:459
-#: cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_acl.go:459 cmd/incus/network_forward.go:389
+#: cmd/incus/network.go:416 cmd/incus/network_load_balancer.go:392
 #: cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467
 #: cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
 #, c-format
@@ -1232,12 +1232,12 @@ msgstr ""
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:349 cmd/incus/network.go:846 cmd/incus/network.go:927
-#: cmd/incus/network.go:1509 cmd/incus/network.go:1602
-#: cmd/incus/network.go:1674 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338
+#: cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927
+#: cmd/incus/network_forward.go:1011 cmd/incus/network.go:349
+#: cmd/incus/network.go:846 cmd/incus/network.go:927 cmd/incus/network.go:1509
+#: cmd/incus/network.go:1602 cmd/incus/network.go:1674
 #: cmd/incus/network_load_balancer.go:259
 #: cmd/incus/network_load_balancer.go:341
 #: cmd/incus/network_load_balancer.go:517
@@ -1246,16 +1246,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:906
 #: cmd/incus/network_load_balancer.go:984
 #: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
+#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage_bucket.go:105
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274
+#: cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657
+#: cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053
+#: cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223
+#: cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433
+#: cmd/incus/storage_bucket.go:1582 cmd/incus/storage.go:110
 #: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
 #: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
 #: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
 #: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
 #: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
@@ -1274,17 +1274,17 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
 #: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1101
-#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
+#: cmd/incus/config_trust.go:617 cmd/incus/image_alias.go:211
+#: cmd/incus/image.go:1093 cmd/incus/list.go:134
+#: cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115
+#: cmd/incus/network.go:1101 cmd/incus/network.go:1307
+#: cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123
+#: cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115
+#: cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537
+#: cmd/incus/remote.go:750 cmd/incus/snapshot.go:316
 #: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:694 cmd/incus/storage_volume.go:1567
+#: cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
 msgid "Columns"
 msgstr ""
 
@@ -1334,12 +1334,13 @@ msgstr ""
 #: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:809 cmd/incus/network_acl.go:726
-#: cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814
-#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429
-#: cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
+#: cmd/incus/image.go:464 cmd/incus/network_acl.go:726
+#: cmd/incus/network_forward.go:801 cmd/incus/network.go:809
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
+#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
+#: cmd/incus/project.go:409 cmd/incus/storage_bucket.go:369
+#: cmd/incus/storage_bucket.go:1322 cmd/incus/storage.go:375
 #: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
 #, c-format
 msgid "Config parsing error: %s"
@@ -1661,15 +1662,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1132
-#: cmd/incus/network_acl.go:173 cmd/incus/network_forward.go:137
+#: cmd/incus/config_trust.go:442 cmd/incus/image_alias.go:251
+#: cmd/incus/image.go:1122 cmd/incus/list.go:581 cmd/incus/network_acl.go:173
+#: cmd/incus/network_forward.go:137 cmd/incus/network.go:1132
 #: cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145
 #: cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138
 #: cmd/incus/network_zone.go:933 cmd/incus/operation.go:156
-#: cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721
+#: cmd/incus/profile.go:761 cmd/incus/project.go:569
 #: cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932
-#: cmd/incus/storage_volume.go:1686
+#: cmd/incus/storage.go:721 cmd/incus/storage_volume.go:1686
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1826,64 +1827,58 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
-#: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1355 cmd/incus/image.go:40 cmd/incus/image.go:148
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112
+#: cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591
+#: cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329
+#: cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975
+#: cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871
+#: cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44
+#: cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32
+#: cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58
+#: cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384
+#: cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361
+#: cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:377 cmd/incus/image.go:40 cmd/incus/image.go:148
 #: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
 #: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
 #: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
-#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
-#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
-#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
-#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
-#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/import.go:27
+#: cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50
+#: cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33
+#: cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
 #: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
 #: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
@@ -1896,13 +1891,19 @@ msgstr ""
 #: cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633
 #: cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834
 #: cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924
-#: cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
-#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563
-#: cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698
-#: cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_forward.go:1007 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:339
+#: cmd/incus/network.go:455 cmd/incus/network.go:513 cmd/incus/network.go:610
+#: cmd/incus/network.go:707 cmd/incus/network.go:843 cmd/incus/network.go:924
+#: cmd/incus/network.go:1082 cmd/incus/network.go:1285
+#: cmd/incus/network.go:1443 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1599 cmd/incus/network.go:1671
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:333
 #: cmd/incus/network_load_balancer.go:441
@@ -1950,19 +1951,19 @@ msgstr ""
 #: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
 #: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
 #: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
+#: cmd/incus/snapshot.go:593 cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:1035 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
 #: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
@@ -2076,7 +2077,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1362
+#: cmd/incus/file.go:1368
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2330,17 +2331,18 @@ msgstr ""
 
 #: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
 #: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1147
-#: cmd/incus/network.go:1345 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
+#: cmd/incus/config_trust.go:642 cmd/incus/image_alias.go:260
+#: cmd/incus/image.go:1140 cmd/incus/list.go:640
+#: cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151
+#: cmd/incus/network.go:1147 cmd/incus/network.go:1345
+#: cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158
+#: cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151
+#: cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579
+#: cmd/incus/remote.go:777 cmd/incus/snapshot.go:350
 #: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/storage.go:733 cmd/incus/storage_volume.go:1714
+#: cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92
+#: cmd/incus/warning.go:241
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2406,13 +2408,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1577
-#: cmd/incus/network_acl.go:552 cmd/incus/network_forward.go:606
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:552
+#: cmd/incus/network_forward.go:606 cmd/incus/network.go:1577
 #: cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592
 #: cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560
 #: cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097
-#: cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
+#: cmd/incus/project.go:865 cmd/incus/storage_bucket.go:718
+#: cmd/incus/storage.go:907 cmd/incus/storage_volume.go:2052
 #: cmd/incus/storage_volume.go:2095
 #, c-format
 msgid "Error setting properties: %v"
@@ -2429,13 +2431,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1571 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
+#: cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600
+#: cmd/incus/network.go:1571 cmd/incus/network_integration.go:666
 #: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
 #: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/profile.go:1091 cmd/incus/project.go:859
+#: cmd/incus/storage_bucket.go:712 cmd/incus/storage.go:901
+#: cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2608,8 +2610,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:441 cmd/incus/image_alias.go:249
+#: cmd/incus/image.go:1124 cmd/incus/image.go:1125
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2621,12 +2623,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1642
+#: cmd/incus/file.go:1648
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2641,12 +2643,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1669
+#: cmd/incus/file.go:1675
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1460
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2676,7 +2678,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1575
+#: cmd/incus/file.go:1581
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2716,7 +2718,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1580
+#: cmd/incus/file.go:1586
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2731,12 +2733,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1480
+#: cmd/incus/file.go:1486
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1607
+#: cmd/incus/file.go:1613
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2845,12 +2847,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1592
+#: cmd/incus/file.go:1598
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main_aliases.go:222 cmd/incus/main.go:402
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2948,7 +2950,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1188
+#: cmd/incus/file.go:1194
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2977,7 +2979,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1225 cmd/incus/network_acl.go:137
+#: cmd/incus/network_acl.go:137 cmd/incus/network.go:1225
 #: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3066,16 +3068,16 @@ msgstr ""
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
 #: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1102 cmd/incus/network.go:1306
+#: cmd/incus/image_alias.go:210 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_forward.go:114 cmd/incus/network.go:1102
+#: cmd/incus/network.go:1306 cmd/incus/network_integration.go:437
 #: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
 #: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
 #: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
 #: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
+#: cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914
+#: cmd/incus/storage.go:696 cmd/incus/storage_volume.go:1585
 #: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
@@ -3338,22 +3340,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1692
+#: cmd/incus/file.go:1698
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1681
+#: cmd/incus/file.go:1687
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1504
+#: cmd/incus/file.go:1510
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1514
+#: cmd/incus/file.go:1520
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3583,11 +3585,11 @@ msgstr ""
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1506
+#: cmd/incus/file.go:1512
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1683
+#: cmd/incus/file.go:1689
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3601,7 +3603,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1426
+#: cmd/incus/file.go:1432
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3701,7 +3703,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1421
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3816,8 +3818,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1334
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
+#: cmd/incus/list.go:623 cmd/incus/network_forward.go:140
+#: cmd/incus/network.go:1334 cmd/incus/network_load_balancer.go:147
 #: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
 #: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
 msgid "LOCATION"
@@ -4712,12 +4714,12 @@ msgstr ""
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1604
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1600
+#: cmd/incus/file.go:1606
 msgid "Login without username and password"
 msgstr ""
 
@@ -4737,7 +4739,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1331 cmd/incus/network_allocations.go:80
+#: cmd/incus/network_allocations.go:80 cmd/incus/network.go:1331
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -5143,15 +5145,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:487
-#: cmd/incus/network.go:549 cmd/incus/network.go:646 cmd/incus/network.go:759
-#: cmd/incus/network.go:882 cmd/incus/network.go:958 cmd/incus/network.go:1397
-#: cmd/incus/network.go:1475 cmd/incus/network.go:1541
-#: cmd/incus/network.go:1633 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
+#: cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288
+#: cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739
+#: cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965
+#: cmd/incus/network_forward.go:1048 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:487 cmd/incus/network.go:549
+#: cmd/incus/network.go:646 cmd/incus/network.go:759 cmd/incus/network.go:882
+#: cmd/incus/network.go:958 cmd/incus/network.go:1397 cmd/incus/network.go:1475
+#: cmd/incus/network.go:1541 cmd/incus/network.go:1633
 #: cmd/incus/network_load_balancer.go:211
 #: cmd/incus/network_load_balancer.go:292
 #: cmd/incus/network_load_balancer.go:363
@@ -5190,24 +5192,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
 #: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
 #: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
 #: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
 #: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
 #: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
 #: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage.go:251
+#: cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525
+#: cmd/incus/storage.go:875 cmd/incus/storage.go:981
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732
+#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907
+#: cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241
+#: cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918
+#: cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174
+#: cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770
+#: cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
 msgid "Missing pool name"
 msgstr ""
 
@@ -5281,7 +5283,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1354 cmd/incus/file.go:1355
+#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5341,13 +5343,14 @@ msgstr ""
 #: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
 #: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
 #: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1127 cmd/incus/network_acl.go:172
+#: cmd/incus/network_acl.go:172 cmd/incus/network.go:1127
 #: cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932
 #: cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704
-#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
+#: cmd/incus/remote.go:763 cmd/incus/snapshot.go:339
 #: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/storage.go:719 cmd/incus/storage_volume.go:1685
+#: cmd/incus/storage_volume.go:2669
 msgid "NAME"
 msgstr ""
 
@@ -5808,8 +5811,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1126
-#: cmd/incus/network_acl.go:178 cmd/incus/network_zone.go:136
+#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network_acl.go:178
+#: cmd/incus/network.go:1126 cmd/incus/network_zone.go:136
 #: cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525
 #: cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79
 #: cmd/incus/warning.go:218
@@ -5845,7 +5848,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1568
+#: cmd/incus/file.go:1574
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5929,7 +5932,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1484
+#: cmd/incus/file.go:1490
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5937,13 +5940,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:810 cmd/incus/network_acl.go:727
-#: cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:727 cmd/incus/network_forward.go:802
+#: cmd/incus/network.go:810 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815
 #: cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430
-#: cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376
+#: cmd/incus/profile.go:609 cmd/incus/project.go:410
 #: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/storage.go:376 cmd/incus/storage_volume.go:1122
+#: cmd/incus/storage_volume.go:1154
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6128,7 +6132,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1235
+#: cmd/incus/file.go:931 cmd/incus/file.go:1241
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6534,17 +6538,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1595
+#: cmd/incus/file.go:1601
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1612
+#: cmd/incus/file.go:1618
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1619
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6658,7 +6662,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1369
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6959,7 +6963,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1367
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7431,12 +7435,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1128
-#: cmd/incus/network.go:1333 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:439 cmd/incus/image_alias.go:250
+#: cmd/incus/image.go:1130 cmd/incus/list.go:595
+#: cmd/incus/network_allocations.go:78 cmd/incus/network.go:1128
+#: cmd/incus/network.go:1333 cmd/incus/network_integration.go:455
+#: cmd/incus/network_peer.go:135 cmd/incus/operation.go:155
+#: cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
 msgid "TYPE"
 msgstr ""
 
@@ -7444,11 +7448,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1420
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1408
+#: cmd/incus/file.go:1414
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7895,8 +7899,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1133 cmd/incus/network_acl.go:174
-#: cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456
+#: cmd/incus/network_acl.go:174 cmd/incus/network_allocations.go:76
+#: cmd/incus/network.go:1133 cmd/incus/network_integration.go:456
 #: cmd/incus/network_zone.go:139 cmd/incus/profile.go:762
 #: cmd/incus/project.go:570 cmd/incus/storage.go:723
 #: cmd/incus/storage_volume.go:1688
@@ -7930,24 +7934,25 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1635
+#: cmd/incus/file.go:1641
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
 #: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1153
-#: cmd/incus/network.go:1351 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
+#: cmd/incus/config_trust.go:648 cmd/incus/image_alias.go:266
+#: cmd/incus/image.go:1148 cmd/incus/list.go:655
+#: cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157
+#: cmd/incus/network.go:1153 cmd/incus/network.go:1351
+#: cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164
+#: cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157
+#: cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585
+#: cmd/incus/remote.go:783 cmd/incus/snapshot.go:356
 #: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/storage.go:739 cmd/incus/storage_volume.go:1722
+#: cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98
+#: cmd/incus/warning.go:249
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8457,7 +8462,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
 #: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
 #: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1079 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1079
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515
 #: cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20
@@ -8699,7 +8704,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1359
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8759,9 +8764,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:452 cmd/incus/network.go:705 cmd/incus/network.go:922
-#: cmd/incus/network.go:1283 cmd/incus/network.go:1597
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:452
+#: cmd/incus/network.go:705 cmd/incus/network.go:922 cmd/incus/network.go:1283
+#: cmd/incus/network.go:1597 cmd/incus/network_load_balancer.go:97
 #: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8872,8 +8877,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage_bucket.go:483 cmd/incus/storage.go:216
+#: cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9221,15 +9226,6 @@ msgid ""
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/storage.go:104
-msgid ""
-"incus create storage s1 dir\n"
-"\n"
-"incus create storage s1 dir < config.yaml\n"
-"    Create a storage pool using the content of config.yaml.\n"
-"\t"
-msgstr ""
-
 #: cmd/incus/debug.go:48
 msgid ""
 "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
@@ -9259,7 +9255,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1357
+#: cmd/incus/file.go:1363
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -9587,6 +9583,15 @@ msgid ""
 "pool."
 msgstr ""
 
+#: cmd/incus/storage.go:104
+msgid ""
+"incus storage create s1 dir\n"
+"\n"
+"incus storage create s1 dir < config.yaml\n"
+"    Create a storage pool using the content of config.yaml.\n"
+"\t"
+msgstr ""
+
 #: cmd/incus/storage.go:279
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -9716,16 +9721,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1524
+#: cmd/incus/file.go:1530
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1483
+#: cmd/incus/file.go:1489
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1436
+#: cmd/incus/file.go:1442
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 


### PR DESCRIPTION
The storage command on CLI has the following examples:
  incus create storage s1 dir
  incus create storage s1 dir < config.yaml
This is wrong syntax because incus create is used for creating VMs and not storage, the examples should present incus storage create instead.
 