### PR TITLE
Enable filtering with the `all-projects` flag when listing images

### DIFF
--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -55,6 +55,27 @@ func (r *ProtocolIncus) GetImagesAllProjects() ([]api.Image, error) {
 	return images, nil
 }
 
+// GetImagesAllProjectsWithFilter returns a filtered list of images across all projects as Image structs.
+func (r *ProtocolIncus) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
+	images := []api.Image{}
+
+	v := url.Values{}
+	v.Set("recursion", "1")
+	v.Set("all-projects", "true")
+	v.Set("filter", parseFilters(filters))
+
+	if !r.HasExtension("images_all_projects") {
+		return nil, fmt.Errorf("The server is missing the required \"images_all_projects\" API extension")
+	}
+
+	_, err := r.queryStruct("GET", fmt.Sprintf("/images?%s", v.Encode()), nil, "", &images)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolIncus) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	if !r.HasExtension("api_filtering") {

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -49,6 +49,7 @@ type ImageServer interface {
 	// Image handling functions
 	GetImages() (images []api.Image, err error)
 	GetImagesAllProjects() (images []api.Image, err error)
+	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 	GetImageFingerprints() (fingerprints []string, err error)
 	GetImagesWithFilter(filters []string) (images []api.Image, err error)
 

--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -60,6 +60,11 @@ func (r *ProtocolOCI) GetImagesAllProjects() ([]api.Image, error) {
 	return nil, fmt.Errorf("Can't list images from OCI registry")
 }
 
+// GetImagesAllProjectsWithFilter returns a filtered list of available images as Image structs.
+func (r *ProtocolOCI) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
+	return nil, fmt.Errorf("Can't list images from OCI registry")
+}
+
 // GetImageFingerprints returns a list of available image fingerprints.
 func (r *ProtocolOCI) GetImageFingerprints() ([]string, error) {
 	return nil, fmt.Errorf("Can't list images from OCI registry")

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -31,6 +31,11 @@ func (r *ProtocolSimpleStreams) GetImagesAllProjects() ([]api.Image, error) {
 	return r.GetImages()
 }
 
+// GetImagesAllProjectsWithFilter returns a filtered list of available images as Image structs.
+func (r *ProtocolSimpleStreams) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
+	return nil, fmt.Errorf("GetImagesWithFilter is not supported by the simplestreams protocol")
+}
+
 // GetImageFingerprints returns a list of available image fingerprints.
 func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 	// Get all the images from simplestreams

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -1358,9 +1358,14 @@ func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
 
 	var allImages, images []api.Image
 	if c.flagAllProjects {
-		allImages, err = remoteServer.GetImagesAllProjects()
+		allImages, err = remoteServer.GetImagesAllProjectsWithFilter(serverFilters)
 		if err != nil {
-			return err
+			allImages, err = remoteServer.GetImagesAllProjects()
+			if err != nil {
+				return err
+			}
+
+			clientFilters = filters
 		}
 	} else {
 		allImages, err = remoteServer.GetImagesWithFilter(serverFilters)


### PR DESCRIPTION
Currently, filtering cannot be used together with the `all-projects` flag when listing images.
This PR introduces `GetImagesAllProjectsWithFilter`, allowing image filtering while the `all-projects` flag is enabled.