### PR TITLE
golangci: Upgrade to version 2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,122 +1,84 @@
+version: "2"
 linters:
   enable:
-    - gci
     - godot
+    - misspell
+    - revive
+    - whitespace
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.ReadCloser).Close
+        - (io.WriteCloser).Close
+        - (io.ReadWriteCloser).Close
+        - (*os.File).Close
+        - (*github.com/gorilla/websocket.Conn).Close
+        - (*github.com/mdlayher/vsock.Listener).Close
+        - os.Remove
+        - (*compress/gzip.Writer).Close
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - checkPrivateReceivers
+            - disableStutteringCheck
+        - name: import-shadowing
+        - name: unchecked-type-assertion
+        - name: var-naming
+          arguments:
+            - []
+            - []
+            - - upperCaseConst: true
+        - name: early-return
+        - name: redundant-import-alias
+        - name: redefines-builtin-id
+        - name: struct-tag
+        - name: receiver-naming
+        - name: deep-exit
+        - name: defer
+        - name: bool-literal-in-expr
+        - name: comment-spacings
+        - name: use-any
+        - name: bare-return
+        - name: empty-block
+        - name: range-val-address
+        - name: range-val-in-closure
+        - name: var-declaration
+        - name: useless-break
+        - name: error-naming
+        - name: indent-error-flow
+        - name: datarace
+        - name: modifies-value-receiver
+        - name: empty-lines
+        - name: duplicated-imports
+        - name: error-return
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        source: '^//generate-database:mapper '
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
     - gofumpt
     - goimports
-    - misspell
-    - whitespace
-    - revive
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - revive
-      source: "^//generate-database:mapper "
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/lxc/incus)
-  goimports:
-    local-prefixes: github.com/lxc/incus
-  errcheck:
-    exclude-functions:
-      - (io.ReadCloser).Close
-      - (io.WriteCloser).Close
-      - (io.ReadWriteCloser).Close
-      - (*os.File).Close
-      - (*github.com/gorilla/websocket.Conn).Close
-      - (*github.com/mdlayher/vsock.Listener).Close
-      - os.Remove
-      - (*compress/gzip.Writer).Close
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-          - "disableStutteringCheck"
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#import-shadowing
-      - name: import-shadowing
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
-      - name: unchecked-type-assertion
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
-      - name: var-naming
-        arguments: # The arguments here are quite odd looking. See the rule description.
-          - [ ]
-          - [ ]
-          - [ { "upperCaseConst": true } ]
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
-      - name: early-return
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias
-      - name: redundant-import-alias
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redefines-builtin-id
-      - name: redefines-builtin-id
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#struct-tag
-      - name: struct-tag
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#receiver-naming
-      - name: receiver-naming
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
-      - name: deep-exit
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
-      - name: defer
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-      - name: bool-literal-in-expr
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#comment-spacings
-      - name: comment-spacings
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#use-any
-      - name: use-any
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bare-return
-      - name: bare-return
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-block
-      - name: empty-block
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-address
-      - name: range-val-address
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-in-closure
-      - name: range-val-in-closure
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-declaration
-      - name: var-declaration
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#useless-break
-      - name: useless-break
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-naming
-      - name: error-naming
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#indent-error-flow
-      - name: indent-error-flow
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#datarace
-      - name: datarace
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#modifies-value-receiver
-      - name: modifies-value-receiver
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-lines
-      - name: empty-lines
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#duplicated-imports
-      - name: duplicated-imports
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
-      - name: error-return
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/lxc/incus)
+    goimports:
+      local-prefixes:
+        - github.com/lxc/incus
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Some of the CI tools occasionally break with older Go versions and the static analysis result shouldn't depend on Go versions anyway.