### PR TITLE
Add support for server-side filtering by instance name

### DIFF
--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -1353,7 +1353,7 @@ func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	serverFilters, clientFilters := getServerSupportedFilters(filters, api.Image{})
+	serverFilters, clientFilters := getServerSupportedFilters(filters, api.Image{}, false)
 
 	var allImages, images []api.Image
 	if c.flagAllProjects {

--- a/cmd/incus/list_test.go
+++ b/cmd/incus/list_test.go
@@ -115,10 +115,6 @@ func TestShouldShow(t *testing.T) {
 		t.Error("user.blah=abc type=container didn't match")
 	}
 
-	if list.shouldShow([]string{"bar", "u.blah=abc"}, inst, nil, false) {
-		t.Errorf("name filter didn't work")
-	}
-
 	if list.shouldShow([]string{"bar", "u.blah=other"}, inst, nil, false) {
 		t.Errorf("value filter didn't work")
 	}

--- a/cmd/incus/utils_test.go
+++ b/cmd/incus/utils_test.go
@@ -78,7 +78,11 @@ func (s *utilsTestSuite) TestGetServerSupportedFilters() {
 		"foo", "type=container", "user.blah=a", "status=running,stopped",
 	}
 
-	supportedFilters, unsupportedFilters := getServerSupportedFilters(filters, api.InstanceFull{})
+	supportedFilters, unsupportedFilters := getServerSupportedFilters(filters, api.InstanceFull{}, false)
 	s.Equal([]string{"type=container"}, supportedFilters)
 	s.Equal([]string{"foo", "user.blah=a", "status=running,stopped"}, unsupportedFilters)
+
+	supportedFilters, unsupportedFilters = getServerSupportedFilters(filters, api.InstanceFull{}, true)
+	s.Equal([]string{"foo", "type=container"}, supportedFilters)
+	s.Equal([]string{"user.blah=a", "status=running,stopped"}, unsupportedFilters)
 }


### PR DESCRIPTION
This PR introduces the following changes:
- Added a parameter (`singleValueServerSupport`) to `getServerSupportedFilters`. This new parameter determines whether single-value filters should be handled by the server or the client. Images use single-value filters to filter by aliases and fingerprints, which can be more complex to implement on the server side. Since image filtering is less critical compared to instances, handling this on the client side is acceptable.
- Introduced `modifySingleValueFilters`. This function prepares single-value filters into a format that is accepted by the server.
- Fixed duplicate filters issue - resolved a bug where duplicate filters were being added to the filters slice.