### PR TITLE
incusd/instance/qemu enable s4 by default

### DIFF
--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -299,16 +299,17 @@ value = "1"
 [global]
 driver = "ICH9-LPC"
 property = "disable_s4"
-value = "1"
+value = "0"
 ```
 
-To specify which section to override, specify an index.
-For example:
+The first `global` section disabled S3(Suspend to RAM), the second `global`
+section enabled S4(suspend to disk). In order to disable S4, the second `global`
+section index needs to be specified:
 
 ```
 raw.qemu.conf: |-
     [global][1]
-    value = "0"
+    value = "1"
 ```
 
 Section indexes start at 0 (which is the default value when not specified), so the above example would generate the following configuration:
@@ -322,7 +323,7 @@ value = "1"
 [global]
 driver = "ICH9-LPC"
 property = "disable_s4"
-value = "0"
+value = "1"
 ```
 
 ### Override QEMU runtime objects

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -48,7 +48,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[global]
 			driver = "ICH9-LPC"
 			property = "disable_s4"
-			value = "1"
+			value = "0"
 
 			[boot-opts]
 			strict = "on"`,
@@ -1097,7 +1097,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			Entries: []cfg.Entry{
 				{Key: "driver", Value: "ICH9-LPC"},
 				{Key: "property", Value: "disable_s4"},
-				{Key: "value", Value: "1"},
+				{Key: "value", Value: "0"},
 			},
 		}, {
 			Name: "memory",
@@ -1135,7 +1135,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[global]
 			driver = "ICH9-LPC"
 			property = "disable_s4"
-			value = "1"
+			value = "0"
 
 			[memory]
 			size = "1024M"
@@ -1168,7 +1168,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 			[global]
 			driver = "ICH9-LPC"
 			property = "disable_s4"
-			value = "1"
+			value = "0"
 
 			[memory]
 			size = "4096M"
@@ -1201,7 +1201,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "1024M"
@@ -1238,7 +1238,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "1024M"
@@ -1279,7 +1279,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "2048M"
@@ -1338,7 +1338,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "1024M"
@@ -1385,7 +1385,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "1024M"
@@ -1470,7 +1470,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "1024M"
@@ -1525,7 +1525,7 @@ func TestQemuConfigTemplates(t *testing.T) {
 				[global]
 				driver = "ICH9-LPC"
 				property = "disable_s4"
-				value = "1"
+				value = "0"
 
 				[memory]
 				size = "8192M"

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -101,7 +101,7 @@ func qemuBase(opts *qemuBaseOpts) []cfg.Section {
 			Entries: []cfg.Entry{
 				{Key: "driver", Value: "ICH9-LPC"},
 				{Key: "property", Value: "disable_s4"},
-				{Key: "value", Value: "1"},
+				{Key: "value", Value: "0"},
 			},
 		}}...)
 	}


### PR DESCRIPTION
Windows fast startup feature is enabled by default, which depends on s4 feature enabled. If s4 disabled by default, Windows fast startup would not work, which lead to longer boot time. And for linux s4 feature has no obvious hurt.