### PR TITLE
incusd/instance/common: Fix concurrent restarts

### DIFF
--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -654,8 +654,13 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 	}
 
 	// Setup a new operation for the start phase.
-	op, err = operationlock.Create(d.Project().Name, d.Name(), d.op, operationlock.ActionRestart, true, true)
+	op, err = operationlock.CreateWaitGet(d.Project().Name, d.Name(), d.op, operationlock.ActionRestart, nil, true, false)
 	if err != nil {
+		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+			// An existing matching operation has now succeeded, return.
+			return nil
+		}
+
 		return fmt.Errorf("Create restart (for start) operation: %w", err)
 	}
 


### PR DESCRIPTION
When multiple restarts occur at the same time, we need to wait for the ongoing one to complete rather than call Start multiple times in parallel.


Sponsored-by: https://webdock.io