### PR TITLE
incusd/instance/lxc: Fix max gid when in a privileged container

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2316,7 +2316,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		}
 
 		// Allow unprivileged users to use ping.
-		maxGid := int64(4294967295)
+		maxGid := int64(4294967294)
 
 		if !d.IsPrivileged() {
 			maxGid = 0


### PR DESCRIPTION
Closes #1858