### PR TITLE
Extend minio client naming

### DIFF
--- a/internal/server/storage/s3/miniod/admin_client.go
+++ b/internal/server/storage/s3/miniod/admin_client.go
@@ -101,11 +101,13 @@ func (c *AdminClient) isMinIOClient() bool {
 		return false
 	}
 
-	if !strings.Contains(lines[0], "mc version") && !strings.Contains(lines[0], "mcli version") {
-		return false
+	for _, name := range []string{"miniocli", "minioc", "mcli", "minio-client", "mc"} {
+		if strings.Contains(lines[0], name+" version") {
+			return true
+		}
 	}
 
-	return true
+	return false
 }
 
 // ServiceStop stops the MinIO cluster.

--- a/internal/server/storage/s3/miniod/miniod.go
+++ b/internal/server/storage/s3/miniod/miniod.go
@@ -70,7 +70,7 @@ func (p *Process) AdminUser() string {
 func (p *Process) AdminClient() (*AdminClient, error) {
 	var binaryName string
 
-	for _, name := range []string{"miniocli", "minioc", "mcli", "mc"} {
+	for _, name := range []string{"miniocli", "minioc", "mcli", "minio-client", "mc"} {
 		_, err := exec.LookPath(name)
 		if err == nil {
 			binaryName = name


### PR DESCRIPTION
Building on #1821, add `minio-client` to the list of potential MinIO client binaries, and update logic in admin_client.go to match changes in miniod.go.