### PR TITLE
generate-database: Fix documentation for `ignore`

### DIFF
--- a/cmd/generate-database/README.md
+++ b/cmd/generate-database/README.md
@@ -119,7 +119,7 @@ Tag                         | Description
 `joinon=<table>.<column>`   | Overrides the default `JOIN ON` clause with the given table and column, replacing `<table>.<joinTable_id>` above.
 `primary=yes`               | Assigns column associated with the field to be sufficient for returning a row from the table. Will default to `Name` if unspecified. Fields with this key will be included in the default 'ORDER BY' clause.
 `omit=<Stmt Types>`         | Omits a given field from consideration for the comma separated list of statement types (`create`, `objects-by-Name`, `update`).
-`ignore=yes`                | Outright ignore the struct field as though it does not exist.
+`ignore`                    | Outright ignore the struct field as though it does not exist. `ignore` needs to be the only tag value in order to be recognized.
 `marshal=<yes/json>`        | Marshal/Unmarshal data into the field. The column must be a TEXT column. If `marshal=yes`, then the type must implement both `Marshal` and `Unmarshal`. If `marshal=json`, the type is marshaled to JSON using the standard library ([json.Marshal](https://pkg.go.dev/encoding/json#Marshal)). This works for entity tables only, and not for association or mapping tables.
 
 ### Go Function Generation


### PR DESCRIPTION
In https://github.com/lxc/incus/blob/main/cmd/generate-database/db/parse.go#L456, the condition checks exactly for `ignore` as the stuct tag value for `db`. Therefore a field is only ignored, if the struct tag is `db:"ignore"`.