### PR TITLE
incusd/instance/edk2: Limit test to UEFI architectures

### DIFF
--- a/internal/server/instance/drivers/edk2/driver_edk2_test.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2_test.go
@@ -1,3 +1,5 @@
+//go:build amd64 || arm64
+
 package edk2
 
 import (


### PR DESCRIPTION
Closes #1863