### PR TITLE
Add support for USB NICs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2752,3 +2752,7 @@ Introduces `ipv4.dhcp.expiry` for OVN networks.
 ## `instance_state_cpu_time`
 
 This adds an `allocated_time` field below `CPU` in the instance state API.
+
+## `network_io_bus`
+
+This introduces a new `io.bus` property for compatible network devices allowing to choose between `virtio` (default) and `usb`.

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -10,6 +10,11 @@ NICs support hotplugging for both containers and VMs (with the exception of the 
 Network devices, also referred to as *Network Interface Controllers* or *NICs*, supply a connection to a network.
 Incus supports several different types of network devices (*NIC types*).
 
+```{note}
+When using a USB network adapter with a VM, mainline QEMU will replace the leading two bytes of a MAC address with `40:`.
+Those affected by this may want to manually set the `hwaddr` property to a MAC address starting with `40:` to align the host and guest reporting of the MAC.
+```
+
 ## `nictype` vs. `network`
 
 When adding a network device to an instance, there are two methods to specify the type of device that you want to add: through the `nictype` device option or the `network` device option.
@@ -75,6 +80,7 @@ Key                                   | Type    | Default           | Managed | 
 `boot.priority`                       | integer | -                 | no      | Boot priority for VMs (higher value boots first)
 `host_name`                           | string  | randomly assigned | no      | The name of the interface inside the host
 `hwaddr`                              | string  | randomly assigned | no      | The MAC address of the new interface
+`io.bus`                              | string  | `virtio`          | no      | Override the bus for the device (can be `virtio` or `usb`) (VM only)
 `ipv4.address`                        | string  | -                 | no      | An IPv4 address to assign to the instance through DHCP (can be `none` to restrict all IPv4 traffic when `security.ipv4_filtering` is set)
 `ipv4.routes`                         | string  | -                 | no      | Comma-delimited list of IPv4 static routes to add on host to NIC
 `ipv4.routes.external`                | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC and publish on uplink network (BGP)
@@ -123,6 +129,7 @@ Key                     | Type    | Default           | Managed | Description
 `boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
 `gvrp`                  | bool    | `false`           | no      | Register VLAN using GARP VLAN Registration Protocol
 `hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
+`io.bus`                | string  | `virtio`          | no      | Override the bus for the device (can be `virtio` or `usb`) (VM only)
 `mode`                  | string  | `bridge`          | no      | Macvlan mode (one of `bridge`, `vepa`, `passthru` or `private`)
 `mtu`                   | integer | parent MTU        | yes     | The MTU of the new interface
 `name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
@@ -350,6 +357,7 @@ Key                     | Type    | Default           | Description
 `boot.priority`         | integer | -                 | Boot priority for VMs (higher value boots first)
 `host_name`             | string  | randomly assigned | The name of the interface inside the host
 `hwaddr`                | string  | randomly assigned | The MAC address of the new interface
+`io.bus`                | string  | `virtio`          | Override the bus for the device (can be `virtio` or `usb`) (VM only)
 `ipv4.routes`           | string  | -                 | Comma-delimited list of IPv4 static routes to add on host to NIC
 `ipv6.routes`           | string  | -                 | Comma-delimited list of IPv6 static routes to add on host to NIC
 `limits.egress`         | string  | -                 | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
@@ -429,6 +437,7 @@ Key                     | Type    | Default           | Description
 `gvrp`                  | bool    | `false`           | Register VLAN using GARP VLAN Registration Protocol
 `host_name`             | string  | randomly assigned | The name of the interface inside the host
 `hwaddr`                | string  | randomly assigned | The MAC address of the new interface
+`io.bus`                | string  | `virtio`          | Override the bus for the device (can be `virtio` or `usb`) (VM only)
 `ipv4.address`          | string  | -                 | Comma-delimited list of IPv4 static addresses to add to the instance
 `ipv4.gateway`          | string  | `auto`            | Whether to add an automatic default IPv4 gateway (can be `auto` or `none`)
 `ipv4.host_address`     | string  | `169.254.0.1`     | The IPv4 address to add to the host-side `veth` interface

--- a/internal/server/device/config/device_runconfig.go
+++ b/internal/server/device/config/device_runconfig.go
@@ -66,6 +66,7 @@ type RunConfig struct {
 	TPMDevice        []RunConfigItem  // TPM device configuration settings.
 	PCIDevice        []RunConfigItem  // PCI device configuration settings.
 	Revert           revert.Hook      // Revert setup of device on post-setup error.
+	UseUSBBus        bool             // Whether to use a USB bus for the device.
 }
 
 // NICConfigDir shared constant used to indicate where NIC config is stored.

--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -99,6 +99,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		"security.acls.default.egress.logged",
 		"boot.priority",
 		"vlan",
+		"io.bus",
 	}
 
 	// checkWithManagedNetwork validates the device's settings against the managed network.
@@ -681,6 +682,10 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: peerName},
 		{Key: "hwaddr", Value: d.config["hwaddr"]},
+	}
+
+	if d.config["io.bus"] == "usb" {
+		runConf.UseUSBBus = true
 	}
 
 	if d.inst.Type() == instancetype.VM {

--- a/internal/server/device/nic_macvlan.go
+++ b/internal/server/device/nic_macvlan.go
@@ -52,6 +52,7 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		"boot.priority",
 		"gvrp",
 		"mode",
+		"io.bus",
 	}
 
 	// Check that if network proeperty is set that conflicting keys are not present.
@@ -263,6 +264,10 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: saveData["host_name"]},
 		{Key: "hwaddr", Value: d.config["hwaddr"]},
+	}
+
+	if d.config["io.bus"] == "usb" {
+		runConf.UseUSBBus = true
 	}
 
 	if d.inst.Type() == instancetype.VM {

--- a/internal/server/device/nic_p2p.go
+++ b/internal/server/device/nic_p2p.go
@@ -42,6 +42,7 @@ func (d *nicP2P) validateConfig(instConf instance.ConfigReader) error {
 		"ipv4.routes",
 		"ipv6.routes",
 		"boot.priority",
+		"io.bus",
 	}
 
 	err := d.config.Validate(nicValidationRules([]string{}, optionalFields, instConf))
@@ -149,6 +150,10 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: peerName},
 		{Key: "hwaddr", Value: d.config["hwaddr"]},
+	}
+
+	if d.config["io.bus"] == "usb" {
+		runConf.UseUSBBus = true
 	}
 
 	if d.inst.Type() == instancetype.VM {

--- a/internal/server/device/nic_routed.go
+++ b/internal/server/device/nic_routed.go
@@ -81,6 +81,7 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		"ipv6.host_table",
 		"gvrp",
 		"vrf",
+		"io.bus",
 	}
 
 	rules := nicValidationRules(requiredFields, optionalFields, instConf)
@@ -508,6 +509,10 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: peerName},
 		{Key: "hwaddr", Value: d.config["hwaddr"]},
+	}
+
+	if d.config["io.bus"] == "usb" {
+		runConf.UseUSBBus = true
 	}
 
 	if d.inst.Type() == instancetype.Container {

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -472,6 +472,7 @@ var APIExtensions = []string{
 	"acme_http01_port",
 	"network_ovn_ipv4_dhcp_expiry",
 	"instance_state_cpu_time",
+	"network_io_bus",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR allows to use USB emulation for NICs through an `io.bus` device option.
It introduces a `UseUSBBus` field to the `RunConfig` struct, which may also help for #1697