### PR TITLE
Docs: correct restriction on `path` option

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -132,7 +132,7 @@ For file systems (shared directories or custom volumes), this is one of:
 
 ```{config:option} path devices-disk
 :required: "yes"
-:shortdesc: "Path inside the instance where the disk will be mounted (only for containers)"
+:shortdesc: "Path inside the instance where the disk will be mounted (only for file system disk devices)"
 :type: "string"
 
 ```

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -322,7 +322,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		// ---
 		//  type: string
 		//  required: yes
-		//  shortdesc: Path inside the instance where the disk will be mounted (only for containers)
+		//  shortdesc: Path inside the instance where the disk will be mounted (only for file system disk devices)
 		"path": validate.IsAny,
 
 		// gendoc:generate(entity=devices, group=disk, key=io.cache)

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -131,7 +131,7 @@
 						"path": {
 							"longdesc": "",
 							"required": "yes",
-							"shortdesc": "Path inside the instance where the disk will be mounted (only for containers)",
+							"shortdesc": "Path inside the instance where the disk will be mounted (only for file system disk devices)",
 							"type": "string"
 						}
 					},


### PR DESCRIPTION
Currently the documentation for the `path` option says it is only available for containers. It is available for custom filesystem volumes on VMs as well, and I assume also for ceph filesystem mounts on VMs.