### PR TITLE
Fix all static analysis in client/, shared/ and cmd/incus/

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -74,8 +74,8 @@ type ConnectionArgs struct {
 // If connecting to an Incus daemon running in PKI mode, the PKI CA (TLSCA) must also be provided.
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
-func ConnectIncus(url string, args *ConnectionArgs) (InstanceServer, error) {
-	return ConnectIncusWithContext(context.Background(), url, args)
+func ConnectIncus(uri string, args *ConnectionArgs) (InstanceServer, error) {
+	return ConnectIncusWithContext(context.Background(), uri, args)
 }
 
 // ConnectIncusWithContext lets you connect to a remote Incus daemon over HTTPs with context.Context.
@@ -85,13 +85,13 @@ func ConnectIncus(url string, args *ConnectionArgs) (InstanceServer, error) {
 // If connecting to an Incus daemon running in PKI mode, the PKI CA (TLSCA) must also be provided.
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
-func ConnectIncusWithContext(ctx context.Context, url string, args *ConnectionArgs) (InstanceServer, error) {
+func ConnectIncusWithContext(ctx context.Context, uri string, args *ConnectionArgs) (InstanceServer, error) {
 	// Cleanup URL
-	url = strings.TrimSuffix(url, "/")
+	uri = strings.TrimSuffix(uri, "/")
 
-	logger.Debug("Connecting to a remote Incus over HTTPS", logger.Ctx{"url": url})
+	logger.Debug("Connecting to a remote Incus over HTTPS", logger.Ctx{"url": uri})
 
-	return httpsIncus(ctx, url, args)
+	return httpsIncus(ctx, uri, args)
 }
 
 // ConnectIncusHTTP lets you connect to a VM agent over a VM socket.
@@ -240,30 +240,30 @@ func ConnectIncusUnixWithContext(ctx context.Context, path string, args *Connect
 // ConnectPublicIncus lets you connect to a remote public Incus daemon over HTTPs.
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
-func ConnectPublicIncus(url string, args *ConnectionArgs) (ImageServer, error) {
-	return ConnectPublicIncusWithContext(context.Background(), url, args)
+func ConnectPublicIncus(uri string, args *ConnectionArgs) (ImageServer, error) {
+	return ConnectPublicIncusWithContext(context.Background(), uri, args)
 }
 
 // ConnectPublicIncusWithContext lets you connect to a remote public Incus daemon over HTTPs with context.Context.
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
-func ConnectPublicIncusWithContext(ctx context.Context, url string, args *ConnectionArgs) (ImageServer, error) {
+func ConnectPublicIncusWithContext(ctx context.Context, uri string, args *ConnectionArgs) (ImageServer, error) {
 	logger.Debug("Connecting to a remote public Incus over HTTPS")
 
 	// Cleanup URL
-	url = strings.TrimSuffix(url, "/")
+	uri = strings.TrimSuffix(uri, "/")
 
-	return httpsIncus(ctx, url, args)
+	return httpsIncus(ctx, uri, args)
 }
 
 // ConnectSimpleStreams lets you connect to a remote SimpleStreams image server over HTTPs.
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
-func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error) {
-	logger.Debug("Connecting to a remote simplestreams server", logger.Ctx{"URL": url})
+func ConnectSimpleStreams(uri string, args *ConnectionArgs) (ImageServer, error) {
+	logger.Debug("Connecting to a remote simplestreams server", logger.Ctx{"URL": uri})
 
 	// Cleanup URL
-	url = strings.TrimSuffix(url, "/")
+	uri = strings.TrimSuffix(uri, "/")
 
 	// Use empty args if not specified
 	if args == nil {
@@ -272,7 +272,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 
 	// Initialize the client struct
 	server := ProtocolSimpleStreams{
-		httpHost:        url,
+		httpHost:        uri,
 		httpUserAgent:   args.UserAgent,
 		httpCertificate: args.TLSServerCert,
 	}
@@ -286,7 +286,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 	server.http = httpClient
 
 	// Get simplestreams client
-	ssClient := simplestreams.NewClient(url, *httpClient, args.UserAgent)
+	ssClient := simplestreams.NewClient(uri, *httpClient, args.UserAgent)
 	server.ssClient = ssClient
 
 	// Setup the cache
@@ -295,7 +295,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 			return nil, fmt.Errorf("Cache directory %q doesn't exist", args.CachePath)
 		}
 
-		hashedURL := fmt.Sprintf("%x", sha256.Sum256([]byte(url)))
+		hashedURL := fmt.Sprintf("%x", sha256.Sum256([]byte(uri)))
 
 		cachePath := filepath.Join(args.CachePath, hashedURL)
 		cacheExpiry := args.CacheExpiry

--- a/client/incus_cluster.go
+++ b/client/incus_cluster.go
@@ -33,7 +33,7 @@ func (r *ProtocolIncus) UpdateCluster(cluster api.ClusterPut, ETag string) (Oper
 		}
 	}
 
-	op, _, err := r.queryOperation("PUT", "/cluster", cluster, "")
+	op, _, err := r.queryOperation("PUT", "/cluster", cluster, ETag)
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -2,6 +2,7 @@ package incus
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -129,7 +130,12 @@ func (r *ProtocolIncus) GetImageSecret(fingerprint string) (string, error) {
 
 	opAPI := op.Get()
 
-	return opAPI.Metadata["secret"].(string), nil
+	secret, ok := opAPI.Metadata["secret"].(string)
+	if !ok {
+		return "", errors.New("Bad secret type")
+	}
+
+	return secret, nil
 }
 
 // GetPrivateImage is similar to GetImage but allows passing a secret download token.
@@ -273,7 +279,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 	}
 
 	// Hashing
-	sha256 := sha256.New()
+	hashSHA256 := sha256.New()
 
 	// Deal with split images
 	if ctype == "multipart/form-data" {
@@ -294,7 +300,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 			return nil, fmt.Errorf("Invalid multipart image")
 		}
 
-		size, err := io.Copy(io.MultiWriter(req.MetaFile, sha256), part)
+		size, err := io.Copy(io.MultiWriter(req.MetaFile, hashSHA256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -312,7 +318,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 			return nil, fmt.Errorf("Invalid multipart image")
 		}
 
-		size, err = io.Copy(io.MultiWriter(req.RootfsFile, sha256), part)
+		size, err = io.Copy(io.MultiWriter(req.RootfsFile, hashSHA256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +327,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 		resp.RootfsName = part.FileName()
 
 		// Check the hash
-		hash := fmt.Sprintf("%x", sha256.Sum(nil))
+		hash := fmt.Sprintf("%x", hashSHA256.Sum(nil))
 		if imageType != "oci" && !strings.HasPrefix(hash, fingerprint) {
 			return nil, fmt.Errorf("Image fingerprint doesn't match. Got %s expected %s", hash, fingerprint)
 		}
@@ -340,7 +346,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 		return nil, fmt.Errorf("No filename in Content-Disposition header")
 	}
 
-	size, err := io.Copy(io.MultiWriter(req.MetaFile, sha256), body)
+	size, err := io.Copy(io.MultiWriter(req.MetaFile, hashSHA256), body)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +355,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 	resp.MetaName = filename
 
 	// Check the hash
-	hash := fmt.Sprintf("%x", sha256.Sum(nil))
+	hash := fmt.Sprintf("%x", hashSHA256.Sum(nil))
 	if imageType != "oci" && !strings.HasPrefix(hash, fingerprint) {
 		return nil, fmt.Errorf("Image fingerprint doesn't match. Got %s expected %s", hash, fingerprint)
 	}
@@ -653,18 +659,23 @@ func (r *ProtocolIncus) tryCopyImage(req api.ImagesPost, urls []string) (RemoteO
 				return
 			}
 
-			var errors []remoteOperationResult
+			var errs []remoteOperationResult
 
 			// Get the operation data
 			op, err := rop.GetTarget()
 			if err != nil {
-				errors = append(errors, remoteOperationResult{Error: err})
-				rop.err = remoteOperationError("Failed to get operation data", errors)
+				errs = append(errs, remoteOperationResult{Error: err})
+				rop.err = remoteOperationError("Failed to get operation data", errs)
 				return
 			}
 
 			// Extract the fingerprint
-			fingerprint := op.Metadata["fingerprint"].(string)
+			fingerprint, ok := op.Metadata["fingerprint"].(string)
+			if !ok {
+				errs = append(errs, remoteOperationResult{Error: errors.New("Bad fingerprint")})
+				rop.err = remoteOperationError("Failed to get operation data", errs)
+				return
+			}
 
 			// Add the aliases
 			for _, entry := range req.Aliases {
@@ -674,8 +685,8 @@ func (r *ProtocolIncus) tryCopyImage(req api.ImagesPost, urls []string) (RemoteO
 
 				err := r.CreateImageAlias(alias)
 				if err != nil {
-					errors = append(errors, remoteOperationResult{Error: err})
-					rop.err = remoteOperationError("Failed to create image alias", errors)
+					errs = append(errs, remoteOperationResult{Error: err})
+					rop.err = remoteOperationError("Failed to create image alias", errs)
 					return
 				}
 			}
@@ -685,13 +696,13 @@ func (r *ProtocolIncus) tryCopyImage(req api.ImagesPost, urls []string) (RemoteO
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		var errors []remoteOperationResult
+		var errs []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Source.Server = serverURL
 
 			op, err := r.CreateImage(req, nil)
 			if err != nil {
-				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
+				errs = append(errs, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -705,7 +716,7 @@ func (r *ProtocolIncus) tryCopyImage(req api.ImagesPost, urls []string) (RemoteO
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
+				errs = append(errs, remoteOperationResult{URL: serverURL, Error: err})
 
 				if localtls.IsConnectionError(err) {
 					continue
@@ -719,7 +730,7 @@ func (r *ProtocolIncus) tryCopyImage(req api.ImagesPost, urls []string) (RemoteO
 		}
 
 		if !success {
-			rop.err = remoteOperationError("Failed remote image download", errors)
+			rop.err = remoteOperationError("Failed remote image download", errs)
 		}
 
 		close(rop.chDone)

--- a/client/incus_network_acls.go
+++ b/client/incus_network_acls.go
@@ -85,13 +85,13 @@ func (r *ProtocolIncus) GetNetworkACLLogfile(name string) (io.ReadCloser, error)
 	}
 
 	// Prepare the HTTP request
-	url := fmt.Sprintf("%s/1.0/network-acls/%s/log", r.httpBaseURL.String(), url.PathEscape(name))
-	url, err := r.setQueryAttributes(url)
+	uri := fmt.Sprintf("%s/1.0/network-acls/%s/log", r.httpBaseURL.String(), url.PathEscape(name))
+	uri, err := r.setQueryAttributes(uri)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_oidc.go
+++ b/client/incus_oidc.go
@@ -47,13 +47,12 @@ func (r *ProtocolIncus) GetOIDCTokens() *oidc.Tokens[*oidc.IDTokenClaims] {
 	return r.oidcClient.tokens
 }
 
-// Custom transport that modifies requests to inject the audience field.
+// oidcTransport is a custom HTTP transport that injects the audience field into requests directed at the device authorization endpoint.
 type oidcTransport struct {
 	deviceAuthorizationEndpoint string
 	audience                    string
 }
 
-// oidcTransport is a custom HTTP transport that injects the audience field into requests directed at the device authorization endpoint.
 // RoundTrip is a method of oidcTransport that modifies the request, adds the audience parameter if appropriate, and sends it along.
 func (o *oidcTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	// Don't modify the request if it's not to the device authorization endpoint, or there are no
@@ -255,12 +254,12 @@ func (o *oidcClient) refresh(issuer string, clientID string) error {
 		return errRefreshAccessToken
 	}
 
-	o.tokens.Token.AccessToken = oauthTokens.AccessToken
+	o.tokens.AccessToken = oauthTokens.AccessToken
 	o.tokens.TokenType = oauthTokens.TokenType
 	o.tokens.Expiry = oauthTokens.Expiry
 
 	if oauthTokens.RefreshToken != "" {
-		o.tokens.Token.RefreshToken = oauthTokens.RefreshToken
+		o.tokens.RefreshToken = oauthTokens.RefreshToken
 	}
 
 	return nil
@@ -312,11 +311,11 @@ func (o *oidcClient) authenticate(issuer string, clientID string, audience strin
 
 	o.tokens.Expiry = time.Now().Add(time.Duration(token.ExpiresIn))
 	o.tokens.IDToken = token.IDToken
-	o.tokens.Token.AccessToken = token.AccessToken
+	o.tokens.AccessToken = token.AccessToken
 	o.tokens.TokenType = token.TokenType
 
 	if token.RefreshToken != "" {
-		o.tokens.Token.RefreshToken = token.RefreshToken
+		o.tokens.RefreshToken = token.RefreshToken
 	}
 
 	return nil

--- a/client/incus_server.go
+++ b/client/incus_server.go
@@ -192,7 +192,7 @@ func (r *ProtocolIncus) GetMetrics() (string, error) {
 // ApplyServerPreseed configures a target Incus server with the provided server and cluster configuration.
 func (r *ProtocolIncus) ApplyServerPreseed(config api.InitPreseed) error {
 	// Apply server configuration.
-	if config.Server.Config != nil && len(config.Server.Config) > 0 {
+	if len(config.Server.Config) > 0 {
 		// Get current config.
 		server, etag, err := r.GetServer()
 		if err != nil {
@@ -211,7 +211,7 @@ func (r *ProtocolIncus) ApplyServerPreseed(config api.InitPreseed) error {
 	}
 
 	// Apply storage configuration.
-	if config.Server.StoragePools != nil && len(config.Server.StoragePools) > 0 {
+	if len(config.Server.StoragePools) > 0 {
 		// Get the list of storagePools.
 		storagePoolNames, err := r.GetStoragePoolNames()
 		if err != nil {
@@ -330,7 +330,7 @@ func (r *ProtocolIncus) ApplyServerPreseed(config api.InitPreseed) error {
 	}
 
 	// Apply project configuration.
-	if config.Server.Projects != nil && len(config.Server.Projects) > 0 {
+	if len(config.Server.Projects) > 0 {
 		// Get the list of projects.
 		projectNames, err := r.GetProjectNames()
 		if err != nil {
@@ -469,8 +469,7 @@ func (r *ProtocolIncus) ApplyServerPreseed(config api.InitPreseed) error {
 	}
 
 	// Apply profile configuration.
-	if config.Server.Profiles != nil && len(config.Server.Profiles) > 0 {
-
+	if len(config.Server.Profiles) > 0 {
 		// Apply profile configuration.
 		applyProfile := func(profile api.InitProfileProjectPost) error {
 			// Get the current profile.
@@ -535,7 +534,6 @@ func (r *ProtocolIncus) ApplyServerPreseed(config api.InitPreseed) error {
 			if err != nil {
 				return err
 			}
-
 		}
 	}
 

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -108,12 +108,12 @@ func (r *ProtocolIncus) GetStoragePoolVolumesAllProjects(pool string) ([]api.Sto
 
 	volumes := []api.StorageVolume{}
 
-	url := api.NewURL().Path("storage-pools", pool, "volumes").
+	uri := api.NewURL().Path("storage-pools", pool, "volumes").
 		WithQuery("recursion", "1").
 		WithQuery("all-projects", "true")
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", url.String(), nil, "", &volumes)
+	_, err = r.queryStruct("GET", uri.String(), nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -155,13 +155,13 @@ func (r *ProtocolIncus) GetStoragePoolVolumesWithFilterAllProjects(pool string, 
 
 	volumes := []api.StorageVolume{}
 
-	url := api.NewURL().Path("storage-pools", pool, "volumes").
+	uri := api.NewURL().Path("storage-pools", pool, "volumes").
 		WithQuery("recursion", "1").
 		WithQuery("filter", parseFilters(filters)).
 		WithQuery("all-projects", "true")
 
 	// Fetch the raw value.
-	_, err = r.queryStruct("GET", url.String(), nil, "", &volumes)
+	_, err = r.queryStruct("GET", uri.String(), nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +636,10 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 
 		targetSecrets := map[string]string{}
 		for k, v := range opAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			val, ok := v.(string)
+			if ok {
+				targetSecrets[k] = val
+			}
 		}
 
 		// Prepare the source request
@@ -666,7 +669,10 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 	// Prepare source server secrets for remote
 	sourceSecrets := map[string]string{}
 	for k, v := range opAPI.Metadata {
-		sourceSecrets[k] = v.(string)
+		val, ok := v.(string)
+		if ok {
+			sourceSecrets[k] = val
+		}
 	}
 
 	// Relay mode migration
@@ -689,7 +695,10 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 		// Extract the websockets
 		targetSecrets := map[string]string{}
 		for k, v := range targetOpAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			val, ok := v.(string)
+			if ok {
+				targetSecrets[k] = val
+			}
 		}
 
 		// Launch the relay

--- a/client/incus_warnings.go
+++ b/client/incus_warnings.go
@@ -66,7 +66,7 @@ func (r *ProtocolIncus) UpdateWarning(UUID string, warning api.WarningPut, ETag 
 	}
 
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), warning, "")
+	_, _, err := r.query("PUT", fmt.Sprintf("/warnings/%s", url.PathEscape(UUID)), warning, ETag)
 	if err != nil {
 		return err
 	}

--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -71,7 +71,7 @@ func (r *ProtocolOCI) GetImageFingerprints() ([]string, error) {
 }
 
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
-func (r *ProtocolOCI) GetImagesWithFilter(filters []string) ([]api.Image, error) {
+func (r *ProtocolOCI) GetImagesWithFilter(_ []string) ([]api.Image, error) {
 	return nil, fmt.Errorf("Can't list images from OCI registry")
 }
 
@@ -320,17 +320,17 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 }
 
 // GetImageSecret isn't relevant for the simplestreams protocol.
-func (r *ProtocolOCI) GetImageSecret(fingerprint string) (string, error) {
+func (r *ProtocolOCI) GetImageSecret(_ string) (string, error) {
 	return "", fmt.Errorf("Private images aren't supported with OCI registry")
 }
 
 // GetPrivateImage isn't relevant for the simplestreams protocol.
-func (r *ProtocolOCI) GetPrivateImage(fingerprint string, secret string) (*api.Image, string, error) {
+func (r *ProtocolOCI) GetPrivateImage(_ string, _ string) (*api.Image, string, error) {
 	return nil, "", fmt.Errorf("Private images aren't supported with OCI registry")
 }
 
 // GetPrivateImageFile isn't relevant for the simplestreams protocol.
-func (r *ProtocolOCI) GetPrivateImageFile(fingerprint string, secret string, req ImageFileRequest) (*ImageFileResponse, error) {
+func (r *ProtocolOCI) GetPrivateImageFile(_ string, _ string, _ ImageFileRequest) (*ImageFileResponse, error) {
 	return nil, fmt.Errorf("Private images aren't supported with OCI registry")
 }
 
@@ -439,6 +439,6 @@ func (r *ProtocolOCI) GetImageAliasArchitectures(imageType string, name string) 
 }
 
 // ExportImage exports (copies) an image to a remote server.
-func (r *ProtocolOCI) ExportImage(fingerprint string, image api.ImageExportPost) (Operation, error) {
+func (r *ProtocolOCI) ExportImage(_ string, _ api.ImageExportPost) (Operation, error) {
 	return nil, fmt.Errorf("Exporting images is not supported with OCI registry")
 }

--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -191,7 +191,7 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		"--insecure-policy",
 		"copy",
 		"--remove-signatures",
-		fmt.Sprintf("%s/%s", strings.ReplaceAll(r.httpHost, "https://", "docker://"), info.Alias),
+		fmt.Sprintf("%s/%s", strings.Replace(r.httpHost, "https://", "docker://", 1), info.Alias),
 		fmt.Sprintf("oci:%s:latest", filepath.Join(ociPath, "oci")))
 	if err != nil {
 		logger.Debug("Error copying remote image to local", logger.Ctx{"image": info.Alias, "stdout": stdout, "stderr": err})
@@ -367,7 +367,7 @@ func (r *ProtocolOCI) GetImageAlias(name string) (*api.ImageAliasesEntry, string
 		nil,
 		"skopeo",
 		"inspect",
-		fmt.Sprintf("%s/%s", strings.ReplaceAll(r.httpHost, "https://", "docker://"), name))
+		fmt.Sprintf("%s/%s", strings.Replace(r.httpHost, "https://", "docker://", 1), name))
 	if err != nil {
 		logger.Debug("Error getting image alias", logger.Ctx{"name": name, "stdout": stdout, "stderr": err})
 		return nil, "", err
@@ -381,7 +381,7 @@ func (r *ProtocolOCI) GetImageAlias(name string) (*api.ImageAliasesEntry, string
 	}
 
 	info.Alias = name
-	info.Digest = strings.ReplaceAll(info.Digest, "sha256:", "")
+	info.Digest = strings.Replace(info.Digest, "sha256:", "", 1)
 
 	archID, err := osarch.ArchitectureID(info.Architecture)
 	if err != nil {

--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -383,7 +383,7 @@ func (r *ProtocolOCI) GetImageAlias(name string) (*api.ImageAliasesEntry, string
 	info.Alias = name
 	info.Digest = strings.ReplaceAll(info.Digest, "sha256:", "")
 
-	archID, err := osarch.ArchitectureId(info.Architecture)
+	archID, err := osarch.ArchitectureID(info.Architecture)
 	if err != nil {
 		return nil, "", err
 	}

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/logger"
+	"github.com/lxc/incus/v6/shared/simplestreams"
 	"github.com/lxc/incus/v6/shared/subprocess"
 	"github.com/lxc/incus/v6/shared/util"
 )
@@ -54,7 +55,7 @@ func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 }
 
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
-func (r *ProtocolSimpleStreams) GetImagesWithFilter(filters []string) ([]api.Image, error) {
+func (r *ProtocolSimpleStreams) GetImagesWithFilter(_ []string) ([]api.Image, error) {
 	return nil, fmt.Errorf("GetImagesWithFilter is not supported by the simplestreams protocol")
 }
 
@@ -160,6 +161,48 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 		downloaded := false
 		_, err := exec.LookPath("xdelta3")
 		if err == nil && req.DeltaSourceRetriever != nil {
+			applyDelta := func(file simplestreams.DownloadableFile, srcPath string, target io.Writer) (int64, error) {
+				// Create temporary file for the delta
+				deltaFile, err := os.CreateTemp("", "incus_image_")
+				if err != nil {
+					return -1, err
+				}
+
+				defer func() { _ = deltaFile.Close() }()
+
+				defer func() { _ = os.Remove(deltaFile.Name()) }()
+
+				// Download the delta
+				_, err = download(file.Path, "rootfs delta", file.Sha256, deltaFile)
+				if err != nil {
+					return -1, err
+				}
+
+				// Create temporary file for the delta
+				patchedFile, err := os.CreateTemp("", "incus_image_")
+				if err != nil {
+					return -1, err
+				}
+
+				defer func() { _ = patchedFile.Close() }()
+
+				defer func() { _ = os.Remove(patchedFile.Name()) }()
+
+				// Apply it
+				_, err = subprocess.RunCommand("xdelta3", "-f", "-d", "-s", srcPath, deltaFile.Name(), patchedFile.Name())
+				if err != nil {
+					return -1, err
+				}
+
+				// Copy to the target
+				size, err := io.Copy(req.RootfsFile, patchedFile)
+				if err != nil {
+					return -1, err
+				}
+
+				return size, nil
+			}
+
 			for filename, file := range files {
 				_, srcFingerprint, prefixFound := strings.Cut(filename, "root.delta-")
 				if !prefixFound {
@@ -172,40 +215,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 					continue
 				}
 
-				// Create temporary file for the delta
-				deltaFile, err := os.CreateTemp("", "incus_image_")
-				if err != nil {
-					return nil, err
-				}
-
-				defer func() { _ = deltaFile.Close() }()
-
-				defer func() { _ = os.Remove(deltaFile.Name()) }()
-
-				// Download the delta
-				_, err = download(file.Path, "rootfs delta", file.Sha256, deltaFile)
-				if err != nil {
-					return nil, err
-				}
-
-				// Create temporary file for the delta
-				patchedFile, err := os.CreateTemp("", "incus_image_")
-				if err != nil {
-					return nil, err
-				}
-
-				defer func() { _ = patchedFile.Close() }()
-
-				defer func() { _ = os.Remove(patchedFile.Name()) }()
-
-				// Apply it
-				_, err = subprocess.RunCommand("xdelta3", "-f", "-d", "-s", srcPath, deltaFile.Name(), patchedFile.Name())
-				if err != nil {
-					return nil, err
-				}
-
-				// Copy to the target
-				size, err := io.Copy(req.RootfsFile, patchedFile)
+				size, err := applyDelta(file, srcPath, req.RootfsFile)
 				if err != nil {
 					return nil, err
 				}
@@ -234,17 +244,17 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 }
 
 // GetImageSecret isn't relevant for the simplestreams protocol.
-func (r *ProtocolSimpleStreams) GetImageSecret(fingerprint string) (string, error) {
+func (r *ProtocolSimpleStreams) GetImageSecret(_ string) (string, error) {
 	return "", fmt.Errorf("Private images aren't supported by the simplestreams protocol")
 }
 
 // GetPrivateImage isn't relevant for the simplestreams protocol.
-func (r *ProtocolSimpleStreams) GetPrivateImage(fingerprint string, secret string) (*api.Image, string, error) {
+func (r *ProtocolSimpleStreams) GetPrivateImage(_ string, _ string) (*api.Image, string, error) {
 	return nil, "", fmt.Errorf("Private images aren't supported by the simplestreams protocol")
 }
 
 // GetPrivateImageFile isn't relevant for the simplestreams protocol.
-func (r *ProtocolSimpleStreams) GetPrivateImageFile(fingerprint string, secret string, req ImageFileRequest) (*ImageFileResponse, error) {
+func (r *ProtocolSimpleStreams) GetPrivateImageFile(_ string, _ string, _ ImageFileRequest) (*ImageFileResponse, error) {
 	return nil, fmt.Errorf("Private images aren't supported by the simplestreams protocol")
 }
 
@@ -315,6 +325,6 @@ func (r *ProtocolSimpleStreams) GetImageAliasArchitectures(imageType string, nam
 }
 
 // ExportImage exports (copies) an image to a remote server.
-func (r *ProtocolSimpleStreams) ExportImage(fingerprint string, image api.ImageExportPost) (Operation, error) {
+func (r *ProtocolSimpleStreams) ExportImage(_ string, _ api.ImageExportPost) (Operation, error) {
 	return nil, fmt.Errorf("Exporting images is not supported by the simplestreams protocol")
 }

--- a/client/util.go
+++ b/client/util.go
@@ -116,7 +116,7 @@ func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey strin
 // Any errors encountered during the setup process are also handled by the function.
 func unixHTTPClient(args *ConnectionArgs, path string) (*http.Client, error) {
 	// Setup a Unix socket dialer
-	unixDial := func(_ context.Context, network, addr string) (net.Conn, error) {
+	unixDial := func(_ context.Context, _ string, _ string) (net.Conn, error) {
 		raddr, err := net.ResolveUnixAddr("unix", path)
 		if err != nil {
 			return nil, err

--- a/cmd/incus-simplestreams/main_add.go
+++ b/cmd/incus-simplestreams/main_add.go
@@ -244,7 +244,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate the metadata.
-	_, err = osarch.ArchitectureId(metadata.Architecture)
+	_, err = osarch.ArchitectureID(metadata.Architecture)
 	if err != nil {
 		return fmt.Errorf("Invalid architecture in metadata.yaml: %w", err)
 	}

--- a/cmd/incus-simplestreams/main_generate_metadata.go
+++ b/cmd/incus-simplestreams/main_generate_metadata.go
@@ -97,7 +97,7 @@ func (c *cmdGenerateMetadata) Run(cmd *cobra.Command, args []string) error {
 	// Question - architecture
 	var incusArch string
 	metaArchitecture, err := asker.AskString("Architecture name: ", "", func(value string) error {
-		id, err := osarch.ArchitectureId(value)
+		id, err := osarch.ArchitectureID(value)
 		if err != nil {
 			return err
 		}

--- a/cmd/incus-user/server.go
+++ b/cmd/incus-user/server.go
@@ -271,7 +271,7 @@ func serverSetupUser(uid uint32) error {
 			return err
 		}
 
-		idmapset, err := idmap.NewSetFromSystem("", "root")
+		idmapset, err := idmap.NewSetFromSystem("root")
 		if err != nil && err != idmap.ErrSubidUnsupported {
 			return fmt.Errorf("Failed to load system idmap: %w", err)
 		}

--- a/cmd/incus/admin.go
+++ b/cmd/incus/admin.go
@@ -13,6 +13,7 @@ type cmdAdmin struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdAdmin) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("admin")

--- a/cmd/incus/admin_cluster.go
+++ b/cmd/incus/admin_cluster.go
@@ -18,6 +18,7 @@ type cmdAdminCluster struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdAdminCluster) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("cluster")
@@ -29,7 +30,8 @@ func (c *cmdAdminCluster) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdAdminCluster) Run(cmd *cobra.Command, args []string) {
+// Run runs the actual command logic.
+func (c *cmdAdminCluster) Run(_ *cobra.Command, args []string) {
 	env := getEnviron()
 	path, _ := exec.LookPath("incusd")
 	if path == "" {
@@ -48,7 +50,7 @@ func (c *cmdAdminCluster) Run(cmd *cobra.Command, args []string) {
 To do so, it's actually part of the "incusd" binary rather than "incus".
 
 You can invoke it through "incusd cluster".`))
-		os.Exit(1)
+		os.Exit(1) // nolint:revive
 	}
 
 	_ = doExec(path, append([]string{"incusd", "admin", "cluster"}, args...), env)

--- a/cmd/incus/admin_init.go
+++ b/cmd/incus/admin_init.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 
@@ -38,6 +39,7 @@ type cmdAdminInit struct {
 	hostname string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdAdminInit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("init")
@@ -66,24 +68,25 @@ func (c *cmdAdminInit) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdAdminInit) Run(cmd *cobra.Command, args []string) error {
+// Run runs the actual command logic.
+func (c *cmdAdminInit) Run(cmd *cobra.Command, _ []string) error {
 	// Quick checks.
 	if c.flagAuto && c.flagPreseed {
-		return fmt.Errorf(i18n.G("Can't use --auto and --preseed together"))
+		return errors.New(i18n.G("Can't use --auto and --preseed together"))
 	}
 
 	if c.flagMinimal && c.flagPreseed {
-		return fmt.Errorf(i18n.G("Can't use --minimal and --preseed together"))
+		return errors.New(i18n.G("Can't use --minimal and --preseed together"))
 	}
 
 	if c.flagMinimal && c.flagAuto {
-		return fmt.Errorf(i18n.G("Can't use --minimal and --auto together"))
+		return errors.New(i18n.G("Can't use --minimal and --auto together"))
 	}
 
 	if !c.flagAuto && (c.flagNetworkAddress != "" || c.flagNetworkPort != -1 ||
 		c.flagStorageBackend != "" || c.flagStorageDevice != "" ||
 		c.flagStorageLoopSize != -1 || c.flagStoragePool != "") {
-		return fmt.Errorf(i18n.G("Configuration flags require --auto"))
+		return errors.New(i18n.G("Configuration flags require --auto"))
 	}
 
 	if c.flagDump && (c.flagAuto || c.flagMinimal ||
@@ -91,7 +94,7 @@ func (c *cmdAdminInit) Run(cmd *cobra.Command, args []string) error {
 		c.flagNetworkPort != -1 || c.flagStorageBackend != "" ||
 		c.flagStorageDevice != "" || c.flagStorageLoopSize != -1 ||
 		c.flagStoragePool != "") {
-		return fmt.Errorf(i18n.G("Can't use --dump with other flags"))
+		return errors.New(i18n.G("Can't use --dump with other flags"))
 	}
 
 	// Connect to the daemon
@@ -120,7 +123,7 @@ func (c *cmdAdminInit) Run(cmd *cobra.Command, args []string) error {
 
 	// Preseed mode
 	if c.flagPreseed {
-		config, err = c.RunPreseed(cmd, args, d)
+		config, err = c.RunPreseed()
 		if err != nil {
 			return err
 		}
@@ -128,7 +131,7 @@ func (c *cmdAdminInit) Run(cmd *cobra.Command, args []string) error {
 
 	// Auto mode
 	if c.flagAuto || c.flagMinimal {
-		config, err = c.RunAuto(cmd, args, d, server)
+		config, err = c.RunAuto(d, server)
 		if err != nil {
 			return err
 		}
@@ -136,7 +139,7 @@ func (c *cmdAdminInit) Run(cmd *cobra.Command, args []string) error {
 
 	// Interactive mode
 	if !c.flagAuto && !c.flagMinimal && !c.flagPreseed {
-		config, err = c.RunInteractive(cmd, args, d, server)
+		config, err = c.RunInteractive(cmd, d, server)
 		if err != nil {
 			return err
 		}
@@ -191,7 +194,7 @@ func (c *cmdAdminInit) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		if config.Cluster.ClusterCertificate == "" {
-			return fmt.Errorf(i18n.G("Unable to connect to any of the cluster members specified in join token"))
+			return errors.New(i18n.G("Unable to connect to any of the cluster members specified in join token"))
 		}
 	}
 

--- a/cmd/incus/admin_init_dump.go
+++ b/cmd/incus/admin_init_dump.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 )
 
+// RunDump runs the actual command logic.
 func (c *cmdAdminInit) RunDump(d incus.InstanceServer) error {
 	currentServer, _, err := d.GetServer()
 	if err != nil {

--- a/cmd/incus/admin_init_preseed.go
+++ b/cmd/incus/admin_init_preseed.go
@@ -7,15 +7,14 @@ import (
 	"io"
 	"os"
 
-	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/internal/i18n"
 	"github.com/lxc/incus/v6/shared/api"
 )
 
-func (c *cmdAdminInit) RunPreseed(cmd *cobra.Command, args []string, d incus.InstanceServer) (*api.InitPreseed, error) {
+// RunPreseed runs the actual command logic.
+func (c *cmdAdminInit) RunPreseed() (*api.InitPreseed, error) {
 	// Read the YAML
 	bytes, err := io.ReadAll(os.Stdin)
 	if err != nil {

--- a/cmd/incus/admin_other.go
+++ b/cmd/incus/admin_other.go
@@ -13,6 +13,7 @@ type cmdAdmin struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdAdmin) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("admin")

--- a/cmd/incus/admin_sql.go
+++ b/cmd/incus/admin_sql.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +24,7 @@ type cmdAdminSQL struct {
 	flagFormat string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdAdminSQL) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("sql", i18n.G("<local|global> <query>"))
@@ -54,13 +56,14 @@ func (c *cmdAdminSQL) Command() *cobra.Command {
 	cmd.RunE = c.Run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdAdminSQL) Run(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		_ = cmd.Help()
@@ -69,7 +72,7 @@ func (c *cmdAdminSQL) Run(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		return fmt.Errorf(i18n.G("Missing required arguments"))
+		return errors.New(i18n.G("Missing required arguments"))
 	}
 
 	database := args[0]
@@ -78,7 +81,7 @@ func (c *cmdAdminSQL) Run(cmd *cobra.Command, args []string) error {
 	if !slices.Contains([]string{"local", "global"}, database) {
 		_ = cmd.Help()
 
-		return fmt.Errorf(i18n.G("Invalid database type"))
+		return errors.New(i18n.G("Invalid database type"))
 	}
 
 	if query == "-" {

--- a/cmd/incus/admin_waitready.go
+++ b/cmd/incus/admin_waitready.go
@@ -20,6 +20,7 @@ type cmdAdminWaitready struct {
 	flagTimeout int
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdAdminWaitready) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("waitready")
@@ -35,7 +36,8 @@ func (c *cmdAdminWaitready) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdAdminWaitready) Run(cmd *cobra.Command, args []string) error {
+// Run runs the actual command logic.
+func (c *cmdAdminWaitready) Run(_ *cobra.Command, _ []string) error {
 	finger := make(chan error, 1)
 	var errLast error
 	go func() {
@@ -88,7 +90,6 @@ func (c *cmdAdminWaitready) Run(cmd *cobra.Command, args []string) error {
 	if c.flagTimeout > 0 {
 		select {
 		case <-finger:
-			break
 		case <-time.After(time.Second * time.Duration(c.flagTimeout)):
 			return fmt.Errorf(i18n.G("Daemon still not running after %ds timeout (%v)"), c.flagTimeout, errLast)
 		}

--- a/cmd/incus/alias.go
+++ b/cmd/incus/alias.go
@@ -43,7 +43,7 @@ func (c *cmdAlias) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -76,7 +76,7 @@ func (c *cmdAliasAdd) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
@@ -113,7 +113,7 @@ func (c *cmdAliasList) Command() *cobra.Command {
 		`List aliases`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -128,7 +128,7 @@ func (c *cmdAliasList) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 0)
+	exit, err := c.global.checkArgs(cmd, args, 0, 0)
 	if exit {
 		return err
 	}
@@ -187,7 +187,7 @@ func (c *cmdAliasRename) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
@@ -242,7 +242,7 @@ func (c *cmdAliasRemove) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}

--- a/cmd/incus/cluster_role.go
+++ b/cmd/incus/cluster_role.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -16,7 +17,7 @@ type cmdClusterRole struct {
 	cluster *cmdCluster
 }
 
-// It uses the cmdGlobal, cmdCluster, and cmdClusterRole structs for context and operation.
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdClusterRole) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("role")
@@ -33,7 +34,7 @@ func (c *cmdClusterRole) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -43,7 +44,7 @@ type cmdClusterRoleAdd struct {
 	clusterRole *cmdClusterRole
 }
 
-// Setting up the usage, short description, and long description of the command, as well as its RunE method.
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdClusterRoleAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<member> <role[,role...]>"))
@@ -53,7 +54,7 @@ func (c *cmdClusterRoleAdd) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpClusterMembers(toComplete)
 		}
@@ -64,14 +65,14 @@ func (c *cmdClusterRoleAdd) Command() *cobra.Command {
 	return cmd
 }
 
-// It checks and parses input arguments, verifies role assignment, and updates the member's roles.
+// Run runs the actual command logic.
 func (c *cmdClusterRoleAdd) Run(cmd *cobra.Command, args []string) error {
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func (c *cmdClusterRoleAdd) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing cluster member name"))
+		return errors.New(i18n.G("Missing cluster member name"))
 	}
 
 	// Extract the current value
@@ -107,7 +108,7 @@ type cmdClusterRoleRemove struct {
 	clusterRole *cmdClusterRole
 }
 
-// Removing the roles from a cluster member, setting up usage, descriptions, and the RunE method.
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdClusterRoleRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<member> <role[,role...]>"))
@@ -117,7 +118,7 @@ func (c *cmdClusterRoleRemove) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpClusterMembers(toComplete)
 		}
@@ -132,14 +133,14 @@ func (c *cmdClusterRoleRemove) Command() *cobra.Command {
 	return cmd
 }
 
-// Run executes the removal of specified roles from a cluster member, checking inputs, validating role assignment, and updating the member's roles.
+// Run runs the actual command logic.
 func (c *cmdClusterRoleRemove) Run(cmd *cobra.Command, args []string) error {
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -147,7 +148,7 @@ func (c *cmdClusterRoleRemove) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing cluster member name"))
+		return errors.New(i18n.G("Missing cluster member name"))
 	}
 
 	// Extract the current value

--- a/cmd/incus/completion.go
+++ b/cmd/incus/completion.go
@@ -18,7 +18,7 @@ func (g *cmdGlobal) cmpClusterGroupNames(toComplete string) ([]string, cobra.She
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -43,7 +43,7 @@ func (g *cmdGlobal) cmpClusterGroups(toComplete string) ([]string, cobra.ShellCo
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -84,7 +84,7 @@ func (g *cmdGlobal) cmpClusterGroups(toComplete string) ([]string, cobra.ShellCo
 
 func (g *cmdGlobal) cmpClusterGroupConfigs(groupName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(groupName)
+	resources, err := g.parseServers(groupName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -112,7 +112,7 @@ func (g *cmdGlobal) cmpClusterGroupConfigs(groupName string) ([]string, cobra.Sh
 
 func (g *cmdGlobal) cmpClusterMemberConfigs(memberName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(memberName)
+	resources, err := g.parseServers(memberName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -140,7 +140,7 @@ func (g *cmdGlobal) cmpClusterMemberConfigs(memberName string) ([]string, cobra.
 
 func (g *cmdGlobal) cmpClusterMemberRoles(memberName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(memberName)
+	resources, err := g.parseServers(memberName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -165,7 +165,7 @@ func (g *cmdGlobal) cmpClusterMembers(toComplete string) ([]string, cobra.ShellC
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -274,7 +274,7 @@ func (g *cmdGlobal) cmpInstanceAllKeys() ([]string, cobra.ShellCompDirective) {
 
 func (g *cmdGlobal) cmpInstanceConfigTemplates(instanceName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(instanceName)
+	resources, err := g.parseServers(instanceName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -298,7 +298,7 @@ func (g *cmdGlobal) cmpInstanceConfigTemplates(instanceName string) ([]string, c
 
 func (g *cmdGlobal) cmpInstanceDeviceNames(instanceName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(instanceName)
+	resources, err := g.parseServers(instanceName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -320,7 +320,7 @@ func (g *cmdGlobal) cmpInstanceDeviceNames(instanceName string) ([]string, cobra
 }
 
 func (g *cmdGlobal) cmpInstanceSnapshots(instanceName string) ([]string, cobra.ShellCompDirective) {
-	resources, err := g.ParseServers(instanceName)
+	resources, err := g.parseServers(instanceName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -340,7 +340,7 @@ func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDi
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -376,7 +376,7 @@ func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -415,7 +415,7 @@ func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra
 func (g *cmdGlobal) cmpInstanceNamesFromRemote(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -431,7 +431,7 @@ func (g *cmdGlobal) cmpInstanceNamesFromRemote(toComplete string) ([]string, cob
 
 func (g *cmdGlobal) cmpNetworkACLConfigs(aclName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(aclName)
+	resources, err := g.parseServers(aclName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -456,7 +456,7 @@ func (g *cmdGlobal) cmpNetworkACLs(toComplete string) ([]string, cobra.ShellComp
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -503,7 +503,7 @@ func (g *cmdGlobal) cmpNetworkACLRuleProperties() ([]string, cobra.ShellCompDire
 
 func (g *cmdGlobal) cmpNetworkForwardConfigs(networkName string, listenAddress string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(networkName)
+	resources, err := g.parseServers(networkName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -525,10 +525,9 @@ func (g *cmdGlobal) cmpNetworkForwardConfigs(networkName string, listenAddress s
 }
 
 func (g *cmdGlobal) cmpNetworkForwards(networkName string) ([]string, cobra.ShellCompDirective) {
-	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(networkName)
+	resources, _ := g.parseServers(networkName)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -545,10 +544,9 @@ func (g *cmdGlobal) cmpNetworkForwards(networkName string) ([]string, cobra.Shel
 }
 
 func (g *cmdGlobal) cmpNetworkLoadBalancers(networkName string) ([]string, cobra.ShellCompDirective) {
-	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(networkName)
+	resources, _ := g.parseServers(networkName)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -568,7 +566,7 @@ func (g *cmdGlobal) cmpNetworkPeerConfigs(networkName string, peerName string) (
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(networkName)
+	resources, _ := g.parseServers(networkName)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -589,10 +587,9 @@ func (g *cmdGlobal) cmpNetworkPeerConfigs(networkName string, peerName string) (
 }
 
 func (g *cmdGlobal) cmpNetworkPeers(networkName string) ([]string, cobra.ShellCompDirective) {
-	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(networkName)
+	resources, _ := g.parseServers(networkName)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -612,7 +609,7 @@ func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDir
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -646,7 +643,7 @@ func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDir
 
 func (g *cmdGlobal) cmpNetworkConfigs(networkName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(networkName)
+	resources, err := g.parseServers(networkName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -669,7 +666,7 @@ func (g *cmdGlobal) cmpNetworkConfigs(networkName string) ([]string, cobra.Shell
 
 func (g *cmdGlobal) cmpNetworkInstances(networkName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(networkName)
+	resources, err := g.parseServers(networkName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -697,7 +694,7 @@ func (g *cmdGlobal) cmpNetworkInstances(networkName string) ([]string, cobra.She
 
 func (g *cmdGlobal) cmpNetworkProfiles(networkName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(networkName)
+	resources, err := g.parseServers(networkName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -725,7 +722,7 @@ func (g *cmdGlobal) cmpNetworkProfiles(networkName string) ([]string, cobra.Shel
 
 func (g *cmdGlobal) cmpNetworkZoneConfigs(zoneName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(zoneName)
+	resources, err := g.parseServers(zoneName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -750,7 +747,7 @@ func (g *cmdGlobal) cmpNetworkZoneRecordConfigs(zoneName string, recordName stri
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(zoneName)
+	resources, _ := g.parseServers(zoneName)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -771,10 +768,9 @@ func (g *cmdGlobal) cmpNetworkZoneRecordConfigs(zoneName string, recordName stri
 }
 
 func (g *cmdGlobal) cmpNetworkZoneRecords(zoneName string) ([]string, cobra.ShellCompDirective) {
-	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(zoneName)
+	resources, _ := g.parseServers(zoneName)
 
 	if len(resources) <= 0 {
 		return nil, cobra.ShellCompDirectiveError
@@ -794,7 +790,7 @@ func (g *cmdGlobal) cmpNetworkZones(toComplete string) ([]string, cobra.ShellCom
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -827,7 +823,7 @@ func (g *cmdGlobal) cmpNetworkZones(toComplete string) ([]string, cobra.ShellCom
 }
 
 func (g *cmdGlobal) cmpProfileConfigs(profileName string) ([]string, cobra.ShellCompDirective) {
-	resources, err := g.ParseServers(profileName)
+	resources, err := g.parseServers(profileName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -850,7 +846,7 @@ func (g *cmdGlobal) cmpProfileConfigs(profileName string) ([]string, cobra.Shell
 
 func (g *cmdGlobal) cmpProfileDeviceNames(instanceName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(instanceName)
+	resources, err := g.parseServers(instanceName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -874,7 +870,7 @@ func (g *cmdGlobal) cmpProfileDeviceNames(instanceName string) ([]string, cobra.
 func (g *cmdGlobal) cmpProfileNamesFromRemote(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -890,7 +886,7 @@ func (g *cmdGlobal) cmpProfiles(toComplete string, includeRemotes bool) ([]strin
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -920,7 +916,7 @@ func (g *cmdGlobal) cmpProfiles(toComplete string, includeRemotes bool) ([]strin
 }
 
 func (g *cmdGlobal) cmpProjectConfigs(projectName string) ([]string, cobra.ShellCompDirective) {
-	resources, err := g.ParseServers(projectName)
+	resources, err := g.parseServers(projectName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -945,7 +941,7 @@ func (g *cmdGlobal) cmpProjects(toComplete string) ([]string, cobra.ShellCompDir
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -1011,7 +1007,7 @@ func (g *cmdGlobal) cmpRemoteNames() ([]string, cobra.ShellCompDirective) {
 
 func (g *cmdGlobal) cmpStoragePoolConfigs(poolName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(poolName)
+	resources, err := g.parseServers(poolName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -1072,7 +1068,7 @@ func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra
 func (g *cmdGlobal) cmpStoragePools(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 
-	resources, _ := g.ParseServers(toComplete)
+	resources, _ := g.parseServers(toComplete)
 
 	if len(resources) > 0 {
 		resource := resources[0]
@@ -1102,7 +1098,7 @@ func (g *cmdGlobal) cmpStoragePools(toComplete string) ([]string, cobra.ShellCom
 
 func (g *cmdGlobal) cmpStoragePoolVolumeConfigs(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(poolName)
+	resources, err := g.parseServers(poolName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -1132,7 +1128,7 @@ func (g *cmdGlobal) cmpStoragePoolVolumeConfigs(poolName string, volumeName stri
 
 func (g *cmdGlobal) cmpStoragePoolVolumeInstances(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(poolName)
+	resources, err := g.parseServers(poolName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -1167,7 +1163,7 @@ func (g *cmdGlobal) cmpStoragePoolVolumeInstances(poolName string, volumeName st
 
 func (g *cmdGlobal) cmpStoragePoolVolumeProfiles(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(poolName)
+	resources, err := g.parseServers(poolName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -1202,7 +1198,7 @@ func (g *cmdGlobal) cmpStoragePoolVolumeProfiles(poolName string, volumeName str
 
 func (g *cmdGlobal) cmpStoragePoolVolumeSnapshots(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(poolName)
+	resources, err := g.parseServers(poolName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -1227,7 +1223,7 @@ func (g *cmdGlobal) cmpStoragePoolVolumeSnapshots(poolName string, volumeName st
 
 func (g *cmdGlobal) cmpStoragePoolVolumes(poolName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
-	resources, err := g.ParseServers(poolName)
+	resources, err := g.parseServers(poolName)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/incus/completion.go
+++ b/cmd/incus/completion.go
@@ -14,18 +14,6 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 )
 
-func (g *cmdGlobal) appendCompletion(comps []string, comp, toComplete, remote string) []string {
-	if remote != g.conf.DefaultRemote || strings.Contains(toComplete, g.conf.DefaultRemote) {
-		comp = fmt.Sprintf("%s:%s", remote, comp)
-	}
-
-	if !strings.HasPrefix(comp, toComplete) {
-		return comps
-	}
-
-	return append(comps, comp)
-}
-
 func (g *cmdGlobal) cmpClusterGroupNames(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -273,34 +261,6 @@ func (g *cmdGlobal) cmpImageFingerprintsFromRemote(toComplete string, remote str
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp
-}
-
-func (g *cmdGlobal) cmpImageFingerprints(toComplete string) ([]string, cobra.ShellCompDirective) {
-	results := []string{}
-	var remote string
-	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
-
-	if strings.Contains(toComplete, ":") {
-		remote = strings.Split(toComplete, ":")[0]
-	} else {
-		remote = g.conf.DefaultRemote
-	}
-
-	remoteServer, _ := g.conf.GetImageServer(remote)
-
-	images, _ := remoteServer.GetImages()
-
-	for _, image := range images {
-		results = g.appendCompletion(results, image.Fingerprint, toComplete, remote)
-	}
-
-	if !strings.Contains(toComplete, ":") {
-		remotes, directives := g.cmpRemotes(toComplete, true)
-		results = append(results, remotes...)
-		cmpDirectives |= directives
-	}
-
-	return results, cmpDirectives
 }
 
 func (g *cmdGlobal) cmpInstanceAllKeys() ([]string, cobra.ShellCompDirective) {

--- a/cmd/incus/config_device.go
+++ b/cmd/incus/config_device.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,6 +18,7 @@ type cmdConfigDevice struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDevice) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("device")
@@ -60,7 +62,7 @@ func (c *cmdConfigDevice) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -72,6 +74,7 @@ type cmdConfigDeviceAdd struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Short = i18n.G("Add instance devices")
@@ -97,7 +100,7 @@ incus profile device add [<remote>:]profile1 <device-name> disk pool=some-pool s
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -112,15 +115,16 @@ incus profile device add [<remote>:]profile1 <device-name> disk pool=some-pool s
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
+	exit, err := c.global.checkArgs(cmd, args, 3, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -128,7 +132,7 @@ func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// Add the device
@@ -160,7 +164,7 @@ func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 
 		_, ok := profile.Devices[devname]
 		if ok {
-			return fmt.Errorf(i18n.G("The device already exists"))
+			return errors.New(i18n.G("The device already exists"))
 		}
 
 		profile.Devices[devname] = device
@@ -177,7 +181,7 @@ func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 
 		_, ok := inst.Devices[devname]
 		if ok {
-			return fmt.Errorf(i18n.G("The device already exists"))
+			return errors.New(i18n.G("The device already exists"))
 		}
 
 		inst.Devices[devname] = device
@@ -208,6 +212,7 @@ type cmdConfigDeviceGet struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceGet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
@@ -222,7 +227,7 @@ func (c *cmdConfigDeviceGet) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -245,15 +250,16 @@ func (c *cmdConfigDeviceGet) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -261,7 +267,7 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// Get the config key
@@ -276,7 +282,7 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 
 		dev, ok := profile.Devices[devname]
 		if !ok {
-			return fmt.Errorf(i18n.G("Device doesn't exist"))
+			return errors.New(i18n.G("Device doesn't exist"))
 		}
 
 		fmt.Println(dev[key])
@@ -290,10 +296,10 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 		if !ok {
 			_, ok = inst.ExpandedDevices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("Device doesn't exist"))
+				return errors.New(i18n.G("Device doesn't exist"))
 			}
 
-			return fmt.Errorf(i18n.G("Device from profile(s) cannot be retrieved for individual instance"))
+			return errors.New(i18n.G("Device from profile(s) cannot be retrieved for individual instance"))
 		}
 
 		fmt.Println(dev[key])
@@ -310,6 +316,7 @@ type cmdConfigDeviceList struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Aliases = []string{"ls"}
@@ -324,7 +331,7 @@ func (c *cmdConfigDeviceList) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -339,15 +346,16 @@ func (c *cmdConfigDeviceList) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -355,7 +363,7 @@ func (c *cmdConfigDeviceList) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// List the devices
@@ -393,6 +401,7 @@ type cmdConfigDeviceOverride struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceOverride) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("override", i18n.G("[<remote>:]<instance> <device> [key=value...]"))
@@ -402,7 +411,7 @@ func (c *cmdConfigDeviceOverride) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -413,15 +422,16 @@ func (c *cmdConfigDeviceOverride) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceOverride) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	exit, err := c.global.checkArgs(cmd, args, 2, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -429,7 +439,7 @@ func (c *cmdConfigDeviceOverride) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// Override the device
@@ -441,12 +451,12 @@ func (c *cmdConfigDeviceOverride) Run(cmd *cobra.Command, args []string) error {
 	devname := args[1]
 	_, ok := inst.Devices[devname]
 	if ok {
-		return fmt.Errorf(i18n.G("The device already exists"))
+		return errors.New(i18n.G("The device already exists"))
 	}
 
 	device, ok := inst.ExpandedDevices[devname]
 	if !ok {
-		return fmt.Errorf(i18n.G("The profile device doesn't exist"))
+		return errors.New(i18n.G("The profile device doesn't exist"))
 	}
 
 	if len(args) > 2 {
@@ -489,6 +499,7 @@ type cmdConfigDeviceRemove struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
@@ -504,7 +515,7 @@ func (c *cmdConfigDeviceRemove) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -525,15 +536,16 @@ func (c *cmdConfigDeviceRemove) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	exit, err := c.global.checkArgs(cmd, args, 2, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -541,7 +553,7 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// Remove the device
@@ -554,7 +566,7 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 		for _, devname := range args[1:] {
 			_, ok := profile.Devices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("Device doesn't exist"))
+				return errors.New(i18n.G("Device doesn't exist"))
 			}
 
 			delete(profile.Devices, devname)
@@ -575,10 +587,10 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 			if !ok {
 				_, ok := inst.ExpandedDevices[devname]
 				if !ok {
-					return fmt.Errorf(i18n.G("Device doesn't exist"))
+					return errors.New(i18n.G("Device doesn't exist"))
 				}
 
-				return fmt.Errorf(i18n.G("Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"))
+				return errors.New(i18n.G("Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"))
 			}
 
 			delete(inst.Devices, devname)
@@ -610,6 +622,7 @@ type cmdConfigDeviceSet struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceSet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Short = i18n.G("Set device configuration keys")
@@ -631,7 +644,7 @@ For backward compatibility, a single configuration key may still be set with:
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -654,15 +667,16 @@ For backward compatibility, a single configuration key may still be set with:
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
+	exit, err := c.global.checkArgs(cmd, args, 3, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -670,7 +684,7 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// Set the device config key
@@ -689,7 +703,7 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 
 		dev, ok := profile.Devices[devname]
 		if !ok {
-			return fmt.Errorf(i18n.G("Device doesn't exist"))
+			return errors.New(i18n.G("Device doesn't exist"))
 		}
 
 		for k, v := range keys {
@@ -712,10 +726,10 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 		if !ok {
 			_, ok = inst.ExpandedDevices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("Device doesn't exist"))
+				return errors.New(i18n.G("Device doesn't exist"))
 			}
 
-			return fmt.Errorf(i18n.G("Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"))
+			return errors.New(i18n.G("Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"))
 		}
 
 		for k, v := range keys {
@@ -746,6 +760,7 @@ type cmdConfigDeviceShow struct {
 	profile      *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
@@ -760,7 +775,7 @@ func (c *cmdConfigDeviceShow) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -775,15 +790,16 @@ func (c *cmdConfigDeviceShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -791,7 +807,7 @@ func (c *cmdConfigDeviceShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing name"))
+		return errors.New(i18n.G("Missing name"))
 	}
 
 	// Show the devices
@@ -831,6 +847,7 @@ type cmdConfigDeviceUnset struct {
 	profile         *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceUnset) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	if c.config != nil {
@@ -845,7 +862,7 @@ func (c *cmdConfigDeviceUnset) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if c.config != nil {
 				return c.global.cmpInstances(toComplete)
@@ -868,9 +885,10 @@ func (c *cmdConfigDeviceUnset) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigDeviceUnset) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}

--- a/cmd/incus/config_metadata.go
+++ b/cmd/incus/config_metadata.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,7 @@ type cmdConfigMetadata struct {
 	config *cmdConfig
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigMetadata) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("metadata")
@@ -36,7 +38,7 @@ func (c *cmdConfigMetadata) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -47,6 +49,7 @@ type cmdConfigMetadataEdit struct {
 	configMetadata *cmdConfigMetadata
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigMetadataEdit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<instance>"))
@@ -56,7 +59,7 @@ func (c *cmdConfigMetadataEdit) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -91,15 +94,16 @@ func (c *cmdConfigMetadataEdit) helpTemplate() string {
 ###     properties: {}`)
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -107,7 +111,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Edit the metadata
@@ -180,6 +184,7 @@ type cmdConfigMetadataShow struct {
 	configMetadata *cmdConfigMetadata
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigMetadataShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<instance>"))
@@ -189,7 +194,7 @@ func (c *cmdConfigMetadataShow) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -200,15 +205,16 @@ func (c *cmdConfigMetadataShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigMetadataShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -216,7 +222,7 @@ func (c *cmdConfigMetadataShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Show the instance metadata

--- a/cmd/incus/config_template.go
+++ b/cmd/incus/config_template.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,7 @@ type cmdConfigTemplate struct {
 	config *cmdConfig
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigTemplate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("template")
@@ -48,7 +50,7 @@ func (c *cmdConfigTemplate) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -59,6 +61,7 @@ type cmdConfigTemplateCreate struct {
 	configTemplate *cmdConfigTemplate
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigTemplateCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<instance> <template>"))
@@ -72,7 +75,7 @@ incus config template create u1 t1 < config.tpl
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -83,11 +86,12 @@ incus config template create u1 t1 < config.tpl
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigTemplateCreate) Run(cmd *cobra.Command, args []string) error {
 	var stdinData io.ReadSeeker
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
@@ -104,7 +108,7 @@ func (c *cmdConfigTemplateCreate) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -112,7 +116,7 @@ func (c *cmdConfigTemplateCreate) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Create instance file template
@@ -126,6 +130,7 @@ type cmdConfigTemplateDelete struct {
 	configTemplate *cmdConfigTemplate
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigTemplateDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance> <template>"))
@@ -136,7 +141,7 @@ func (c *cmdConfigTemplateDelete) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -151,15 +156,16 @@ func (c *cmdConfigTemplateDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigTemplateDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -167,7 +173,7 @@ func (c *cmdConfigTemplateDelete) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Delete instance file template
@@ -181,6 +187,7 @@ type cmdConfigTemplateEdit struct {
 	configTemplate *cmdConfigTemplate
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigTemplateEdit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<instance> <template>"))
@@ -190,7 +197,7 @@ func (c *cmdConfigTemplateEdit) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -205,15 +212,16 @@ func (c *cmdConfigTemplateEdit) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -221,7 +229,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Edit instance file template
@@ -281,6 +289,7 @@ type cmdConfigTemplateList struct {
 	flagFormat string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigTemplateList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<instance>"))
@@ -289,13 +298,13 @@ func (c *cmdConfigTemplateList) Command() *cobra.Command {
 		`List instance file templates`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -306,15 +315,16 @@ func (c *cmdConfigTemplateList) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -322,7 +332,7 @@ func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// List the templates
@@ -353,6 +363,7 @@ type cmdConfigTemplateShow struct {
 	configTemplate *cmdConfigTemplate
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigTemplateShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<instance> <template>"))
@@ -362,7 +373,7 @@ func (c *cmdConfigTemplateShow) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -377,15 +388,16 @@ func (c *cmdConfigTemplateShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdConfigTemplateShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -393,7 +405,7 @@ func (c *cmdConfigTemplateShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Show the template

--- a/cmd/incus/create.go
+++ b/cmd/incus/create.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -37,6 +38,7 @@ type cmdCreate struct {
 	flagDescription     string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<image> [<remote>:][<name>]"))
@@ -66,7 +68,7 @@ incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io.bus=nvme
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Create a virtual machine"))
 	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Instance description")+"``")
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -77,9 +79,10 @@ incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io.bus=nvme
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdCreate) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 2)
+	exit, err := c.global.checkArgs(cmd, args, 0, 2)
 	if exit {
 		return err
 	}
@@ -138,7 +141,7 @@ func (c *cmdCreate) create(conf *config.Config, args []string, launch bool) (inc
 
 	if c.flagEmpty {
 		if len(args) > 1 {
-			return nil, "", fmt.Errorf(i18n.G("--empty cannot be combined with an image name"))
+			return nil, "", errors.New(i18n.G("--empty cannot be combined with an image name"))
 		}
 
 		if len(args) == 0 {
@@ -385,7 +388,7 @@ func (c *cmdCreate) create(conf *config.Config, args []string, launch bool) (inc
 
 		if conf.Remotes[iremote].Protocol == "incus" {
 			if imgInfo.Type != "virtual-machine" && c.flagVM {
-				return nil, "", fmt.Errorf(i18n.G("Asked for a VM but image is of type container"))
+				return nil, "", errors.New(i18n.G("Asked for a VM but image is of type container"))
 			}
 
 			req.Type = api.InstanceType(imgInfo.Type)
@@ -442,16 +445,16 @@ func (c *cmdCreate) create(conf *config.Config, args []string, launch bool) (inc
 
 	instances, ok := opInfo.Resources["instances"]
 	if !ok || len(instances) == 0 {
-		return nil, "", fmt.Errorf(i18n.G("Didn't get name of new instance from the server"))
+		return nil, "", errors.New(i18n.G("Didn't get name of new instance from the server"))
 	}
 
 	if len(instances) == 1 && name == "" {
-		url, err := url.Parse(instances[0])
+		uri, err := url.Parse(instances[0])
 		if err != nil {
 			return nil, "", err
 		}
 
-		name = path.Base(url.Path)
+		name = path.Base(uri.Path)
 		fmt.Printf(i18n.G("Instance name is: %s")+"\n", name)
 	}
 

--- a/cmd/incus/debug.go
+++ b/cmd/incus/debug.go
@@ -60,7 +60,7 @@ func (c *cmdDebugMemory) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}

--- a/cmd/incus/export.go
+++ b/cmd/incus/export.go
@@ -25,6 +25,7 @@ type cmdExport struct {
 	flagCompressionAlgorithm string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdExport) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("export", i18n.G("[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"))
@@ -45,11 +46,12 @@ func (c *cmdExport) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+	exit, err := c.global.checkArgs(cmd, args, 1, 2)
 	if exit {
 		return err
 	}

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -23,6 +24,7 @@ type cmdImageAlias struct {
 	image  *cmdImage
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdImageAlias) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("alias")
@@ -48,7 +50,7 @@ func (c *cmdImageAlias) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -61,6 +63,7 @@ type cmdImageAliasCreate struct {
 	flagDescription string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdImageAliasCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<alias> <fingerprint>"))
@@ -72,7 +75,7 @@ func (c *cmdImageAliasCreate) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 1 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -92,15 +95,16 @@ func (c *cmdImageAliasCreate) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdImageAliasCreate) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -108,7 +112,7 @@ func (c *cmdImageAliasCreate) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Alias name missing"))
+		return errors.New(i18n.G("Alias name missing"))
 	}
 
 	// Create the alias
@@ -127,6 +131,7 @@ type cmdImageAliasDelete struct {
 	imageAlias *cmdImageAlias
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdImageAliasDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<alias>"))
@@ -137,7 +142,7 @@ func (c *cmdImageAliasDelete) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -148,15 +153,16 @@ func (c *cmdImageAliasDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdImageAliasDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -164,7 +170,7 @@ func (c *cmdImageAliasDelete) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Alias name missing"))
+		return errors.New(i18n.G("Alias name missing"))
 	}
 
 	// Delete the alias
@@ -181,6 +187,7 @@ type cmdImageAliasList struct {
 	flagColumns string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdImageAliasList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:] [<filters>...]"))
@@ -210,13 +217,13 @@ Pre-defined column shorthand chars:
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultImageAliasColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -289,9 +296,10 @@ func (c *cmdImageAliasList) descriptionColumntData(imageAlias api.ImageAliasesEn
 	return imageAlias.Description
 }
 
+// Run runs the actual command logic.
 func (c *cmdImageAliasList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, -1)
+	exit, err := c.global.checkArgs(cmd, args, 0, -1)
 	if exit {
 		return err
 	}
@@ -369,6 +377,7 @@ type cmdImageAliasRename struct {
 	imageAlias *cmdImageAlias
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdImageAliasRename) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<alias> <new-name>"))
@@ -379,7 +388,7 @@ func (c *cmdImageAliasRename) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -390,15 +399,16 @@ func (c *cmdImageAliasRename) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdImageAliasRename) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -406,7 +416,7 @@ func (c *cmdImageAliasRename) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Alias name missing"))
+		return errors.New(i18n.G("Alias name missing"))
 	}
 
 	// Rename the alias

--- a/cmd/incus/import.go
+++ b/cmd/incus/import.go
@@ -20,6 +20,7 @@ type cmdImport struct {
 	flagStorage string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdImport) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("import", i18n.G("[<remote>:] <backup file> [<instance name>]"))
@@ -36,9 +37,10 @@ func (c *cmdImport) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 3)
+	exit, err := c.global.checkArgs(cmd, args, 1, 3)
 	if exit {
 		return err
 	}
@@ -64,7 +66,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 		instanceName = args[srcFilePosition+1]
 	}
 
-	resources, err := c.global.ParseServers(remote)
+	resources, err := c.global.parseServers(remote)
 	if err != nil {
 		return err
 	}

--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/lxc/incus/v6/internal/i18n"
 	"github.com/lxc/incus/v6/internal/instance"
 	"github.com/lxc/incus/v6/shared/api"
-	config "github.com/lxc/incus/v6/shared/cliconfig"
 	"github.com/lxc/incus/v6/shared/units"
 	"github.com/lxc/incus/v6/shared/util"
 )
@@ -29,6 +29,7 @@ type cmdInfo struct {
 	flagTarget     string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdInfo) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:][<instance>]"))
@@ -48,7 +49,7 @@ incus info [<remote>:] [--resources]
 	cmd.Flags().BoolVar(&c.flagResources, "resources", false, i18n.G("Show the resources available to the server"))
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -59,11 +60,12 @@ incus info [<remote>:] [--resources]
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdInfo) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
@@ -107,7 +109,7 @@ func (c *cmdInfo) Run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return c.instanceInfo(d, conf.Remotes[remote], cName, c.flagShowLog)
+	return c.instanceInfo(d, cName, c.flagShowLog)
 }
 
 func (c *cmdInfo) renderGPU(gpu api.ResourcesGPUCard, prefix string, initial bool) {
@@ -384,7 +386,7 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 	// Targeting
 	if c.flagTarget != "" {
 		if !d.IsClustered() {
-			return fmt.Errorf(i18n.G("To use --target, the destination remote must be a cluster"))
+			return errors.New(i18n.G("To use --target, the destination remote must be a cluster"))
 		}
 
 		d = d.UseTarget(c.flagTarget)
@@ -392,7 +394,7 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 
 	if c.flagResources {
 		if !d.HasExtension("resources_v2") {
-			return fmt.Errorf(i18n.G("The server doesn't implement the newer v2 resources API"))
+			return errors.New(i18n.G("The server doesn't implement the newer v2 resources API"))
 		}
 
 		resources, err := d.GetServerResources()
@@ -619,10 +621,10 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 	return nil
 }
 
-func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, name string, showLog bool) error {
+func (c *cmdInfo) instanceInfo(d incus.InstanceServer, name string, showLog bool) error {
 	// Quick checks.
 	if c.flagTarget != "" {
-		return fmt.Errorf(i18n.G("--target cannot be used with instances"))
+		return errors.New(i18n.G("--target cannot be used with instances"))
 	}
 
 	// Get the full instance data.
@@ -889,17 +891,20 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 
 	if showLog {
 		var log io.Reader
-		if inst.Type == "container" {
+		switch inst.Type {
+		case "container":
 			log, err = d.GetInstanceLogfile(name, "lxc.log")
 			if err != nil {
 				return err
 			}
-		} else if inst.Type == "virtual-machine" {
+
+		case "virtual-machine":
 			log, err = d.GetInstanceLogfile(name, "qemu.log")
 			if err != nil {
 				return err
 			}
-		} else {
+
+		default:
 			return fmt.Errorf(i18n.G("Unsupported instance type: %s"), inst.Type)
 		}
 

--- a/cmd/incus/launch.go
+++ b/cmd/incus/launch.go
@@ -17,6 +17,7 @@ type cmdLaunch struct {
 	flagConsole string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdLaunch) Command() *cobra.Command {
 	cmd := c.init.Command()
 	cmd.Use = usage("launch", i18n.G("[<remote>:]<image> [<remote>:][<name>]"))
@@ -44,7 +45,7 @@ incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io.bus=nvme
 	cmd.Flags().StringVar(&c.flagConsole, "console", "", i18n.G("Immediately attach to the console")+"``")
 	cmd.Flags().Lookup("console").NoOptDefVal = "console"
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -55,11 +56,12 @@ incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io.bus=nvme
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+	exit, err := c.global.checkArgs(cmd, args, 1, 2)
 	if exit {
 		return err
 	}

--- a/cmd/incus/list.go
+++ b/cmd/incus/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -42,6 +43,7 @@ type cmdList struct {
 	shorthandFilters map[string]func(*api.Instance, *api.InstanceState, string) bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:] [<filter>...]"))
@@ -136,11 +138,11 @@ incus list -c ns,user.comment:comment
 	cmd.Flags().BoolVar(&c.flagFast, "fast", false, i18n.G("Fast mode (same as --columns=nsacPt)"))
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display instances from all projects"))
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpRemotes(toComplete, false)
 		}
@@ -396,17 +398,18 @@ func (c *cmdList) showInstances(instances []api.InstanceFull, filters []string, 
 	return cli.RenderTable(os.Stdout, c.flagFormat, headers, data, instancesFiltered)
 }
 
+// Run runs the actual command logic.
 func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, -1)
+	exit, err := c.global.checkArgs(cmd, args, 0, -1)
 	if exit {
 		return err
 	}
 
 	if c.global.flagProject != "" && c.flagAllProjects {
-		return fmt.Errorf(i18n.G("Can't specify --project with --all-projects"))
+		return errors.New(i18n.G("Can't specify --project with --all-projects"))
 	}
 
 	// Parse the remote
@@ -492,23 +495,23 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 
 func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 	columnsShorthandMap := map[rune]column{
-		'4': {i18n.G("IPV4"), c.IP4ColumnData, true, false},
-		'6': {i18n.G("IPV6"), c.IP6ColumnData, true, false},
-		'a': {i18n.G("ARCHITECTURE"), c.ArchitectureColumnData, false, false},
-		'b': {i18n.G("STORAGE POOL"), c.StoragePoolColumnData, false, false},
-		'c': {i18n.G("CREATED AT"), c.CreatedColumnData, false, false},
+		'4': {i18n.G("IPV4"), c.ip4ColumnData, true, false},
+		'6': {i18n.G("IPV6"), c.ip6ColumnData, true, false},
+		'a': {i18n.G("ARCHITECTURE"), c.architectureColumnData, false, false},
+		'b': {i18n.G("STORAGE POOL"), c.storagePoolColumnData, false, false},
+		'c': {i18n.G("CREATED AT"), c.createdColumnData, false, false},
 		'd': {i18n.G("DESCRIPTION"), c.descriptionColumnData, false, false},
 		'D': {i18n.G("DISK USAGE"), c.diskUsageColumnData, true, false},
 		'e': {i18n.G("PROJECT"), c.projectColumnData, false, false},
 		'f': {i18n.G("BASE IMAGE"), c.baseImageColumnData, false, false},
 		'F': {i18n.G("BASE IMAGE"), c.baseImageFullColumnData, false, false},
-		'l': {i18n.G("LAST USED AT"), c.LastUsedColumnData, false, false},
+		'l': {i18n.G("LAST USED AT"), c.lastUsedColumnData, false, false},
 		'm': {i18n.G("MEMORY USAGE"), c.memoryUsageColumnData, true, false},
 		'M': {i18n.G("MEMORY USAGE%"), c.memoryUsagePercentColumnData, true, false},
 		'n': {i18n.G("NAME"), c.nameColumnData, false, false},
-		'N': {i18n.G("PROCESSES"), c.NumberOfProcessesColumnData, true, false},
-		'p': {i18n.G("PID"), c.PIDColumnData, true, false},
-		'P': {i18n.G("PROFILES"), c.ProfilesColumnData, false, false},
+		'N': {i18n.G("PROCESSES"), c.numberOfProcessesColumnData, true, false},
+		'p': {i18n.G("PID"), c.pidColumnData, true, false},
+		'P': {i18n.G("PROFILES"), c.profilesColumnData, false, false},
 		'S': {i18n.G("SNAPSHOTS"), c.numberSnapshotsColumnData, false, true},
 		's': {i18n.G("STATE"), c.statusColumnData, false, false},
 		't': {i18n.G("TYPE"), c.typeColumnData, false, false},
@@ -527,7 +530,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 	if c.flagFast {
 		if c.flagColumns != defaultColumns && c.flagColumns != defaultColumnsAllProjects {
 			// --columns was specified too
-			return nil, false, fmt.Errorf(i18n.G("Can't specify --fast with --columns"))
+			return nil, false, errors.New(i18n.G("Can't specify --fast with --columns"))
 		}
 
 		if c.flagColumns == defaultColumnsAllProjects {
@@ -544,7 +547,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 	} else {
 		if c.flagColumns != defaultColumns && c.flagColumns != defaultColumnsAllProjects {
 			if strings.ContainsAny(c.flagColumns, "L") {
-				return nil, false, fmt.Errorf(i18n.G("Can't specify column L when not clustered"))
+				return nil, false, errors.New(i18n.G("Can't specify column L when not clustered"))
 			}
 		}
 		c.flagColumns = strings.ReplaceAll(c.flagColumns, "L", "")
@@ -564,14 +567,14 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 		if !strings.Contains(columnEntry, ".") {
 			for _, columnRune := range columnEntry {
 				column, ok := columnsShorthandMap[columnRune]
-				if ok {
-					columns = append(columns, column)
-
-					if column.NeedsState || column.NeedsSnapshots {
-						needsData = true
-					}
-				} else {
+				if !ok {
 					return nil, false, fmt.Errorf(i18n.G("Unknown column shorthand char '%c' in '%s'"), columnRune, columnEntry)
+				}
+
+				columns = append(columns, column)
+
+				if column.NeedsState || column.NeedsSnapshots {
+					needsData = true
 				}
 			}
 		} else {
@@ -648,8 +651,8 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 						v = cInfo.ExpandedDevices[d[0]][d[1]]
 					}
 
-					//// Truncate the data according to the max width.  A negative max width
-					//// indicates there is no effective limit.
+					// Truncate the data according to the max width.  A negative max width
+					// indicates there is no effective limit.
 					if maxWidth > 0 && len(v) > maxWidth {
 						return v[:maxWidth]
 					}
@@ -701,15 +704,15 @@ func (c *cmdList) statusColumnData(cInfo api.InstanceFull) string {
 	return strings.ToUpper(cInfo.Status)
 }
 
-func (c *cmdList) IP4ColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) ip4ColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Network != nil {
 		ipv4s := []string{}
-		for netName, net := range cInfo.State.Network {
-			if net.Type == "loopback" {
+		for netName, network := range cInfo.State.Network {
+			if network.Type == "loopback" {
 				continue
 			}
 
-			for _, addr := range net.Addresses {
+			for _, addr := range network.Addresses {
 				if slices.Contains([]string{"link", "local"}, addr.Scope) {
 					continue
 				}
@@ -727,15 +730,15 @@ func (c *cmdList) IP4ColumnData(cInfo api.InstanceFull) string {
 	return ""
 }
 
-func (c *cmdList) IP6ColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) ip6ColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Network != nil {
 		ipv6s := []string{}
-		for netName, net := range cInfo.State.Network {
-			if net.Type == "loopback" {
+		for netName, network := range cInfo.State.Network {
+			if network.Type == "loopback" {
 				continue
 			}
 
-			for _, addr := range net.Addresses {
+			for _, addr := range network.Addresses {
 				if slices.Contains([]string{"link", "local"}, addr.Scope) {
 					continue
 				}
@@ -828,7 +831,7 @@ func (c *cmdList) numberSnapshotsColumnData(cInfo api.InstanceFull) string {
 	return "0"
 }
 
-func (c *cmdList) PIDColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) pidColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil {
 		return fmt.Sprintf("%d", cInfo.State.Pid)
 	}
@@ -836,11 +839,11 @@ func (c *cmdList) PIDColumnData(cInfo api.InstanceFull) string {
 	return ""
 }
 
-func (c *cmdList) ArchitectureColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) architectureColumnData(cInfo api.InstanceFull) string {
 	return cInfo.Architecture
 }
 
-func (c *cmdList) StoragePoolColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) storagePoolColumnData(cInfo api.InstanceFull) string {
 	for _, v := range cInfo.ExpandedDevices {
 		if v["type"] == "disk" && v["path"] == "/" {
 			return v["pool"]
@@ -850,11 +853,11 @@ func (c *cmdList) StoragePoolColumnData(cInfo api.InstanceFull) string {
 	return ""
 }
 
-func (c *cmdList) ProfilesColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) profilesColumnData(cInfo api.InstanceFull) string {
 	return strings.Join(cInfo.Profiles, "\n")
 }
 
-func (c *cmdList) CreatedColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) createdColumnData(cInfo api.InstanceFull) string {
 	if !cInfo.CreatedAt.IsZero() {
 		return cInfo.CreatedAt.Local().Format(dateLayout)
 	}
@@ -870,7 +873,7 @@ func (c *cmdList) startedColumnData(cInfo api.InstanceFull) string {
 	return ""
 }
 
-func (c *cmdList) LastUsedColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) lastUsedColumnData(cInfo api.InstanceFull) string {
 	if !cInfo.LastUsedAt.IsZero() {
 		return cInfo.LastUsedAt.Local().Format(dateLayout)
 	}
@@ -878,7 +881,7 @@ func (c *cmdList) LastUsedColumnData(cInfo api.InstanceFull) string {
 	return ""
 }
 
-func (c *cmdList) NumberOfProcessesColumnData(cInfo api.InstanceFull) string {
+func (c *cmdList) numberOfProcessesColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil {
 		return fmt.Sprintf("%d", cInfo.State.Processes)
 	}

--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -365,7 +366,8 @@ If you already added a remote server, make it the default with "incus remote swi
 	}
 }
 
-func (c *cmdGlobal) PreRun(cmd *cobra.Command, args []string) error {
+// PreRun runs for every command and pre-configures the CLI.
+func (c *cmdGlobal) PreRun(cmd *cobra.Command, _ []string) error {
 	var err error
 
 	// If calling the help, skip pre-run
@@ -494,7 +496,8 @@ Or for a virtual machine: incus launch images:ubuntu/22.04 --vm`)+"\n")
 	return nil
 }
 
-func (c *cmdGlobal) PostRun(cmd *cobra.Command, args []string) error {
+// PostRun runs after a successful command.
+func (c *cmdGlobal) PostRun(_ *cobra.Command, _ []string) error {
 	if c.conf != nil && util.PathExists(c.confPath) {
 		// Save OIDC tokens on exit
 		c.conf.SaveOIDCTokens()
@@ -509,7 +512,7 @@ type remoteResource struct {
 	name   string
 }
 
-func (c *cmdGlobal) ParseServers(remotes ...string) ([]remoteResource, error) {
+func (c *cmdGlobal) parseServers(remotes ...string) ([]remoteResource, error) {
 	servers := map[string]incus.InstanceServer{}
 	resources := []remoteResource{}
 
@@ -548,7 +551,7 @@ func (c *cmdGlobal) ParseServers(remotes ...string) ([]remoteResource, error) {
 	return resources, nil
 }
 
-func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, maxArgs int) (bool, error) {
+func (c *cmdGlobal) checkArgs(cmd *cobra.Command, args []string, minArgs int, maxArgs int) (bool, error) {
 	if len(args) < minArgs || (maxArgs != -1 && len(args) > maxArgs) {
 		_ = cmd.Help()
 
@@ -556,7 +559,7 @@ func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, ma
 			return true, nil
 		}
 
-		return true, fmt.Errorf(i18n.G("Invalid number of arguments"))
+		return true, errors.New(i18n.G("Invalid number of arguments"))
 	}
 
 	return false, nil

--- a/cmd/incus/main_aliases.go
+++ b/cmd/incus/main_aliases.go
@@ -167,10 +167,9 @@ func expandAlias(conf *config.Config, args []string, app *cobra.Command) ([]stri
 			// if completing we want to stop on @ARGS@ and append the completion below
 			if completion {
 				break
-			} else {
-				newArgs = append(newArgs, atArgs...)
 			}
 
+			newArgs = append(newArgs, atArgs...)
 			hasReplacedArgsVar = true
 			continue
 		}

--- a/cmd/incus/manpage.go
+++ b/cmd/incus/manpage.go
@@ -17,6 +17,7 @@ type cmdManpage struct {
 	flagAll    bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdManpage) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("manpage", i18n.G("<target>"))
@@ -27,7 +28,7 @@ func (c *cmdManpage) Command() *cobra.Command {
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "man", i18n.G("Format (man|md|rest|yaml)")+"``")
 	cmd.Flags().BoolVar(&c.flagAll, "all", false, i18n.G("Include less common commands"))
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		format := cmd.Flag("format").Value.String()
 		switch format {
 		case "man", "md", "rest", "yaml":
@@ -42,9 +43,10 @@ func (c *cmdManpage) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdManpage) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}

--- a/cmd/incus/monitor.go
+++ b/cmd/incus/monitor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -26,6 +27,7 @@ type cmdMonitor struct {
 	flagFormat      string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdMonitor) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("monitor", i18n.G("[<remote>:]"))
@@ -55,6 +57,7 @@ incus monitor --type=lifecycle
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
@@ -62,7 +65,7 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 	var remote string
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
@@ -77,7 +80,7 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.flagFormat != "pretty" && c.flagLogLevel != "" {
-		return fmt.Errorf(i18n.G("Log level filtering can only be used with pretty formatting"))
+		return errors.New(i18n.G("Log level filtering can only be used with pretty formatting"))
 	}
 
 	// Connect to the event source.
@@ -189,13 +192,15 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 
 		// And now print the result.
 		var render []byte
-		if c.flagFormat == "yaml" {
+		switch c.flagFormat {
+		case "yaml":
 			render, err = yaml.Marshal(&rawEvent)
 			if err != nil {
 				chError <- err
 				return
 			}
-		} else if c.flagFormat == "json" {
+
+		case "json":
 			render, err = json.Marshal(&rawEvent)
 			if err != nil {
 				chError <- err

--- a/cmd/incus/move.go
+++ b/cmd/incus/move.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,6 +28,7 @@ type cmdMove struct {
 	flagAllowInconsistent bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdMove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("move", i18n.G("[<remote>:]<instance> [<remote>:][<instance>]"))
@@ -65,7 +67,7 @@ incus move <instance>/<old snapshot name> <instance>/<new snapshot name>
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagAllowInconsistent, "allow-inconsistent", false, i18n.G("Ignore copy errors for volatile files"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -80,17 +82,18 @@ incus move <instance>/<old snapshot name> <instance>/<new snapshot name>
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
 	if c.flagTarget == "" && c.flagTargetProject == "" && c.flagStorage == "" {
-		exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+		exit, err := c.global.checkArgs(cmd, args, 2, 2)
 		if exit {
 			return err
 		}
 	} else {
-		exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+		exit, err := c.global.checkArgs(cmd, args, 1, 2)
 		if exit {
 			return err
 		}
@@ -124,7 +127,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 	// simply won't work).
 	if sourceRemote == destRemote && c.flagTarget == "" && c.flagStorage == "" && c.flagTargetProject == "" {
 		if c.flagConfig != nil || c.flagDevice != nil || c.flagProfile != nil || c.flagNoProfiles {
-			return fmt.Errorf(i18n.G("Can't override configuration or profiles in local rename"))
+			return errors.New(i18n.G("Can't override configuration or profiles in local rename"))
 		}
 
 		source, err := conf.GetInstanceServer(sourceRemote)
@@ -247,7 +250,7 @@ func (c *cmdMove) moveInstance(sourceResource string, destResource string, state
 
 	// Make sure we have an instance or snapshot name.
 	if sourceName == "" {
-		return fmt.Errorf(i18n.G("You must specify a source instance name"))
+		return errors.New(i18n.G("You must specify a source instance name"))
 	}
 
 	// The destination name is optional.
@@ -262,7 +265,7 @@ func (c *cmdMove) moveInstance(sourceResource string, destResource string, state
 	}
 
 	if !source.IsClustered() && c.flagTarget != "" {
-		return fmt.Errorf(i18n.G("--target can only be used with clusters"))
+		return errors.New(i18n.G("--target can only be used with clusters"))
 	}
 
 	// Set the target if specified.

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,6 +30,7 @@ type networkColumn struct {
 	Data func(api.Network) string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetwork) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("network")
@@ -126,7 +128,7 @@ func (c *cmdNetwork) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -136,6 +138,7 @@ type cmdNetworkAttach struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkAttach) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach", i18n.G("[<remote>:]<network> <instance> [<device name>] [<interface name>]"))
@@ -145,7 +148,7 @@ func (c *cmdNetworkAttach) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpNetworks(toComplete)
 		}
@@ -160,15 +163,16 @@ func (c *cmdNetworkAttach) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkAttach) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 4)
+	exit, err := c.global.checkArgs(cmd, args, 2, 4)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -176,7 +180,7 @@ func (c *cmdNetworkAttach) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Default name is same as network
@@ -233,6 +237,7 @@ type cmdNetworkAttachProfile struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkAttachProfile) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach-profile", i18n.G("[<remote>:]<network> <profile> [<device name>] [<interface name>]"))
@@ -242,7 +247,7 @@ func (c *cmdNetworkAttachProfile) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpNetworks(toComplete)
 		}
@@ -257,15 +262,16 @@ func (c *cmdNetworkAttachProfile) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkAttachProfile) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 4)
+	exit, err := c.global.checkArgs(cmd, args, 2, 4)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -273,7 +279,7 @@ func (c *cmdNetworkAttachProfile) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Default name is same as network
@@ -332,6 +338,7 @@ type cmdNetworkCreate struct {
 	flagDescription string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> [key=value...]"))
@@ -352,7 +359,7 @@ incus network create bar network=baz --type ovn
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -363,11 +370,12 @@ incus network create bar network=baz --type ovn
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkCreate) Run(cmd *cobra.Command, args []string) error {
 	var stdinData api.NetworkPut
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
+	exit, err := c.global.checkArgs(cmd, args, 1, -1)
 	if exit {
 		return err
 	}
@@ -386,7 +394,7 @@ func (c *cmdNetworkCreate) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -447,6 +455,7 @@ type cmdNetworkDelete struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network>"))
@@ -457,7 +466,7 @@ func (c *cmdNetworkDelete) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -468,15 +477,16 @@ func (c *cmdNetworkDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -484,7 +494,7 @@ func (c *cmdNetworkDelete) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Delete the network
@@ -506,6 +516,7 @@ type cmdNetworkDetach struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkDetach) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach", i18n.G("[<remote>:]<network> <instance> [<device name>]"))
@@ -515,7 +526,7 @@ func (c *cmdNetworkDetach) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpNetworks(toComplete)
 		}
@@ -530,15 +541,16 @@ func (c *cmdNetworkDetach) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
+	exit, err := c.global.checkArgs(cmd, args, 2, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -546,7 +558,7 @@ func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Default name is same as network
@@ -566,7 +578,7 @@ func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
 		for n, d := range inst.Devices {
 			if d["type"] == "nic" && (d["parent"] == resource.name || d["network"] == resource.name) {
 				if devName != "" {
-					return fmt.Errorf(i18n.G("More than one device matches, specify the device name"))
+					return errors.New(i18n.G("More than one device matches, specify the device name"))
 				}
 
 				devName = n
@@ -575,16 +587,16 @@ func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if devName == "" {
-		return fmt.Errorf(i18n.G("No device found for this network"))
+		return errors.New(i18n.G("No device found for this network"))
 	}
 
 	device, ok := inst.Devices[devName]
 	if !ok {
-		return fmt.Errorf(i18n.G("The specified device doesn't exist"))
+		return errors.New(i18n.G("The specified device doesn't exist"))
 	}
 
 	if device["type"] != "nic" || (device["parent"] != resource.name && device["network"] != resource.name) {
-		return fmt.Errorf(i18n.G("The specified device doesn't match the network"))
+		return errors.New(i18n.G("The specified device doesn't match the network"))
 	}
 
 	// Remove the device
@@ -603,6 +615,7 @@ type cmdNetworkDetachProfile struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkDetachProfile) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach-profile", i18n.G("[<remote>:]<network> <profile> [<device name>]"))
@@ -612,7 +625,7 @@ func (c *cmdNetworkDetachProfile) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpNetworks(toComplete)
 		}
@@ -627,15 +640,16 @@ func (c *cmdNetworkDetachProfile) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkDetachProfile) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
+	exit, err := c.global.checkArgs(cmd, args, 2, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -643,7 +657,7 @@ func (c *cmdNetworkDetachProfile) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Default name is same as network
@@ -663,7 +677,7 @@ func (c *cmdNetworkDetachProfile) Run(cmd *cobra.Command, args []string) error {
 		for n, d := range profile.Devices {
 			if d["type"] == "nic" && (d["parent"] == resource.name || d["network"] == resource.name) {
 				if devName != "" {
-					return fmt.Errorf(i18n.G("More than one device matches, specify the device name"))
+					return errors.New(i18n.G("More than one device matches, specify the device name"))
 				}
 
 				devName = n
@@ -672,16 +686,16 @@ func (c *cmdNetworkDetachProfile) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if devName == "" {
-		return fmt.Errorf(i18n.G("No device found for this network"))
+		return errors.New(i18n.G("No device found for this network"))
 	}
 
 	device, ok := profile.Devices[devName]
 	if !ok {
-		return fmt.Errorf(i18n.G("The specified device doesn't exist"))
+		return errors.New(i18n.G("The specified device doesn't exist"))
 	}
 
 	if device["type"] != "nic" || (device["parent"] != resource.name && device["network"] != resource.name) {
-		return fmt.Errorf(i18n.G("The specified device doesn't match the network"))
+		return errors.New(i18n.G("The specified device doesn't match the network"))
 	}
 
 	// Remove the device
@@ -700,6 +714,7 @@ type cmdNetworkEdit struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkEdit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<network>"))
@@ -709,7 +724,7 @@ func (c *cmdNetworkEdit) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -740,15 +755,16 @@ func (c *cmdNetworkEdit) helpTemplate() string {
 ### Note that only the configuration can be changed.`)
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -756,7 +772,7 @@ func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// If stdin isn't a terminal, read text from it
@@ -782,7 +798,7 @@ func (c *cmdNetworkEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !network.Managed {
-		return fmt.Errorf(i18n.G("Only managed networks can be modified"))
+		return errors.New(i18n.G("Only managed networks can be modified"))
 	}
 
 	data, err := yaml.Marshal(&network)
@@ -836,6 +852,7 @@ type cmdNetworkGet struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkGet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<network> <key>"))
@@ -847,7 +864,7 @@ func (c *cmdNetworkGet) Command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network property"))
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpNetworks(toComplete)
 		}
@@ -862,15 +879,16 @@ func (c *cmdNetworkGet) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkGet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -879,7 +897,7 @@ func (c *cmdNetworkGet) Run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Get the network key
@@ -894,7 +912,7 @@ func (c *cmdNetworkGet) Run(cmd *cobra.Command, args []string) error {
 
 	if c.flagIsProperty {
 		w := resp.Writable()
-		res, err := getFieldByJsonTag(&w, args[1])
+		res, err := getFieldByJSONTag(&w, args[1])
 		if err != nil {
 			return fmt.Errorf(i18n.G("The property %q does not exist on the network %q: %v"), args[1], resource.name, err)
 		}
@@ -917,6 +935,7 @@ type cmdNetworkInfo struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkInfo) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("info", i18n.G("[<remote>:]<network>"))
@@ -927,7 +946,7 @@ func (c *cmdNetworkInfo) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -938,15 +957,16 @@ func (c *cmdNetworkInfo) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkInfo) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -955,13 +975,13 @@ func (c *cmdNetworkInfo) Run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Targeting.
 	if c.network.flagTarget != "" {
 		if !client.IsClustered() {
-			return fmt.Errorf(i18n.G("To use --target, the destination remote must be a cluster"))
+			return errors.New(i18n.G("To use --target, the destination remote must be a cluster"))
 		}
 
 		client = client.UseTarget(c.network.flagTarget)
@@ -984,7 +1004,7 @@ func (c *cmdNetworkInfo) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf(i18n.G("Type: %s")+"\n", state.Type)
 
 	// IP addresses.
-	if state.Addresses != nil && len(state.Addresses) > 0 {
+	if len(state.Addresses) > 0 {
 		fmt.Println("")
 		fmt.Println(i18n.G("IP addresses:"))
 		for _, addr := range state.Addresses {
@@ -1074,6 +1094,7 @@ type cmdNetworkList struct {
 	flagAllProjects bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
@@ -1102,13 +1123,13 @@ u - Used by (count)`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("List networks in all projects"))
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -1200,9 +1221,10 @@ func (c *cmdNetworkList) stateColumnData(network api.Network) string {
 	return strings.ToUpper(network.Status)
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
@@ -1213,7 +1235,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		remote = args[0]
 	}
 
-	resources, err := c.global.ParseServers(remote)
+	resources, err := c.global.parseServers(remote)
 	if err != nil {
 		return err
 	}
@@ -1222,7 +1244,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 
 	// List the networks
 	if resource.name != "" {
-		return fmt.Errorf(i18n.G("Filtering isn't supported yet"))
+		return errors.New(i18n.G("Filtering isn't supported yet"))
 	}
 
 	var networks []api.Network
@@ -1278,6 +1300,7 @@ type networkLeasesColumn struct {
 	Data func(api.NetworkLease) string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkListLeases) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list-leases", i18n.G("[<remote>:]<network>"))
@@ -1306,13 +1329,13 @@ Pre-defined column shorthand chars:
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkListLeasesColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -1378,15 +1401,16 @@ func (c *cmdNetworkListLeases) locationColumnData(lease api.NetworkLease) string
 	return lease.Location
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1394,7 +1418,7 @@ func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// List DHCP leases
@@ -1435,6 +1459,7 @@ type cmdNetworkRename struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkRename) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<network> <new-name>"))
@@ -1445,7 +1470,7 @@ func (c *cmdNetworkRename) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -1456,15 +1481,16 @@ func (c *cmdNetworkRename) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkRename) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1472,7 +1498,7 @@ func (c *cmdNetworkRename) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Rename the network
@@ -1496,6 +1522,7 @@ type cmdNetworkSet struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkSet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<network> <key>=<value>..."))
@@ -1510,7 +1537,7 @@ For backward compatibility, a single configuration key may still be set with:
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network property"))
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -1521,15 +1548,16 @@ For backward compatibility, a single configuration key may still be set with:
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkSet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	exit, err := c.global.checkArgs(cmd, args, 2, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1538,7 +1566,7 @@ func (c *cmdNetworkSet) Run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Handle targeting
@@ -1553,7 +1581,7 @@ func (c *cmdNetworkSet) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !network.Managed {
-		return fmt.Errorf(i18n.G("Only managed networks can be modified"))
+		return errors.New(i18n.G("Only managed networks can be modified"))
 	}
 
 	// Set the keys
@@ -1566,7 +1594,7 @@ func (c *cmdNetworkSet) Run(cmd *cobra.Command, args []string) error {
 	if c.flagIsProperty {
 		if cmd.Name() == "unset" {
 			for k := range keys {
-				err := unsetFieldByJsonTag(&writable, k)
+				err := unsetFieldByJSONTag(&writable, k)
 				if err != nil {
 					return fmt.Errorf(i18n.G("Error unsetting property: %v"), err)
 				}
@@ -1592,6 +1620,7 @@ type cmdNetworkShow struct {
 	network *cmdNetwork
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<network>"))
@@ -1602,7 +1631,7 @@ func (c *cmdNetworkShow) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -1613,15 +1642,16 @@ func (c *cmdNetworkShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1630,7 +1660,7 @@ func (c *cmdNetworkShow) Run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network name"))
+		return errors.New(i18n.G("Missing network name"))
 	}
 
 	// Show the network config
@@ -1664,6 +1694,7 @@ type cmdNetworkUnset struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkUnset) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<network> <key>"))
@@ -1675,7 +1706,7 @@ func (c *cmdNetworkUnset) Command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network property"))
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpNetworks(toComplete)
 		}
@@ -1690,9 +1721,10 @@ func (c *cmdNetworkUnset) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdNetworkUnset) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}

--- a/cmd/incus/network_allocations.go
+++ b/cmd/incus/network_allocations.go
@@ -28,6 +28,7 @@ type networkAllocationColumn struct {
 	Data func(api.NetworkAllocations) string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdNetworkListAllocations) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list-allocations")
@@ -62,7 +63,7 @@ Pre-defined column shorthand chars:
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Run against all projects"))
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkAllocationColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -126,13 +127,14 @@ func (c *cmdNetworkListAllocations) macAddressColumnData(alloc api.NetworkAlloca
 	return alloc.Hwaddr
 }
 
-func (c *cmdNetworkListAllocations) Run(cmd *cobra.Command, args []string) error {
+// Run runs the actual command logic.
+func (c *cmdNetworkListAllocations) Run(_ *cobra.Command, args []string) error {
 	remote := ""
 	if len(args) > 0 {
 		remote = args[0]
 	}
 
-	resources, err := c.global.ParseServers(remote)
+	resources, err := c.global.parseServers(remote)
 	if err != nil {
 		return err
 	}

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -66,7 +67,7 @@ func (c *cmdNetworkIntegration) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -101,7 +102,7 @@ func (c *cmdNetworkIntegrationCreate) Run(cmd *cobra.Command, args []string) err
 	var stdinData api.NetworkIntegrationPut
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
@@ -120,7 +121,7 @@ func (c *cmdNetworkIntegrationCreate) Run(cmd *cobra.Command, args []string) err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -128,7 +129,7 @@ func (c *cmdNetworkIntegrationCreate) Run(cmd *cobra.Command, args []string) err
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// Create the network integration
@@ -186,13 +187,13 @@ func (c *cmdNetworkIntegrationDelete) Command() *cobra.Command {
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Get the network integration.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -200,7 +201,7 @@ func (c *cmdNetworkIntegrationDelete) Run(cmd *cobra.Command, args []string) err
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// Delete the network integration
@@ -249,13 +250,13 @@ func (c *cmdNetworkIntegrationEdit) helpTemplate() string {
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -263,7 +264,7 @@ func (c *cmdNetworkIntegrationEdit) Run(cmd *cobra.Command, args []string) error
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// If stdin isn't a terminal, read text from it
@@ -360,13 +361,13 @@ func (c *cmdNetworkIntegrationGet) Command() *cobra.Command {
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationGet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -374,7 +375,7 @@ func (c *cmdNetworkIntegrationGet) Run(cmd *cobra.Command, args []string) error 
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// Get the configuration key
@@ -385,7 +386,7 @@ func (c *cmdNetworkIntegrationGet) Run(cmd *cobra.Command, args []string) error 
 
 	if c.flagIsProperty {
 		w := networkIntegration.Writable()
-		res, err := getFieldByJsonTag(&w, args[1])
+		res, err := getFieldByJSONTag(&w, args[1])
 		if err != nil {
 			return fmt.Errorf(i18n.G("The property %q does not exist on the network integration %q: %v"), args[1], resource.name, err)
 		}
@@ -437,7 +438,7 @@ Pre-defined column shorthand chars:
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultNetworkIntegrationColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -498,7 +499,7 @@ func (c *cmdNetworkIntegrationList) Run(cmd *cobra.Command, args []string) error
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
@@ -509,7 +510,7 @@ func (c *cmdNetworkIntegrationList) Run(cmd *cobra.Command, args []string) error
 		remote = args[0]
 	}
 
-	resources, err := c.global.ParseServers(remote)
+	resources, err := c.global.parseServers(remote)
 	if err != nil {
 		return err
 	}
@@ -571,13 +572,13 @@ func (c *cmdNetworkIntegrationRename) Command() *cobra.Command {
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationRename) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -585,7 +586,7 @@ func (c *cmdNetworkIntegrationRename) Run(cmd *cobra.Command, args []string) err
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// Rename the network integration
@@ -628,13 +629,13 @@ For backward compatibility, a single configuration key may still be set with:
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationSet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	exit, err := c.global.checkArgs(cmd, args, 2, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -642,7 +643,7 @@ func (c *cmdNetworkIntegrationSet) Run(cmd *cobra.Command, args []string) error 
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// Get the network integration
@@ -661,7 +662,7 @@ func (c *cmdNetworkIntegrationSet) Run(cmd *cobra.Command, args []string) error 
 	if c.flagIsProperty {
 		if cmd.Name() == "unset" {
 			for k := range keys {
-				err := unsetFieldByJsonTag(&writable, k)
+				err := unsetFieldByJSONTag(&writable, k)
 				if err != nil {
 					return fmt.Errorf(i18n.G("Error unsetting property: %v"), err)
 				}
@@ -706,7 +707,7 @@ func (c *cmdNetworkIntegrationUnset) Command() *cobra.Command {
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationUnset) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
@@ -739,13 +740,13 @@ func (c *cmdNetworkIntegrationShow) Command() *cobra.Command {
 // Run actually performs the action.
 func (c *cmdNetworkIntegrationShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -753,7 +754,7 @@ func (c *cmdNetworkIntegrationShow) Run(cmd *cobra.Command, args []string) error
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing network integration name"))
+		return errors.New(i18n.G("Missing network integration name"))
 	}
 
 	// Show the network integration

--- a/cmd/incus/operation.go
+++ b/cmd/incus/operation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -23,6 +24,7 @@ type operationColumn struct {
 	Data func(api.Operation) string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdOperation) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("operation")
@@ -45,7 +47,7 @@ func (c *cmdOperation) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -55,6 +57,7 @@ type cmdOperationDelete struct {
 	operation *cmdOperation
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdOperationDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<operation>"))
@@ -68,15 +71,16 @@ func (c *cmdOperationDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdOperationDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -106,6 +110,7 @@ type cmdOperationList struct {
 	flagAllProjects bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdOperationList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
@@ -138,7 +143,7 @@ Pre-defined column shorthand chars:
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("List operations from all projects")+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultOperationColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -218,9 +223,10 @@ func (c *cmdOperationList) locationColumnData(op api.Operation) string {
 	return op.Location
 }
 
+// Run runs the actual command logic.
 func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
@@ -231,14 +237,14 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 		remote = args[0]
 	}
 
-	resources, err := c.global.ParseServers(remote)
+	resources, err := c.global.parseServers(remote)
 	if err != nil {
 		return err
 	}
 
 	resource := resources[0]
 	if resource.name != "" {
-		return fmt.Errorf(i18n.G("Filtering isn't supported yet"))
+		return errors.New(i18n.G("Filtering isn't supported yet"))
 	}
 
 	// Get operations
@@ -286,6 +292,7 @@ type cmdOperationShow struct {
 	operation *cmdOperation
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdOperationShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<operation>"))
@@ -301,15 +308,16 @@ func (c *cmdOperationShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdOperationShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/incus/profile.go
+++ b/cmd/incus/profile.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,7 @@ type cmdProfile struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfile) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("profile")
@@ -92,7 +94,7 @@ func (c *cmdProfile) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -102,6 +104,7 @@ type cmdProfileAdd struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<instance> <profile>"))
@@ -111,7 +114,7 @@ func (c *cmdProfileAdd) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -126,15 +129,16 @@ func (c *cmdProfileAdd) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileAdd) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -142,7 +146,7 @@ func (c *cmdProfileAdd) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Add the profile
@@ -176,6 +180,7 @@ type cmdProfileAssign struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileAssign) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("assign", i18n.G("[<remote>:]<instance> <profiles>"))
@@ -195,7 +200,7 @@ incus profile assign foo ''
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -206,15 +211,16 @@ incus profile assign foo ''
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileAssign) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -223,7 +229,7 @@ func (c *cmdProfileAssign) Run(cmd *cobra.Command, args []string) error {
 
 	// Assign the profiles
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	inst, etag, err := resource.server.GetInstance(resource.name)
@@ -267,6 +273,7 @@ type cmdProfileCopy struct {
 	flagRefresh       bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileCopy) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("copy", i18n.G("[<remote>:]<profile> [<remote>:]<profile>"))
@@ -279,7 +286,7 @@ func (c *cmdProfileCopy) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -294,15 +301,16 @@ func (c *cmdProfileCopy) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileCopy) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args...)
+	resources, err := c.global.parseServers(args...)
 	if err != nil {
 		return err
 	}
@@ -311,7 +319,7 @@ func (c *cmdProfileCopy) Run(cmd *cobra.Command, args []string) error {
 	dest := resources[1]
 
 	if source.name == "" {
-		return fmt.Errorf(i18n.G("Missing source profile name"))
+		return errors.New(i18n.G("Missing source profile name"))
 	}
 
 	if dest.name == "" {
@@ -352,6 +360,7 @@ type cmdProfileCreate struct {
 	flagDescription string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<profile>"))
@@ -368,7 +377,7 @@ incus profile create p1 < config.yaml
 
 	cmd.Flags().StringVar(&c.flagDescription, "description", "", i18n.G("Profile description")+"``")
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpRemotes(toComplete, false)
 		}
@@ -379,11 +388,12 @@ incus profile create p1 < config.yaml
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileCreate) Run(cmd *cobra.Command, args []string) error {
 	var stdinData api.ProfilePut
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
@@ -402,7 +412,7 @@ func (c *cmdProfileCreate) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -410,7 +420,7 @@ func (c *cmdProfileCreate) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// Create the profile
@@ -440,6 +450,7 @@ type cmdProfileDelete struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<profile>"))
@@ -450,7 +461,7 @@ func (c *cmdProfileDelete) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -461,15 +472,16 @@ func (c *cmdProfileDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -477,7 +489,7 @@ func (c *cmdProfileDelete) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// Delete the profile
@@ -499,6 +511,7 @@ type cmdProfileEdit struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileEdit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<profile>"))
@@ -511,7 +524,7 @@ func (c *cmdProfileEdit) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -543,15 +556,16 @@ func (c *cmdProfileEdit) helpTemplate() string {
 ### Note that the name is shown but cannot be changed`)
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -559,7 +573,7 @@ func (c *cmdProfileEdit) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// If stdin isn't a terminal, read text from it
@@ -635,6 +649,7 @@ type cmdProfileGet struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileGet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<profile> <key>"))
@@ -646,7 +661,7 @@ func (c *cmdProfileGet) Command() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a profile property"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -661,15 +676,16 @@ func (c *cmdProfileGet) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileGet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -677,7 +693,7 @@ func (c *cmdProfileGet) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// Get the configuration key
@@ -688,7 +704,7 @@ func (c *cmdProfileGet) Run(cmd *cobra.Command, args []string) error {
 
 	if c.flagIsProperty {
 		w := profile.Writable()
-		res, err := getFieldByJsonTag(&w, args[1])
+		res, err := getFieldByJSONTag(&w, args[1])
 		if err != nil {
 			return fmt.Errorf(i18n.G("The property %q does not exist on the profile %q: %v"), args[1], resource.name, err)
 		}
@@ -710,6 +726,7 @@ type cmdProfileList struct {
 	flagAllProjects bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
@@ -734,11 +751,11 @@ u - Used By`))
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display profiles from all projects"))
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpRemotes(toComplete, false)
 		}
@@ -806,15 +823,16 @@ func (c *cmdProfileList) usedByColumnData(profile api.Profile) string {
 	return fmt.Sprintf("%d", len(profile.UsedBy))
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
 
 	if c.global.flagProject != "" && c.flagAllProjects {
-		return fmt.Errorf(i18n.G("Can't specify --project with --all-projects"))
+		return errors.New(i18n.G("Can't specify --project with --all-projects"))
 	}
 
 	// Parse remote
@@ -823,7 +841,7 @@ func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
 		remote = args[0]
 	}
 
-	resources, err := c.global.ParseServers(remote)
+	resources, err := c.global.parseServers(remote)
 	if err != nil {
 		return err
 	}
@@ -875,6 +893,7 @@ type cmdProfileRemove struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<instance> <profile>"))
@@ -884,7 +903,7 @@ func (c *cmdProfileRemove) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -899,15 +918,16 @@ func (c *cmdProfileRemove) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileRemove) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -915,7 +935,7 @@ func (c *cmdProfileRemove) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	// Remove the profile
@@ -962,6 +982,7 @@ type cmdProfileRename struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileRename) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<profile> <new-name>"))
@@ -972,7 +993,7 @@ func (c *cmdProfileRename) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -983,15 +1004,16 @@ func (c *cmdProfileRename) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileRename) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -999,7 +1021,7 @@ func (c *cmdProfileRename) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// Rename the profile
@@ -1023,6 +1045,7 @@ type cmdProfileSet struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileSet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<profile> <key><value>..."))
@@ -1036,7 +1059,7 @@ For backward compatibility, a single configuration key may still be set with:
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a profile property"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -1051,15 +1074,16 @@ For backward compatibility, a single configuration key may still be set with:
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileSet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	exit, err := c.global.checkArgs(cmd, args, 2, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1067,7 +1091,7 @@ func (c *cmdProfileSet) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// Get the profile
@@ -1086,7 +1110,7 @@ func (c *cmdProfileSet) Run(cmd *cobra.Command, args []string) error {
 	if c.flagIsProperty {
 		if cmd.Name() == "unset" {
 			for k := range keys {
-				err := unsetFieldByJsonTag(&writable, k)
+				err := unsetFieldByJSONTag(&writable, k)
 				if err != nil {
 					return fmt.Errorf(i18n.G("Error unsetting property: %v"), err)
 				}
@@ -1112,6 +1136,7 @@ type cmdProfileShow struct {
 	profile *cmdProfile
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<profile>"))
@@ -1121,7 +1146,7 @@ func (c *cmdProfileShow) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -1132,15 +1157,16 @@ func (c *cmdProfileShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	// Parse remote
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1148,7 +1174,7 @@ func (c *cmdProfileShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing profile name"))
+		return errors.New(i18n.G("Missing profile name"))
 	}
 
 	// Show the profile
@@ -1176,6 +1202,7 @@ type cmdProfileUnset struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdProfileUnset) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<profile> <key>"))
@@ -1186,7 +1213,7 @@ func (c *cmdProfileUnset) Command() *cobra.Command {
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a profile property"))
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpProfiles(toComplete, true)
 		}
@@ -1201,9 +1228,10 @@ func (c *cmdProfileUnset) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdProfileUnset) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}

--- a/cmd/incus/query.go
+++ b/cmd/incus/query.go
@@ -27,6 +27,7 @@ type cmdQuery struct {
 	flagData     string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdQuery) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("query", i18n.G("[<remote>:]<API path>"))
@@ -60,17 +61,18 @@ func (c *cmdQuery) pretty(input any) string {
 	return pretty.String()
 }
 
+// Run runs the actual command logic.
 func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
 
 	if c.global.flagProject != "" {
-		return fmt.Errorf(i18n.G("--project cannot be used with the query command"))
+		return errors.New(i18n.G("--project cannot be used with the query command"))
 	}
 
 	if !slices.Contains([]string{"GET", "PUT", "POST", "PATCH", "DELETE"}, c.flagAction) {
@@ -85,7 +87,7 @@ func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 
 	// Validate path
 	if !strings.HasPrefix(path, "/") {
-		return fmt.Errorf(i18n.G("Query path must start with /"))
+		return errors.New(i18n.G("Query path must start with /"))
 	}
 
 	// Attempt to connect

--- a/cmd/incus/remote_windows.go
+++ b/cmd/incus/remote_windows.go
@@ -11,6 +11,7 @@ type cmdRemoteProxy struct {
 	remote *cmdRemote
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdRemoteProxy) Command() *cobra.Command {
 	return nil
 }

--- a/cmd/incus/rename.go
+++ b/cmd/incus/rename.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,7 @@ type cmdRename struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdRename) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<instance> <instance>"))
@@ -22,7 +24,7 @@ func (c *cmdRename) Command() *cobra.Command {
 		`Rename instances`))
 	cmd.RunE = c.Run
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return c.global.cmpInstances(toComplete)
 		}
@@ -33,11 +35,12 @@ func (c *cmdRename) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdRename) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
@@ -56,7 +59,7 @@ func (c *cmdRename) Run(cmd *cobra.Command, args []string) error {
 	if sourceRemote != destRemote {
 		// We just do renames
 		if strings.Contains(args[1], ":") {
-			return fmt.Errorf(i18n.G("Can't specify a different remote for rename"))
+			return errors.New(i18n.G("Can't specify a different remote for rename"))
 		}
 
 		// Don't require the remote to be passed as both source and target

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -27,6 +28,7 @@ type cmdStorageBucket struct {
 	flagTarget string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucket) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("bucket")
@@ -79,7 +81,7 @@ func (c *cmdStorageBucket) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -91,6 +93,7 @@ type cmdStorageBucketCreate struct {
 	flagDescription string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> [key=value...]"))
@@ -110,15 +113,16 @@ incus storage bucket create p1 b01 < config.yaml
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketCreate) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
+	exit, err := c.global.checkArgs(cmd, args, 2, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -126,11 +130,11 @@ func (c *cmdStorageBucketCreate) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	// If stdin isn't a terminal, read yaml from it.
@@ -201,6 +205,7 @@ type cmdStorageBucketDelete struct {
 	storageBucket *cmdStorageBucket
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket>"))
@@ -214,15 +219,16 @@ func (c *cmdStorageBucketDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -230,11 +236,11 @@ func (c *cmdStorageBucketDelete) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	client := resource.server
@@ -263,6 +269,7 @@ type cmdStorageBucketEdit struct {
 	storageBucket *cmdStorageBucket
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketEdit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool> <bucket>"))
@@ -290,15 +297,16 @@ func (c *cmdStorageBucketEdit) helpTemplate() string {
 ###   size: "61203283968"`)
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -306,11 +314,11 @@ func (c *cmdStorageBucketEdit) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	client := resource.server
@@ -396,6 +404,7 @@ type cmdStorageBucketGet struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketGet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<pool> <bucket> <key>"))
@@ -409,15 +418,16 @@ func (c *cmdStorageBucketGet) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketGet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -425,11 +435,11 @@ func (c *cmdStorageBucketGet) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	client := resource.server
@@ -447,7 +457,7 @@ func (c *cmdStorageBucketGet) Run(cmd *cobra.Command, args []string) error {
 
 	if c.flagIsProperty {
 		w := resp.Writable()
-		res, err := getFieldByJsonTag(&w, args[2])
+		res, err := getFieldByJSONTag(&w, args[2])
 		if err != nil {
 			return fmt.Errorf(i18n.G("The property %q does not exist on the storage bucket %q: %v"), args[2], resource.name, err)
 		}
@@ -478,6 +488,7 @@ type storageBucketColumn struct {
 	Data func(api.StorageBucket) string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<pool>"))
@@ -509,7 +520,7 @@ Pre-defined column shorthand chars:
 	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display storage pool buckets from all projects"))
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultStorageBucketColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -573,15 +584,16 @@ func (c *cmdStorageBucketList) projectColumnData(bucket api.StorageBucket) strin
 	return bucket.Project
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
+	exit, err := c.global.checkArgs(cmd, args, 1, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -589,7 +601,7 @@ func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	client := resource.server
@@ -644,6 +656,7 @@ type cmdStorageBucketSet struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketSet) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<pool> <bucket> <key>=<value>..."))
@@ -661,15 +674,16 @@ For backward compatibility, a single configuration key may still be set with:
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketSet) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, -1)
+	exit, err := c.global.checkArgs(cmd, args, 3, -1)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -677,11 +691,11 @@ func (c *cmdStorageBucketSet) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	client := resource.server
@@ -707,7 +721,7 @@ func (c *cmdStorageBucketSet) Run(cmd *cobra.Command, args []string) error {
 	if c.flagIsProperty {
 		if cmd.Name() == "unset" {
 			for k := range keys {
-				err := unsetFieldByJsonTag(&writable, k)
+				err := unsetFieldByJSONTag(&writable, k)
 				if err != nil {
 					return fmt.Errorf(i18n.G("Error unsetting property: %v"), err)
 				}
@@ -738,6 +752,7 @@ type cmdStorageBucketShow struct {
 	storageBucket *cmdStorageBucket
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> <bucket>"))
@@ -753,15 +768,16 @@ func (c *cmdStorageBucketShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -769,11 +785,11 @@ func (c *cmdStorageBucketShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	client := resource.server
@@ -807,6 +823,7 @@ type cmdStorageBucketUnset struct {
 	flagIsProperty bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketUnset) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<pool> <bucket> <key>"))
@@ -820,9 +837,10 @@ func (c *cmdStorageBucketUnset) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketUnset) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
@@ -841,6 +859,7 @@ type cmdStorageBucketKey struct {
 	flagTarget string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketKey) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("key")
@@ -869,7 +888,7 @@ func (c *cmdStorageBucketKey) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -886,6 +905,7 @@ type storageBucketKeyListColumns struct {
 	Data func(api.StorageBucketKey) string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketKeyList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]<pool> <bucket>"))
@@ -915,7 +935,7 @@ Pre-defined column shorthand chars:
 	cmd.Flags().StringVar(&c.storageBucketKey.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultStorageBucketKeyColumns, i18n.G("Columns")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -966,15 +986,16 @@ func (c *cmdStorageBucketKeyList) roleColumnData(buckKey api.StorageBucketKey) s
 	return buckKey.Role
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	exit, err := c.global.checkArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -982,11 +1003,11 @@ func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	client := resource.server
@@ -1037,6 +1058,7 @@ type cmdStorageBucketKeyCreate struct {
 	flagDescription  string
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketKeyCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> <key>"))
@@ -1059,15 +1081,16 @@ incus storage bucket key create p1 b01 k1 < config.yaml
 	return cmd
 }
 
+// RunAdd runs the actual command logic.
 func (c *cmdStorageBucketKeyCreate) RunAdd(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1075,15 +1098,15 @@ func (c *cmdStorageBucketKeyCreate) RunAdd(cmd *cobra.Command, args []string) er
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	if args[2] == "" {
-		return fmt.Errorf(i18n.G("Missing key name"))
+		return errors.New(i18n.G("Missing key name"))
 	}
 
 	client := resource.server
@@ -1148,6 +1171,7 @@ type cmdStorageBucketKeyDelete struct {
 	storageBucketKey *cmdStorageBucketKey
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketKeyDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket> <key>"))
@@ -1160,15 +1184,16 @@ func (c *cmdStorageBucketKeyDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// RunRemove runs the actual command logic.
 func (c *cmdStorageBucketKeyDelete) RunRemove(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1176,15 +1201,15 @@ func (c *cmdStorageBucketKeyDelete) RunRemove(cmd *cobra.Command, args []string)
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	if args[2] == "" {
-		return fmt.Errorf(i18n.G("Missing key name"))
+		return errors.New(i18n.G("Missing key name"))
 	}
 
 	client := resource.server
@@ -1212,6 +1237,7 @@ type cmdStorageBucketKeyEdit struct {
 	storageBucketKey *cmdStorageBucketKey
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketKeyEdit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool> <bucket> <key>"))
@@ -1239,15 +1265,16 @@ func (c *cmdStorageBucketKeyEdit) helpTemplate() string {
 ###   size: "61203283968"`)
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketKeyEdit) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1255,15 +1282,15 @@ func (c *cmdStorageBucketKeyEdit) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	if args[2] == "" {
-		return fmt.Errorf(i18n.G("Missing key name"))
+		return errors.New(i18n.G("Missing key name"))
 	}
 
 	client := resource.server
@@ -1347,6 +1374,7 @@ type cmdStorageBucketKeyShow struct {
 	storageBucketKey *cmdStorageBucketKey
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdStorageBucketKeyShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> <bucket> <key>"))
@@ -1362,15 +1390,16 @@ func (c *cmdStorageBucketKeyShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdStorageBucketKeyShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 3, 3)
+	exit, err := c.global.checkArgs(cmd, args, 3, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
@@ -1378,15 +1407,15 @@ func (c *cmdStorageBucketKeyShow) Run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	if args[1] == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	if args[2] == "" {
-		return fmt.Errorf(i18n.G("Missing key name"))
+		return errors.New(i18n.G("Missing key name"))
 	}
 
 	client := resource.server
@@ -1440,25 +1469,25 @@ func (c *cmdStorageBucketExport) Command() *cobra.Command {
 // Run runs the actual command logic.
 func (c *cmdStorageBucketExport) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
+	exit, err := c.global.checkArgs(cmd, args, 2, 3)
 	if exit {
 		return err
 	}
 
 	// Parse remote.
-	resources, err := c.global.ParseServers(args[0])
+	resources, err := c.global.parseServers(args[0])
 	if err != nil {
 		return err
 	}
 
 	pool := resources[0]
 	if pool.name == "" {
-		return fmt.Errorf(i18n.G("Missing pool name"))
+		return errors.New(i18n.G("Missing pool name"))
 	}
 
 	bucketName := args[1]
 	if bucketName == "" {
-		return fmt.Errorf(i18n.G("Missing bucket name"))
+		return errors.New(i18n.G("Missing bucket name"))
 	}
 
 	s := pool.server
@@ -1590,7 +1619,7 @@ func (c *cmdStorageBucketImport) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
+	exit, err := c.global.checkArgs(cmd, args, 2, 3)
 	if exit {
 		return err
 	}

--- a/cmd/incus/top.go
+++ b/cmd/incus/top.go
@@ -139,7 +139,7 @@ func (c *cmdTop) diskUsageColumnData(dd displayData) string {
 func (c *cmdTop) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}

--- a/cmd/incus/utils.go
+++ b/cmd/incus/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -510,7 +511,7 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 				}
 			}
 			if editor == "" {
-				return []byte{}, fmt.Errorf(i18n.G("No text editor found, please set the EDITOR environment variable"))
+				return []byte{}, errors.New(i18n.G("No text editor found, please set the EDITOR environment variable"))
 			}
 		}
 	}
@@ -522,9 +523,10 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		revert := revert.New()
-		defer revert.Fail()
-		revert.Add(func() {
+		reverter := revert.New()
+		defer reverter.Fail()
+
+		reverter.Add(func() {
 			_ = f.Close()
 			_ = os.Remove(f.Name())
 		})
@@ -550,8 +552,8 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		revert.Success()
-		revert.Add(func() { _ = os.Remove(path) })
+		reverter.Success()
+		reverter.Add(func() { _ = os.Remove(path) })
 	} else {
 		path = inPath
 	}

--- a/cmd/incus/utils_properties_test.go
+++ b/cmd/incus/utils_properties_test.go
@@ -45,7 +45,8 @@ func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncValidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncInvalidData() {
 	hookFunc := stringToBoolHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook, ok := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	s.Equal(true, ok)
 
 	_, err := hook(reflect.String, reflect.Bool, "not a boolean")
 	s.Error(err, "Expected an error but got nil")
@@ -53,7 +54,8 @@ func (s *utilsPropertiesTestSuite) TestStringToBoolHookFuncInvalidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncValidData() {
 	hookFunc := stringToIntHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook, ok := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	s.Equal(true, ok)
 
 	result, err := hook(reflect.String, reflect.Int, "123")
 	s.NoError(err)
@@ -62,7 +64,8 @@ func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncValidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncInvalidData() {
 	hookFunc := stringToIntHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook, ok := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	s.Equal(true, ok)
 
 	_, err := hook(reflect.String, reflect.Int, "not an int")
 	s.Error(err, "Expected an error but got nil")
@@ -70,7 +73,8 @@ func (s *utilsPropertiesTestSuite) TestStringToIntHookFuncInvalidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToFloatHookFuncValidData() {
 	hookFunc := stringToFloatHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook, ok := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	s.Equal(true, ok)
 
 	result, err := hook(reflect.String, reflect.Float64, "123.45")
 	s.NoError(err)
@@ -79,7 +83,8 @@ func (s *utilsPropertiesTestSuite) TestStringToFloatHookFuncValidData() {
 
 func (s *utilsPropertiesTestSuite) TestStringToFloatHookFuncInvalidData() {
 	hookFunc := stringToFloatHookFunc()
-	hook := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	hook, ok := hookFunc.(func(reflect.Kind, reflect.Kind, any) (any, error))
+	s.Equal(true, ok)
 
 	_, err := hook(reflect.String, reflect.Float64, "not a float")
 	s.Error(err, "Expected an error but got nil")
@@ -90,44 +95,44 @@ type testStruct struct {
 	Age  int    `json:"age"`
 }
 
-func (s *utilsPropertiesTestSuite) TestSetFieldByJsonTagSettable() {
+func (s *utilsPropertiesTestSuite) TestSetFieldByJSONTagSettable() {
 	ts := testStruct{
 		Name: "John Doe",
 		Age:  30,
 	}
 
-	setFieldByJsonTag(&ts, "name", "Jane Doe")
+	setFieldByJSONTag(&ts, "name", "Jane Doe")
 	s.Equal("Jane Doe", ts.Name)
 }
 
-func (s *utilsPropertiesTestSuite) TestSetFieldByJsonTagNonSettable() {
+func (s *utilsPropertiesTestSuite) TestSetFieldByJSONTagNonSettable() {
 	ts := testStruct{
 		Name: "John Doe",
 		Age:  30,
 	}
 
-	setFieldByJsonTag(&ts, "invalid name", "Jane Doe")
+	setFieldByJSONTag(&ts, "invalid name", "Jane Doe")
 	s.NotEqual(ts.Name, "Jane Doe")
 }
 
-func (s *utilsPropertiesTestSuite) TestUnsetFieldByJsonTagValid() {
+func (s *utilsPropertiesTestSuite) TestUnsetFieldByJSONTagValid() {
 	ts := testStruct{
 		Name: "John Doe",
 		Age:  30,
 	}
 
-	err := unsetFieldByJsonTag(&ts, "name")
+	err := unsetFieldByJSONTag(&ts, "name")
 	s.NoError(err)
 	s.Equal("", ts.Name)
 }
 
-func (s *utilsPropertiesTestSuite) TestUnsetFieldByJsonTagInvalid() {
+func (s *utilsPropertiesTestSuite) TestUnsetFieldByJSONTagInvalid() {
 	ts := testStruct{
 		Name: "John Doe",
 		Age:  30,
 	}
 
-	err := unsetFieldByJsonTag(&ts, "invalid")
+	err := unsetFieldByJSONTag(&ts, "invalid")
 	s.Error(err, "Expected an error but got nil")
 }
 

--- a/cmd/incus/version.go
+++ b/cmd/incus/version.go
@@ -15,6 +15,7 @@ type cmdVersion struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdVersion) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("version", i18n.G("[<remote>:]"))
@@ -27,9 +28,10 @@ func (c *cmdVersion) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdVersion) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
@@ -45,17 +47,17 @@ func (c *cmdVersion) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	version := i18n.G("unreachable")
-	resources, err := c.global.ParseServers(remote)
+	ver := i18n.G("unreachable")
+	resources, err := c.global.parseServers(remote)
 	if err == nil {
 		resource := resources[0]
 		info, _, err := resource.server.GetServer()
 		if err == nil {
-			version = info.Environment.ServerVersion
+			ver = info.Environment.ServerVersion
 		}
 	}
 
-	fmt.Printf(i18n.G("Server version: %s\n"), version)
+	fmt.Printf(i18n.G("Server version: %s\n"), ver)
 
 	return nil
 }

--- a/cmd/incus/warning.go
+++ b/cmd/incus/warning.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -23,6 +24,7 @@ type cmdWarning struct {
 	global *cmdGlobal
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdWarning) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("warning")
@@ -49,7 +51,7 @@ func (c *cmdWarning) Command() *cobra.Command {
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
-	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	cmd.Run = func(cmd *cobra.Command, _ []string) { _ = cmd.Usage() }
 	return cmd
 }
 
@@ -65,6 +67,7 @@ type cmdWarningList struct {
 
 const defaultWarningColumns = "utSscpLl"
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdWarningList) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("list", i18n.G("[<remote>:]"))
@@ -95,7 +98,7 @@ Column shorthand chars:
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G(`Format (csv|json|table|yaml|compact), use suffix ",noheader" to disable headers and ",header" to enable it if missing, e.g. csv,header`)+"``")
 	cmd.Flags().BoolVarP(&c.flagAll, "all", "a", false, i18n.G("List all warnings")+"``")
 
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		return cli.ValidateFlagFormatForListOutput(cmd.Flag("format").Value.String())
 	}
 
@@ -104,7 +107,8 @@ Column shorthand chars:
 	return cmd
 }
 
-func (c *cmdWarningList) Run(cmd *cobra.Command, args []string) error {
+// Run runs the actual command logic.
+func (c *cmdWarningList) Run(_ *cobra.Command, args []string) error {
 	// Parse remote
 	remote := ""
 	if len(args) > 0 {
@@ -227,7 +231,7 @@ func (c *cmdWarningList) parseColumns(clustered bool) ([]warningColumn, error) {
 	} else {
 		if c.flagColumns != defaultWarningColumns {
 			if strings.ContainsAny(c.flagColumns, "L") {
-				return nil, fmt.Errorf(i18n.G("Can't specify column L when not clustered"))
+				return nil, errors.New(i18n.G("Can't specify column L when not clustered"))
 			}
 		}
 		c.flagColumns = strings.ReplaceAll(c.flagColumns, "L", "")
@@ -243,11 +247,11 @@ func (c *cmdWarningList) parseColumns(clustered bool) ([]warningColumn, error) {
 
 		for _, columnRune := range columnEntry {
 			column, ok := columnsShorthandMap[columnRune]
-			if ok {
-				columns = append(columns, column)
-			} else {
+			if !ok {
 				return nil, fmt.Errorf(i18n.G("Unknown column shorthand char '%c' in '%s'"), columnRune, columnEntry)
 			}
+
+			columns = append(columns, column)
 		}
 	}
 
@@ -260,6 +264,7 @@ type cmdWarningAcknowledge struct {
 	warning *cmdWarning
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdWarningAcknowledge) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("acknowledge", i18n.G("[<remote>:]<warning-uuid>"))
@@ -273,9 +278,10 @@ func (c *cmdWarningAcknowledge) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdWarningAcknowledge) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
@@ -302,6 +308,7 @@ type cmdWarningShow struct {
 	warning *cmdWarning
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdWarningShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<warning-uuid>"))
@@ -314,9 +321,10 @@ func (c *cmdWarningShow) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdWarningShow) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}
@@ -355,6 +363,7 @@ type cmdWarningDelete struct {
 	flagAll bool
 }
 
+// Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdWarningDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<warning-uuid>"))
@@ -370,9 +379,10 @@ func (c *cmdWarningDelete) Command() *cobra.Command {
 	return cmd
 }
 
+// Run runs the actual command logic.
 func (c *cmdWarningDelete) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.checkArgs(cmd, args, 1, 1)
 	if exit {
 		return err
 	}

--- a/cmd/incus/webui_unix.go
+++ b/cmd/incus/webui_unix.go
@@ -20,7 +20,7 @@ import (
 // Run runs the actual command logic.
 func (c *cmdWebui) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	exit, err := c.global.checkArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -932,7 +932,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 
 		baseImage := snap.Config["volatile.base_image"]
 
-		arch, err := osarch.ArchitectureId(snap.Architecture)
+		arch, err := osarch.ArchitectureID(snap.Architecture)
 		if err != nil {
 			return err
 		}

--- a/cmd/incusd/api_internal_recover.go
+++ b/cmd/incusd/api_internal_recover.go
@@ -564,7 +564,7 @@ func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Poo
 
 	internalImportRootDevicePopulate(pool.Name(), snap.Devices, snap.ExpandedDevices, profiles)
 
-	arch, err := osarch.ArchitectureId(snap.Architecture)
+	arch, err := osarch.ArchitectureID(snap.Architecture)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -1384,7 +1384,7 @@ func getImageMetadata(fname string) (*api.ImageMetadata, string, error) {
 		return nil, "unknown", fmt.Errorf("Metadata tarball is missing metadata.yaml")
 	}
 
-	_, err = osarch.ArchitectureId(result.Architecture)
+	_, err = osarch.ArchitectureID(result.Architecture)
 	if err != nil {
 		return nil, "unknown", err
 	}

--- a/cmd/incusd/instance_patch.go
+++ b/cmd/incusd/instance_patch.go
@@ -137,7 +137,7 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		architecture = c.Architecture()
 	} else {
-		architecture, err = osarch.ArchitectureId(req.Architecture)
+		architecture, err = osarch.ArchitectureID(req.Architecture)
 		if err != nil {
 			architecture = 0
 		}

--- a/cmd/incusd/instance_put.go
+++ b/cmd/incusd/instance_put.go
@@ -121,7 +121,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	architecture, err := osarch.ArchitectureId(configRaw.Architecture)
+	architecture, err := osarch.ArchitectureID(configRaw.Architecture)
 	if err != nil {
 		architecture = 0
 	}

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -130,7 +130,7 @@ func createFromImage(s *state.State, r *http.Request, p api.Project, profiles []
 			return fmt.Errorf("Image not provided for instance creation")
 		}
 
-		args.Architecture, err = osarch.ArchitectureId(img.Architecture)
+		args.Architecture, err = osarch.ArchitectureID(img.Architecture)
 		if err != nil {
 			return err
 		}
@@ -179,7 +179,7 @@ func createFromNone(s *state.State, r *http.Request, projectName string, profile
 	}
 
 	if req.Architecture != "" {
-		architecture, err := osarch.ArchitectureId(req.Architecture)
+		architecture, err := osarch.ArchitectureID(req.Architecture)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -219,7 +219,7 @@ func createFromMigration(ctx context.Context, s *state.State, r *http.Request, p
 	}
 
 	// Parse the architecture name
-	architecture, err := osarch.ArchitectureId(req.Architecture)
+	architecture, err := osarch.ArchitectureID(req.Architecture)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -1128,7 +1128,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 
 				if defaultArch != "" {
-					defaultArchID, err := osarch.ArchitectureId(defaultArch)
+					defaultArchID, err := osarch.ArchitectureID(defaultArch)
 					if err != nil {
 						return err
 					}

--- a/cmd/lxc-to-incus/main_migrate.go
+++ b/cmd/lxc-to-incus/main_migrate.go
@@ -399,14 +399,14 @@ func convertContainer(d incus.InstanceServer, container *liblxc.Container, stora
 		arch = value[0]
 	}
 
-	archID, err := osarch.ArchitectureId(arch)
+	archID, err := osarch.ArchitectureID(arch)
 	if err != nil {
 		// If arch is linux32 or linux64, the architecture ID cannot be determined as multiple
 		// architectures have the linux32 or linux64 personality. In this case, assume the native
 		// architecture.
 		arch = runtime.GOARCH
 
-		archID, err = osarch.ArchitectureId(arch)
+		archID, err = osarch.ArchitectureID(arch)
 		if err != nil {
 			return err
 		}

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5120,7 +5120,7 @@ definitions:
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     ResourcesNetworkCardVDPA:
-        description: ResourceNetworkCardVDPA represents the VDPA configuration of the network card
+        description: ResourcesNetworkCardVDPA represents the VDPA configuration of the network card
         properties:
             device:
                 description: Device identifier of the VDPA device

--- a/internal/server/backup/backup_config_utils.go
+++ b/internal/server/backup/backup_config_utils.go
@@ -25,7 +25,7 @@ func ConfigToInstanceDBArgs(state *state.State, c *config.Config, projectName st
 		return nil, nil
 	}
 
-	arch, _ := osarch.ArchitectureId(c.Container.Architecture)
+	arch, _ := osarch.ArchitectureID(c.Container.Architecture)
 	instanceType, _ := instancetype.New(c.Container.Type)
 
 	inst := &db.InstanceArgs{

--- a/internal/server/db/images.go
+++ b/internal/server/db/images.go
@@ -777,7 +777,7 @@ func (c *ClusterTx) SetImageCachedAndLastUseDate(ctx context.Context, projectNam
 
 // UpdateImage updates the image with the given ID.
 func (c *ClusterTx) UpdateImage(ctx context.Context, id int, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, project string, profileIds []int64) error {
-	arch, err := osarch.ArchitectureId(architecture)
+	arch, err := osarch.ArchitectureID(architecture)
 	if err != nil {
 		arch = 0
 	}
@@ -850,7 +850,7 @@ func (c *ClusterTx) UpdateImage(ctx context.Context, id int, fname string, sz in
 
 // CreateImage creates a new image.
 func (c *ClusterTx) CreateImage(ctx context.Context, project string, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, typeName string, profileIds []int64) error {
-	arch, err := osarch.ArchitectureId(architecture)
+	arch, err := osarch.ArchitectureID(architecture)
 	if err != nil {
 		arch = 0
 	}

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -1343,14 +1343,14 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 }
 
 var (
-	idmappedStorageMap       map[unix.Fsid]idmap.IdmapStorageType = map[unix.Fsid]idmap.IdmapStorageType{}
-	idmappedStorageMapString map[string]idmap.IdmapStorageType    = map[string]idmap.IdmapStorageType{}
+	idmappedStorageMap       map[unix.Fsid]idmap.StorageType = map[unix.Fsid]idmap.StorageType{}
+	idmappedStorageMapString map[string]idmap.StorageType    = map[string]idmap.StorageType{}
 	idmappedStorageMapLock   sync.Mutex
 )
 
 // IdmappedStorage determines if the container can use idmapped mounts.
-func (d *lxc) IdmappedStorage(path string, fstype string) idmap.IdmapStorageType {
-	var mode idmap.IdmapStorageType = idmap.IdmapStorageNone
+func (d *lxc) IdmappedStorage(path string, fstype string) idmap.StorageType {
+	var mode idmap.StorageType = idmap.StorageTypeNone
 	var bindMount bool = fstype == "none" || fstype == ""
 
 	if !d.state.OS.LXCFeatures["idmapped_mounts_v2"] || !d.state.OS.IdmappedMounts {
@@ -1386,7 +1386,7 @@ func (d *lxc) IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 
 	if idmap.CanIdmapMount(path, fstype) {
 		// Use idmapped mounts.
-		mode = idmap.IdmapStorageIdmapped
+		mode = idmap.StorageTypeIdmapped
 	}
 
 	if bindMount {
@@ -1711,10 +1711,10 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 				}
 			}
 
-			var idmapType idmap.IdmapStorageType = idmap.IdmapStorageNone
+			var idmapType idmap.StorageType = idmap.StorageTypeNone
 			if !d.IsPrivileged() && mount.OwnerShift == deviceConfig.MountOwnerShiftDynamic {
 				idmapType = d.IdmappedStorage(mount.DevPath, mount.FSType)
-				if idmapType == idmap.IdmapStorageNone {
+				if idmapType == idmap.StorageTypeNone {
 					return fmt.Errorf("Required idmapping abilities not available")
 				}
 			}
@@ -1828,33 +1828,33 @@ func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	return nil
 }
 
-func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.Set, error) {
+func (d *lxc) handleIdmappedStorage() (idmap.StorageType, *idmap.Set, error) {
 	diskIdmap, err := d.DiskIdmap()
 	if err != nil {
-		return idmap.IdmapStorageNone, nil, fmt.Errorf("Set last ID map: %w", err)
+		return idmap.StorageTypeNone, nil, fmt.Errorf("Set last ID map: %w", err)
 	}
 
 	nextIdmap, err := d.NextIdmap()
 	if err != nil {
-		return idmap.IdmapStorageNone, nil, fmt.Errorf("Set ID map: %w", err)
+		return idmap.StorageTypeNone, nil, fmt.Errorf("Set ID map: %w", err)
 	}
 
 	// Identical on-disk idmaps so no changes required.
 	if nextIdmap.Equals(diskIdmap) {
-		return idmap.IdmapStorageNone, nextIdmap, nil
+		return idmap.StorageTypeNone, nextIdmap, nil
 	}
 
 	// There's no on-disk idmap applied and the container can use idmapped
 	// storage.
 	idmapType := d.IdmappedStorage(d.RootfsPath(), "none")
-	if diskIdmap == nil && idmapType != idmap.IdmapStorageNone {
+	if diskIdmap == nil && idmapType != idmap.StorageTypeNone {
 		return idmapType, nextIdmap, nil
 	}
 
 	// We need to change the on-disk idmap but the container is protected
 	// against idmap changes.
 	if util.IsTrue(d.expandedConfig["security.protection.shift"]) {
-		return idmap.IdmapStorageNone, nil, fmt.Errorf("Container is protected against filesystem shifting")
+		return idmap.StorageTypeNone, nil, fmt.Errorf("Container is protected against filesystem shifting")
 	}
 
 	d.logger.Debug("Container idmap changed, remapping")
@@ -1862,7 +1862,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.Set, error
 
 	storageType, err := d.getStorageType()
 	if err != nil {
-		return idmap.IdmapStorageNone, nil, fmt.Errorf("Storage type: %w", err)
+		return idmap.StorageTypeNone, nil, fmt.Errorf("Storage type: %w", err)
 	}
 
 	// Revert the currently applied on-disk idmap.
@@ -1876,7 +1876,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.Set, error
 		}
 
 		if err != nil {
-			return idmap.IdmapStorageNone, nil, err
+			return idmap.StorageTypeNone, nil, err
 		}
 	}
 
@@ -1885,7 +1885,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.Set, error
 	// If the container can't use idmapped storage apply the new on-disk
 	// idmap of the container now. Otherwise we will later instruct LXC to
 	// make use of idmapped storage.
-	if nextIdmap != nil && idmapType == idmap.IdmapStorageNone {
+	if nextIdmap != nil && idmapType == idmap.StorageTypeNone {
 		if storageType == "zfs" {
 			err = nextIdmap.ShiftPath(d.RootfsPath(), storageDrivers.ShiftZFSSkipper)
 		} else if storageType == "btrfs" {
@@ -1895,12 +1895,12 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.Set, error
 		}
 
 		if err != nil {
-			return idmap.IdmapStorageNone, nil, err
+			return idmap.StorageTypeNone, nil, err
 		}
 
 		idmapJSON, err := nextIdmap.ToJSON()
 		if err != nil {
-			return idmap.IdmapStorageNone, nil, err
+			return idmap.StorageTypeNone, nil, err
 		}
 
 		jsonDiskIdmap = idmapJSON
@@ -1908,7 +1908,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.Set, error
 
 	err = d.VolatileSet(map[string]string{"volatile.last_state.idmap": jsonDiskIdmap})
 	if err != nil {
-		return idmap.IdmapStorageNone, nextIdmap, fmt.Errorf("Set volatile.last_state.idmap config key on container %q (id %d): %w", d.name, d.id, err)
+		return idmap.StorageTypeNone, nextIdmap, fmt.Errorf("Set volatile.last_state.idmap config key on container %q (id %d): %w", d.name, d.id, err)
 	}
 
 	d.updateProgress("")
@@ -2193,7 +2193,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 				}
 			}
 
-			if !d.IsPrivileged() && idmapType == idmap.IdmapStorageIdmapped {
+			if !d.IsPrivileged() && idmapType == idmap.StorageTypeIdmapped {
 				err = lxcSetConfigItem(cc, "lxc.rootfs.options", "idmap=container")
 				if err != nil {
 					return "", nil, fmt.Errorf("Failed to set \"idmap=container\" rootfs option: %w", err)
@@ -2240,9 +2240,9 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 				if !d.IsPrivileged() && mount.OwnerShift == deviceConfig.MountOwnerShiftDynamic {
 					switch d.IdmappedStorage(mount.DevPath, mount.FSType) {
-					case idmap.IdmapStorageIdmapped:
+					case idmap.StorageTypeIdmapped:
 						mntOptions = strings.Join([]string{mntOptions, "idmap=container"}, ",")
-					case idmap.IdmapStorageNone:
+					case idmap.StorageTypeNone:
 						return "", nil, fmt.Errorf("Failed to setup device mount %q: %w", dev.Name(), fmt.Errorf("idmapping abilities are required but aren't supported on system"))
 					}
 				}
@@ -4819,7 +4819,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				}
 			} else if key == "security.guestapi" {
 				if util.IsTrueOrEmpty(value) {
-					err = d.insertMount(internalUtil.VarPath("guestapi"), "/dev/incus", "none", unix.MS_BIND, idmap.IdmapStorageNone)
+					err = d.insertMount(internalUtil.VarPath("guestapi"), "/dev/incus", "none", unix.MS_BIND, idmap.StorageTypeNone)
 					if err != nil {
 						return err
 					}
@@ -7933,7 +7933,7 @@ func (d *lxc) unmount() error {
 // we'll have a deadlock (with a timeout but still). The InitPID() call here is
 // the exception since the seccomp notifier will make sure to always pass a
 // valid PID.
-func (d *lxc) insertMountGo(source, target, fstype string, flags int, mntnsPID int, idmapType idmap.IdmapStorageType) error {
+func (d *lxc) insertMountGo(source, target, fstype string, flags int, mntnsPID int, idmapType idmap.StorageType) error {
 	pid := mntnsPID
 	if pid <= 0 {
 		// Get the init PID
@@ -8051,7 +8051,7 @@ func (d *lxc) insertMountLXC(source, target, fstype string, flags int) error {
 	return nil
 }
 
-func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
+func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idmap.StorageType) error {
 	// Get the init PID
 	pid := d.InitPID()
 	if pid == -1 {
@@ -8060,8 +8060,8 @@ func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idma
 	}
 
 	switch idmapType {
-	case idmap.IdmapStorageIdmapped:
-	case idmap.IdmapStorageNone:
+	case idmap.StorageTypeIdmapped:
+	case idmap.StorageTypeNone:
 	default:
 		return fmt.Errorf("Invalid idmap value specified")
 	}
@@ -8098,12 +8098,12 @@ func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idma
 	return nil
 }
 
-func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
-	if d.state.OS.IdmappedMounts && idmapType == idmap.IdmapStorageIdmapped {
+func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType idmap.StorageType) error {
+	if d.state.OS.IdmappedMounts && idmapType == idmap.StorageTypeIdmapped {
 		return d.moveMount(source, target, fstype, flags, idmapType)
 	}
 
-	if d.state.OS.LXCFeatures["mount_injection_file"] && idmapType == idmap.IdmapStorageNone {
+	if d.state.OS.LXCFeatures["mount_injection_file"] && idmapType == idmap.StorageTypeNone {
 		return d.insertMountLXC(source, target, fstype, flags)
 	}
 
@@ -8217,7 +8217,7 @@ func (d *lxc) InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid 
 
 	// Bind-mount it into the container
 	defer func() { _ = os.Remove(devPath) }()
-	return d.insertMountGo(devPath, tgtPath, "none", unix.MS_BIND, pid, idmap.IdmapStorageNone)
+	return d.insertMountGo(devPath, tgtPath, "none", unix.MS_BIND, pid, idmap.StorageTypeNone)
 }
 
 func (d *lxc) removeUnixDevices() error {

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -1349,7 +1349,7 @@ var (
 )
 
 // IdmappedStorage determines if the container can use idmapped mounts.
-func (d *lxc) IdmappedStorage(path string, fstype string) idmap.StorageType {
+func (d *lxc) IdmappedStorage(fspath string, fstype string) idmap.StorageType {
 	var mode idmap.StorageType = idmap.StorageTypeNone
 	var bindMount bool = fstype == "none" || fstype == ""
 
@@ -1360,9 +1360,9 @@ func (d *lxc) IdmappedStorage(path string, fstype string) idmap.StorageType {
 	buf := &unix.Statfs_t{}
 
 	if bindMount {
-		err := unix.Statfs(path, buf)
+		err := unix.Statfs(fspath, buf)
 		if err != nil {
-			d.logger.Error("Failed to statfs", logger.Ctx{"path": path, "err": err})
+			d.logger.Error("Failed to statfs", logger.Ctx{"path": fspath, "err": err})
 			return mode
 		}
 	}
@@ -1384,7 +1384,7 @@ func (d *lxc) IdmappedStorage(path string, fstype string) idmap.StorageType {
 		}
 	}
 
-	if idmap.CanIdmapMount(path, fstype) {
+	if idmap.CanIdmapMount(fspath, fstype) {
 		// Use idmapped mounts.
 		mode = idmap.StorageTypeIdmapped
 	}

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -186,7 +186,7 @@ type Container interface {
 	ConsoleLog(opts liblxc.ConsoleLogOptions) (string, error)
 	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 	DevptsFd() (*os.File, error)
-	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
+	IdmappedStorage(path string, fstype string) idmap.StorageType
 }
 
 // VM interface is for VM specific functions.

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -578,7 +578,7 @@ func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, sou
 func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx, projectName string, sourceInst *cluster.Instance, sourceImageRef string, req api.InstancesPost) ([]int, error) {
 	// Handle cases where the architecture is already provided.
 	if slices.Contains([]string{"migration", "none"}, req.Source.Type) && req.Architecture != "" {
-		id, err := osarch.ArchitectureId(req.Architecture)
+		id, err := osarch.ArchitectureID(req.Architecture)
 		if err != nil {
 			return nil, err
 		}
@@ -610,7 +610,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx
 				return nil, err
 			}
 
-			id, err := osarch.ArchitectureId(img.Architecture)
+			id, err := osarch.ArchitectureID(img.Architecture)
 			if err != nil {
 				return nil, err
 			}
@@ -676,7 +676,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx
 					return nil, err
 				}
 
-				id, err := osarch.ArchitectureId(img.Architecture)
+				id, err := osarch.ArchitectureID(img.Architecture)
 				if err != nil {
 					return nil, err
 				}
@@ -686,7 +686,7 @@ func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx
 
 			architectures := []int{}
 			for arch := range entries {
-				id, err := osarch.ArchitectureId(arch)
+				id, err := osarch.ArchitectureID(arch)
 				if err != nil {
 					return nil, err
 				}
@@ -1197,7 +1197,7 @@ func SnapshotToProtobuf(snap *api.InstanceSnapshot) *migration.Snapshot {
 	}
 
 	isEphemeral := snap.Ephemeral
-	archID, _ := osarch.ArchitectureId(snap.Architecture)
+	archID, _ := osarch.ArchitectureID(snap.Architecture)
 	arch := int32(archID)
 	stateful := snap.Stateful
 	creationDate := snap.CreatedAt.UTC().Unix()

--- a/internal/server/seccomp/seccomp.go
+++ b/internal/server/seccomp/seccomp.go
@@ -627,7 +627,7 @@ type Instance interface {
 	CGroup() (*cgroup.CGroup, error)
 	CurrentIdmap() (*idmap.Set, error)
 	DiskIdmap() (*idmap.Set, error)
-	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
+	IdmappedStorage(path string, fstype string) idmap.StorageType
 	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 }
 
@@ -1914,7 +1914,7 @@ type MountArgs struct {
 	flags     int
 	data      string
 	pid       int
-	idmapType idmap.IdmapStorageType
+	idmapType idmap.StorageType
 	uid       int64
 	gid       int64
 	fsuid     int64
@@ -2052,7 +2052,7 @@ func (s *Server) mountHandleHugetlbfsArgs(c Instance, args *MountArgs, nsuid int
 	}
 
 	args.data = strings.Join(optStrings, ",")
-	args.idmapType = idmap.IdmapStorageNone
+	args.idmapType = idmap.StorageTypeNone
 	return nil
 }
 
@@ -2511,11 +2511,11 @@ func (s *Server) MountSyscallValid(c Instance, args *MountArgs) (bool, string) {
 }
 
 // MountSyscallShift checks whether this mount syscall needs shifting.
-func (s *Server) MountSyscallShift(c Instance, path string, fsType string) idmap.IdmapStorageType {
+func (s *Server) MountSyscallShift(c Instance, path string, fsType string) idmap.StorageType {
 	if util.IsTrue(c.ExpandedConfig()["security.syscalls.intercept.mount.shift"]) {
 		diskIdmap, err := c.DiskIdmap()
 		if err != nil {
-			return idmap.IdmapStorageNone
+			return idmap.StorageTypeNone
 		}
 
 		if diskIdmap == nil {
@@ -2523,7 +2523,7 @@ func (s *Server) MountSyscallShift(c Instance, path string, fsType string) idmap
 		}
 	}
 
-	return idmap.IdmapStorageNone
+	return idmap.StorageTypeNone
 }
 
 var pageSize = 4096

--- a/internal/server/sys/os.go
+++ b/internal/server/sys/os.go
@@ -247,7 +247,7 @@ func (s *OS) GetUnixSocket() string {
 
 func getIdmapset() *idmap.Set {
 	// Try getting the system map.
-	idmapset, err := idmap.NewSetFromSystem("", "root")
+	idmapset, err := idmap.NewSetFromSystem("root")
 	if err != nil && err != idmap.ErrSubidUnsupported {
 		logger.Error("Unable to parse system idmap", logger.Ctx{"err": err})
 		return nil

--- a/internal/server/util/sys.go
+++ b/internal/server/util/sys.go
@@ -20,7 +20,7 @@ func GetArchitectures() ([]int, error) {
 		return nil, err
 	}
 
-	architecture, err := osarch.ArchitectureId(architectureName)
+	architecture, err := osarch.ArchitectureID(architectureName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/version/useragent.go
+++ b/internal/version/useragent.go
@@ -19,7 +19,7 @@ var (
 )
 
 func getUserAgent() string {
-	archID, err := osarch.ArchitectureId(runtime.GOARCH)
+	archID, err := osarch.ArchitectureID(runtime.GOARCH)
 	if err != nil {
 		panic(err)
 	}

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -45,7 +45,8 @@ type Event struct {
 
 // ToLogging creates log record for the event.
 func (event *Event) ToLogging() (EventLogRecord, error) {
-	if event.Type == EventTypeLogging || event.Type == EventTypeNetworkACL {
+	switch event.Type {
+	case EventTypeLogging, EventTypeNetworkACL:
 		e := &EventLogging{}
 		err := json.Unmarshal(event.Metadata, &e)
 		if err != nil {
@@ -66,7 +67,8 @@ func (event *Event) ToLogging() (EventLogRecord, error) {
 		}
 
 		return record, nil
-	} else if event.Type == EventTypeLifecycle {
+
+	case EventTypeLifecycle:
 		e := &EventLifecycle{}
 		err := json.Unmarshal(event.Metadata, &e)
 		if err != nil {
@@ -93,7 +95,8 @@ func (event *Event) ToLogging() (EventLogRecord, error) {
 		}
 
 		return record, nil
-	} else if event.Type == EventTypeOperation {
+
+	case EventTypeOperation:
 		e := &Operation{}
 		err := json.Unmarshal(event.Metadata, &e)
 		if err != nil {

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -567,7 +567,7 @@ type ResourcesNetworkCardSRIOV struct {
 	VFs []ResourcesNetworkCard `json:"vfs" yaml:"vfs"`
 }
 
-// ResourceNetworkCardVDPA represents the VDPA configuration of the network card
+// ResourcesNetworkCardVDPA represents the VDPA configuration of the network card
 //
 // swagger:model
 //

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -251,6 +251,6 @@ type StorageVolumeSource struct {
 }
 
 // Writable converts a full StorageVolume struct into a StorageVolumePut struct (filters read-only fields).
-func (storageVolume *StorageVolume) Writable() StorageVolumePut {
-	return storageVolume.StorageVolumePut
+func (v *StorageVolume) Writable() StorageVolumePut {
+	return v.StorageVolumePut
 }

--- a/shared/api/storage_pool_volume_snapshot.go
+++ b/shared/api/storage_pool_volume_snapshot.go
@@ -49,7 +49,7 @@ type StorageVolumeSnapshotPost struct {
 //
 // API extension: storage_api_volume_snapshots.
 type StorageVolumeSnapshot struct {
-	StorageVolumeSnapshotPut `json:",inline" yaml:",inline"`
+	StorageVolumeSnapshotPut `yaml:",inline"`
 
 	// Snapshot name
 	// Example: snap0

--- a/shared/api/url.go
+++ b/shared/api/url.go
@@ -45,7 +45,7 @@ func (u *URL) Path(pathParts ...string) *URL {
 	}
 
 	u.URL.Path = path.String()
-	u.URL.RawPath = rawPath.String()
+	u.RawPath = rawPath.String()
 
 	return u
 }

--- a/shared/archive/archive.go
+++ b/shared/archive/archive.go
@@ -26,6 +26,7 @@ type nullWriteCloser struct {
 	*bytes.Buffer
 }
 
+// Close closes the writer.
 func (nwc *nullWriteCloser) Close() error {
 	return nil
 }

--- a/shared/ask/ask.go
+++ b/shared/ask/ask.go
@@ -69,7 +69,7 @@ func (a *Asker) AskInt(question string, minValue int64, maxValue int64, defaultA
 			continue
 		}
 
-		if !((minValue == -1 || result >= minValue) && (maxValue == -1 || result <= maxValue)) {
+		if (minValue > -1 && result >= minValue) || (maxValue > -1 && result <= maxValue) {
 			fmt.Fprintf(os.Stderr, "Invalid input: out of range\n\n")
 			continue
 		}

--- a/shared/ask/ask.go
+++ b/shared/ask/ask.go
@@ -115,12 +115,6 @@ func (a *Asker) AskString(question string, defaultAnswer string, validate func(s
 
 // AskPassword asks the user to enter a password.
 func (a *Asker) AskPassword(question string) string {
-	return AskPassword(question)
-}
-
-// AskPassword asks the user to enter a password.
-// Deprecated: Use asker.AskPassword instead.
-func AskPassword(question string) string {
 	for {
 		fmt.Print(question)
 
@@ -148,14 +142,6 @@ func AskPassword(question string) string {
 //
 // It's the same as AskPassword, but it won't ask to enter it again.
 func (a *Asker) AskPasswordOnce(question string) string {
-	return AskPasswordOnce(question)
-}
-
-// AskPasswordOnce asks the user to enter a password.
-//
-// It's the same as AskPassword, but it won't ask to enter it again.
-// Deprecated: Use asker.AskPasswordOnce instead.
-func AskPasswordOnce(question string) string {
 	for {
 		fmt.Print(question)
 		pwd, _ := term.ReadPassword(0)

--- a/shared/cliconfig/file.go
+++ b/shared/cliconfig/file.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -19,7 +18,7 @@ func getConfigPaths() (string, string, error) {
 	if os.Getenv("INCUS_CONF") != "" {
 		configDir = os.Getenv("INCUS_CONF")
 	} else if os.Getenv("HOME") != "" && util.PathExists(os.Getenv("HOME")) {
-		configDir = path.Join(os.Getenv("HOME"), ".config", "incus")
+		configDir = filepath.Join(os.Getenv("HOME"), ".config", "incus")
 	} else {
 		usr, err := user.Current()
 		if err != nil {
@@ -27,7 +26,7 @@ func getConfigPaths() (string, string, error) {
 		}
 
 		if util.PathExists(usr.HomeDir) {
-			configDir = path.Join(usr.HomeDir, ".config", "incus")
+			configDir = filepath.Join(usr.HomeDir, ".config", "incus")
 		}
 	}
 
@@ -35,7 +34,7 @@ func getConfigPaths() (string, string, error) {
 		return "", "", nil
 	}
 
-	configPath := os.ExpandEnv(path.Join(configDir, "config.yml"))
+	configPath := os.ExpandEnv(filepath.Join(configDir, "config.yml"))
 
 	return configPath, filepath.Dir(configPath), nil
 }

--- a/shared/cliconfig/remote.go
+++ b/shared/cliconfig/remote.go
@@ -87,9 +87,11 @@ func (c *Config) GetInstanceServer(name string) (incus.InstanceServer, error) {
 
 			if errors.As(err, &netErr) {
 				errMsg := netErr.Unwrap().Error()
-				if errMsg == "connect: connection refused" || errMsg == "connect: no such file or directory" {
+
+				switch errMsg {
+				case "connect: connection refused", "connect: no such file or directory":
 					return nil, fmt.Errorf("The incus daemon doesn't appear to be started (socket path: %s)", netErr.Addr)
-				} else if errMsg == "connect: permission denied" {
+				case "connect: permission denied":
 					return nil, fmt.Errorf("You don't have the needed permissions to talk to the incus daemon (socket path: %s)", netErr.Addr)
 				}
 

--- a/shared/idmap/internal_linux.go
+++ b/shared/idmap/internal_linux.go
@@ -43,21 +43,21 @@ func getAllXattr(path string) (map[string]string, error) {
 }
 
 // getErrno checks if the Go error is a kernel errno.
-func getErrno(err error) (errno error, iserrno bool) {
+func getErrno(err error) (iserrno bool, errno error) {
 	sysErr, ok := err.(*os.SyscallError)
 	if ok {
-		return sysErr.Err, true
+		return true, sysErr.Err
 	}
 
 	pathErr, ok := err.(*os.PathError)
 	if ok {
-		return pathErr.Err, true
+		return true, pathErr.Err
 	}
 
 	tmpErrno, ok := err.(unix.Errno)
 	if ok {
-		return tmpErrno, true
+		return true, tmpErrno
 	}
 
-	return nil, false
+	return false, nil
 }

--- a/shared/idmap/set_load.go
+++ b/shared/idmap/set_load.go
@@ -166,7 +166,7 @@ func NewSetFromCurrentProcess() (*Set, error) {
 }
 
 // NewSetFromSystem returns a Set for the specified user from the system's subuid/subgid configuration.
-func NewSetFromSystem(rootfs string, username string) (*Set, error) {
+func NewSetFromSystem(username string) (*Set, error) {
 	// Check if the system supports subuid/subgid.
 	pathNewUIDMap, _ := exec.LookPath("newuidmap")
 	pathNewGIDMap, _ := exec.LookPath("newgidmap")

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -2,8 +2,9 @@
 
 package idmap
 
-// #cgo LDFLAGS: -lacl
 /*
+#cgo LDFLAGS: -lacl
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
@@ -459,13 +460,13 @@ func SetCaps(path string, caps []byte, uid int64) error {
 }
 
 // ShiftACL updates the uid and gid for ACL entries through the provided mapper function.
-func ShiftACL(path string, shiftIds func(uid int64, gid int64) (int64, int64)) error {
-	err := shiftAclType(path, C.ACL_TYPE_ACCESS, shiftIds)
+func ShiftACL(path string, shiftIDs func(uid int64, gid int64) (int64, int64)) error {
+	err := shiftACLType(path, C.ACL_TYPE_ACCESS, shiftIDs)
 	if err != nil {
 		return err
 	}
 
-	err = shiftAclType(path, C.ACL_TYPE_DEFAULT, shiftIds)
+	err = shiftACLType(path, C.ACL_TYPE_DEFAULT, shiftIDs)
 	if err != nil {
 		return err
 	}
@@ -473,7 +474,7 @@ func ShiftACL(path string, shiftIds func(uid int64, gid int64) (int64, int64)) e
 	return nil
 }
 
-func shiftAclType(path string, aclType int, shiftIds func(uid int64, gid int64) (int64, int64)) error {
+func shiftACLType(path string, aclType int, shiftIDs func(uid int64, gid int64) (int64, int64)) error {
 	// Convert the path to something usable with cgo
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
@@ -488,12 +489,12 @@ func shiftAclType(path string, aclType int, shiftIds func(uid int64, gid int64) 
 
 	// Iterate through all ACL entries
 	update := false
-	for entryId := C.ACL_FIRST_ENTRY; ; entryId = C.ACL_NEXT_ENTRY {
+	for entryID := C.ACL_FIRST_ENTRY; ; entryID = C.ACL_NEXT_ENTRY {
 		var ent C.acl_entry_t
 		var tag C.acl_tag_t
 
 		// Get the ACL entry
-		ret := C.acl_get_entry(acl, C.int(entryId), &ent)
+		ret := C.acl_get_entry(acl, C.int(entryID), &ent)
 		if ret == 0 {
 			break
 		} else if ret < 0 {
@@ -518,15 +519,15 @@ func shiftAclType(path string, aclType int, shiftIds func(uid int64, gid int64) 
 		}
 
 		// Shift the value
-		newId := int64(-1)
+		newID := int64(-1)
 		if tag == C.ACL_USER {
-			newId, _ = shiftIds((int64)(*idp), -1)
+			newID, _ = shiftIDs((int64)(*idp), -1)
 		} else {
-			_, newId = shiftIds(-1, (int64)(*idp))
+			_, newID = shiftIDs(-1, (int64)(*idp))
 		}
 
 		// Update the new entry with the shifted value
-		ret = C.acl_set_qualifier(ent, unsafe.Pointer(&newId))
+		ret = C.acl_set_qualifier(ent, unsafe.Pointer(&newID))
 		if ret == -1 {
 			return fmt.Errorf("Failed to set ACL qualifier on %s", path)
 		}
@@ -571,7 +572,7 @@ func SupportsVFS3FSCaps(prefix string) bool {
 	cmd := exec.Command(tmpfile.Name())
 	err = cmd.Run()
 	if err != nil {
-		errno, isErrno := getErrno(err)
+		isErrno, errno := getErrno(err)
 		if isErrno && (errno == unix.ERANGE || errno == unix.EOVERFLOW) {
 			return false
 		}
@@ -611,10 +612,10 @@ func UnshiftACL(value string, set *Set) (string, error) {
 		return "", fmt.Errorf("No valid ACLs found")
 	}
 
-	entry_ptr := C.posix_entry_start(unsafe.Pointer(header))
-	end_entry_ptr := C.posix_entry_end(entry_ptr, C.size_t(count))
-	for entry_ptr != end_entry_ptr {
-		entry := (*C.struct_posix_acl_xattr_entry)(entry_ptr)
+	entryPtr := C.posix_entry_start(unsafe.Pointer(header))
+	endEntryPtr := C.posix_entry_end(entryPtr, C.size_t(count))
+	for entryPtr != endEntryPtr {
+		entry := (*C.struct_posix_acl_xattr_entry)(entryPtr)
 		switch C.le16_to_native(entry.e_tag) {
 		case C.ACL_USER:
 			ouid := int64(C.le32_to_native(entry.e_id))
@@ -644,7 +645,7 @@ func UnshiftACL(value string, set *Set) (string, error) {
 			logger.Debugf("Ignoring unknown ACL type %d", C.le16_to_native(entry.e_tag))
 		}
 
-		entry_ptr = C.posix_entry_next(entry_ptr)
+		entryPtr = C.posix_entry_next(entryPtr)
 	}
 
 	buf = C.GoBytes(cBuf, C.int(size))
@@ -679,13 +680,18 @@ func UnshiftCaps(value string, set *Set) (string, error) {
 	return string(buf), nil
 }
 
+// StorageType represents a storage shifting type.
 type StorageType string
 
 const (
-	StorageTypeNone     = "none"
+	// StorageTypeNone is used for regular manually shifted trees.
+	StorageTypeNone = "none"
+
+	// StorageTypeIdmapped is usded for VFS idmapped mounts.
 	StorageTypeIdmapped = "idmapped"
 )
 
+// CanIdmapMount checks if the provided path and filesystem can use VFS idmapped mounts.
 func CanIdmapMount(path string, fstype string) bool {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -679,11 +679,11 @@ func UnshiftCaps(value string, set *Set) (string, error) {
 	return string(buf), nil
 }
 
-type IdmapStorageType string
+type StorageType string
 
 const (
-	IdmapStorageNone     = "none"
-	IdmapStorageIdmapped = "idmapped"
+	StorageTypeNone     = "none"
+	StorageTypeIdmapped = "idmapped"
 )
 
 func CanIdmapMount(path string, fstype string) bool {

--- a/shared/logger/syslog_linux.go
+++ b/shared/logger/syslog_linux.go
@@ -13,10 +13,12 @@ type syslogHandler struct {
 	handler logrus.Hook
 }
 
+// Fire sends a logging entry through syslog.
 func (h syslogHandler) Fire(entry *logrus.Entry) error {
 	return h.handler.Fire(entry)
 }
 
+// Levels returns the list of supported log levels for syslog.
 func (h syslogHandler) Levels() []logrus.Level {
 	return []logrus.Level{
 		logrus.PanicLevel,

--- a/shared/logger/wrapper.go
+++ b/shared/logger/wrapper.go
@@ -22,34 +22,42 @@ type logWrapper struct {
 	target targetLogger
 }
 
+// Panic logs a panic level message.
 func (lw *logWrapper) Panic(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Panic(msg)
 }
 
+// Fatal logs a fatal level message.
 func (lw *logWrapper) Fatal(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Fatal(msg)
 }
 
+// Error logs an error level message.
 func (lw *logWrapper) Error(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Error(msg)
 }
 
+// Warn logs a warning level message.
 func (lw *logWrapper) Warn(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Warn(msg)
 }
 
+// Info logs an info level message.
 func (lw *logWrapper) Info(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Info(msg)
 }
 
+// Debug logs a debug level message.
 func (lw *logWrapper) Debug(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Debug(msg)
 }
 
+// Trace logs a trace level message.
 func (lw *logWrapper) Trace(msg string, ctx ...Ctx) {
 	lw.ctxLogger(ctx...).Trace(msg)
 }
 
+// AddContext returns a sub-logger with the provided context added.
 func (lw *logWrapper) AddContext(ctx Ctx) Logger {
 	return &logWrapper{lw.ctxLogger(ctx)}
 }

--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -108,7 +108,7 @@ func ArchitectureName(arch int) (string, error) {
 }
 
 // ArchitectureID converts an architecture name to its ID.
-func ArchitectureId(arch string) (int, error) {
+func ArchitectureID(arch string) (int, error) {
 	for archID, archName := range architectureNames {
 		if archName == arch {
 			return archID, nil
@@ -153,7 +153,7 @@ func ArchitectureGetLocalID() (int, error) {
 		return -1, err
 	}
 
-	id, err := ArchitectureId(name)
+	id, err := ArchitectureID(name)
 	if err != nil {
 		return -1, err
 	}

--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -94,28 +94,31 @@ var architectureSupportedPersonalities = map[int][]int{
 	ARCH_64BIT_LOONGARCH:             {},
 }
 
+// ArchitectureDefault is the fallback architecture when the local architecture can't be properly detected.
 const ArchitectureDefault = "x86_64"
 
+// ArchitectureName converts an architecture ID to its name.
 func ArchitectureName(arch int) (string, error) {
-	arch_name, exists := architectureNames[arch]
+	archName, exists := architectureNames[arch]
 	if exists {
-		return arch_name, nil
+		return archName, nil
 	}
 
 	return "unknown", fmt.Errorf("Architecture isn't supported: %d", arch)
 }
 
+// ArchitectureID converts an architecture name to its ID.
 func ArchitectureId(arch string) (int, error) {
-	for arch_id, arch_name := range architectureNames {
-		if arch_name == arch {
-			return arch_id, nil
+	for archID, archName := range architectureNames {
+		if archName == arch {
+			return archID, nil
 		}
 	}
 
-	for arch_id, arch_aliases := range architectureAliases {
-		for _, arch_name := range arch_aliases {
-			if arch_name == arch {
-				return arch_id, nil
+	for archID, archAliases := range architectureAliases {
+		for _, archName := range archAliases {
+			if archName == arch {
+				return archID, nil
 			}
 		}
 	}
@@ -123,15 +126,17 @@ func ArchitectureId(arch string) (int, error) {
 	return ARCH_UNKNOWN, fmt.Errorf("Architecture isn't supported: %s", arch)
 }
 
+// ArchitecturePersonality returns the kernel personality name for the architecture.
 func ArchitecturePersonality(arch int) (string, error) {
-	arch_personality, exists := architecturePersonalities[arch]
+	archPersonality, exists := architecturePersonalities[arch]
 	if exists {
-		return arch_personality, nil
+		return archPersonality, nil
 	}
 
 	return "", fmt.Errorf("Architecture isn't supported: %d", arch)
 }
 
+// ArchitecturePersonalities returns the list of personalities for the provided architecture.
 func ArchitecturePersonalities(arch int) ([]int, error) {
 	personalities, exists := architectureSupportedPersonalities[arch]
 	if exists {

--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// nolint:revive
 const (
 	ARCH_UNKNOWN                     = 0
 	ARCH_32BIT_INTEL_X86             = 1

--- a/shared/proxy/proxy.go
+++ b/shared/proxy/proxy.go
@@ -30,6 +30,7 @@ type envOnce struct {
 	val   string
 }
 
+// Get gets the environment variable.
 func (e *envOnce) Get() string {
 	e.once.Do(e.init)
 	return e.val
@@ -44,13 +45,14 @@ func (e *envOnce) init() {
 	}
 }
 
-// This is basically the same as golang's ProxyFromEnvironment, except it
+// FromEnvironment is basically the same as golang's ProxyFromEnvironment, except it
 // doesn't fall back to http_proxy when https_proxy isn't around, which is
 // incorrect behavior. It still respects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
 func FromEnvironment(req *http.Request) (*url.URL, error) {
 	return FromConfig("", "", "")(req)
 }
 
+// FromConfig returns a proxy function for the provided proxy servers.
 func FromConfig(httpsProxy string, httpProxy string, noProxy string) func(req *http.Request) (*url.URL, error) {
 	return func(req *http.Request) (*url.URL, error) {
 		var proxy, port string

--- a/shared/revert/revert_test.go
+++ b/shared/revert/revert_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func ExampleReverter_fail() {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { fmt.Println("1st step") })
-	revert.Add(func() { fmt.Println("2nd step") })
+	reverter.Add(func() { fmt.Println("1st step") })
+	reverter.Add(func() { fmt.Println("2nd step") })
 
 	// Revert functions are run in reverse order on return.
 	// Output: 2nd step
@@ -19,12 +19,12 @@ func ExampleReverter_fail() {
 }
 
 func ExampleReverter_success() {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { fmt.Println("1st step") })
-	revert.Add(func() { fmt.Println("2nd step") })
+	reverter.Add(func() { fmt.Println("1st step") })
+	reverter.Add(func() { fmt.Println("2nd step") })
 
-	revert.Success() // Revert functions added are not run on return.
+	reverter.Success() // Revert functions added are not run on return.
 	// Output:
 }

--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -107,19 +107,24 @@ func (s *Products) ToAPI() ([]api.Image, map[string][][]string) {
 				// Figure out the fingerprint
 				fingerprint := ""
 				if root != nil {
-					if root.FileType == "root.tar.xz" {
+					switch root.FileType {
+					case "root.tar.xz":
 						if meta.CombinedSha256RootXz != "" {
 							fingerprint = meta.CombinedSha256RootXz
 						} else {
 							fingerprint = meta.CombinedSha256
 						}
-					} else if root.FileType == "squashfs" {
+
+					case "squashfs":
 						fingerprint = meta.CombinedSha256SquashFs
-					} else if root.FileType == "disk-kvm.img" {
+
+					case "disk-kvm.img":
 						fingerprint = meta.CombinedSha256DiskKvmImg
-					} else if root.FileType == "disk1.img" {
+
+					case "disk1.img":
 						fingerprint = meta.CombinedSha256DiskImg
-					} else if root.FileType == "uefi1.img" {
+
+					case "uefi1.img":
 						fingerprint = meta.CombinedSha256DiskUefiImg
 					}
 				} else {

--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -71,7 +71,7 @@ func (s *Products) ToAPI() ([]api.Image, map[string][][]string) {
 
 	for _, product := range s.Products {
 		// Skip unsupported architectures
-		architecture, err := osarch.ArchitectureId(product.Architecture)
+		architecture, err := osarch.ArchitectureID(product.Architecture)
 		if err != nil {
 			continue
 		}

--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -26,10 +26,10 @@ type DownloadableFile struct {
 }
 
 // NewClient returns a simplestreams client for the provided stream URL.
-func NewClient(url string, httpClient http.Client, useragent string) *SimpleStreams {
+func NewClient(uri string, httpClient http.Client, useragent string) *SimpleStreams {
 	return &SimpleStreams{
 		http:           &httpClient,
-		url:            url,
+		url:            uri,
 		cachedProducts: map[string]*Products{},
 		useragent:      useragent,
 	}

--- a/shared/simplestreams/sort.go
+++ b/shared/simplestreams/sort.go
@@ -82,7 +82,7 @@ func (a sortedAliases) Less(i, j int) bool {
 	}
 
 	isPersonality := func(arch string) bool {
-		archID, err := osarch.ArchitectureId(nativeName)
+		archID, err := osarch.ArchitectureID(nativeName)
 		if err != nil {
 			return false
 		}

--- a/shared/tls/cert.go
+++ b/shared/tls/cert.go
@@ -401,6 +401,7 @@ func GenerateMemCert(client bool, addHosts bool) ([]byte, []byte, error) {
 	return cert, key, nil
 }
 
+// ReadCert reads a PEM encoded certificate.
 func ReadCert(fpath string) (*x509.Certificate, error) {
 	cf, err := os.ReadFile(fpath)
 	if err != nil {
@@ -415,10 +416,12 @@ func ReadCert(fpath string) (*x509.Certificate, error) {
 	return x509.ParseCertificate(certBlock.Bytes)
 }
 
+// CertFingerprint returns the SHA256 fingerprint string of an x509 certificate.
 func CertFingerprint(cert *x509.Certificate) string {
 	return fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
 }
 
+// CertFingerprintStr returns the SHA256 fingerprint of a PEM encoded certificate.
 func CertFingerprintStr(c string) (string, error) {
 	pemCertificate, _ := pem.Decode([]byte(c))
 	if pemCertificate == nil {
@@ -433,6 +436,7 @@ func CertFingerprintStr(c string) (string, error) {
 	return CertFingerprint(cert), nil
 }
 
+// GetRemoteCertificate gets the x509 certificate from a remote HTTPS server.
 func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, error) {
 	// Setup a permissive TLS config
 	tlsConfig, err := GetTLSConfig(nil)

--- a/shared/tls/tls.go
+++ b/shared/tls/tls.go
@@ -19,7 +19,7 @@ const connectErrorPrefix = "Unable to connect to"
 
 // RFC3493Dialer connects to the specified server and returns the connection.
 // If the connection cannot be established then an error with the connectErrorPrefix is returned.
-func RFC3493Dialer(context context.Context, network string, address string) (net.Conn, error) {
+func RFC3493Dialer(_ context.Context, network string, address string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
@@ -98,6 +98,7 @@ func finalizeTLSConfig(tlsConfig *tls.Config, tlsRemoteCert *x509.Certificate) {
 	}
 }
 
+// GetTLSConfig returns the TLS config for the provided remote certificate.
 func GetTLSConfig(tlsRemoteCert *x509.Certificate) (*tls.Config, error) {
 	tlsConfig := InitTLSConfig()
 
@@ -106,6 +107,7 @@ func GetTLSConfig(tlsRemoteCert *x509.Certificate) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// GetTLSConfigMem returns the TLS config for the provided client and server certificates.
 func GetTLSConfigMem(tlsClientCert string, tlsClientKey string, tlsClientCA string, tlsRemoteCertPEM string, insecureSkipVerify bool) (*tls.Config, error) {
 	tlsConfig := InitTLSConfig()
 

--- a/shared/util/filesystem.go
+++ b/shared/util/filesystem.go
@@ -6,6 +6,7 @@ import (
 	"os"
 )
 
+// PathExists checks if the provided path exists.
 func PathExists(name string) bool {
 	_, err := os.Lstat(name)
 	if err != nil && errors.Is(err, fs.ErrNotExist) {

--- a/shared/util/filesystem_unix.go
+++ b/shared/util/filesystem_unix.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// PathIsWritable checks if the provided path is writable.
 func PathIsWritable(path string) bool {
 	return unix.Access(path, unix.W_OK) == nil
 }

--- a/shared/util/net.go
+++ b/shared/util/net.go
@@ -17,7 +17,8 @@ import (
 // can not be found (404 HTTP status code).
 var ErrNotFound = errors.New("resource not found")
 
-func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent string, progress func(progress ioprogress.ProgressData), canceler *cancel.HTTPRequestCanceller, filename string, url string, hash string, hashFunc hash.Hash, target io.WriteSeeker) (int64, error) {
+// DownloadFileHash downloads a file while validating its hash.
+func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent string, progress func(progress ioprogress.ProgressData), canceler *cancel.HTTPRequestCanceller, filename string, url string, fileHash string, hashFunc hash.Hash, target io.WriteSeeker) (int64, error) {
 	// Always seek to the beginning
 	_, _ = target.Seek(0, io.SeekStart)
 
@@ -83,8 +84,8 @@ func DownloadFileHash(ctx context.Context, httpClient *http.Client, useragent st
 		}
 
 		result := fmt.Sprintf("%x", hashFunc.Sum(nil))
-		if result != hash {
-			return -1, fmt.Errorf("Hash mismatch for %s: %s != %s", url, result, hash)
+		if result != fileHash {
+			return -1, fmt.Errorf("Hash mismatch for %s: %s != %s", url, result, fileHash)
 		}
 	} else {
 		size, err = io.Copy(target, body)

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -104,15 +104,15 @@ func IsUint32Range(value string) error {
 }
 
 // IsInRange checks whether an integer is within a specific range.
-func IsInRange(min int64, max int64) func(value string) error {
+func IsInRange(minValue int64, maxValue int64) func(value string) error {
 	return func(value string) error {
 		valueInt, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return fmt.Errorf("Invalid value for an integer %q", value)
 		}
 
-		if valueInt < min || valueInt > max {
-			return fmt.Errorf("Value isn't within valid range. Must be between %d and %d", min, max)
+		if valueInt < minValue || valueInt > maxValue {
+			return fmt.Errorf("Value isn't within valid range. Must be between %d and %d", minValue, maxValue)
 		}
 
 		return nil
@@ -154,7 +154,7 @@ func IsOneOf(valid ...string) func(value string) error {
 }
 
 // IsAny accepts all strings as valid.
-func IsAny(value string) error {
+func IsAny(_ string) error {
 	return nil
 }
 

--- a/shared/ws/upgrader.go
+++ b/shared/ws/upgrader.go
@@ -9,6 +9,6 @@ import (
 
 // Upgrader is a websocket upgrader which ignores the request Origin.
 var Upgrader = websocket.Upgrader{
-	CheckOrigin:      func(r *http.Request) bool { return true },
+	CheckOrigin:      func(_ *http.Request) bool { return true },
 	HandshakeTimeout: time.Second * 5,
 }


### PR DESCRIPTION
This fixes all `golangci-lint` reported errors/warnings for the CLI and all its dependencies.

We're still VERY far from being clean across the board as there are another 1596 issues to fix across the remaining tools and the entire server codebase, but that's still a pretty solid start ;)

Most issues are very repetitive:
 - Exported stuff that shouldn't be
 - Exported stuff missing the usual boilerplate comment
 - If/else-if that should be a switch
 - Missing checks on type casting
 - If/else with a breaking statement that can be flattened
 - Variable shadowing
 - Static fmt.Errorf that should be an errors.New
 - x.Write(fmt.Sprintf) that should be a fmt.Fprintf

I used sed or similar scripting for as many as possible, the rest was mechanical changes done by hand. Other than the changes that were specifically split out into separate commits, the linting fixes don't cause functional changes.