### PR TITLE
Add snapshot pre-fetching support

### DIFF
--- a/cmd/incusd/instance_snapshot.go
+++ b/cmd/incusd/instance_snapshot.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lxc/incus/v6/internal/server/request"
 	"github.com/lxc/incus/v6/internal/server/response"
 	"github.com/lxc/incus/v6/internal/server/state"
-	storagePools "github.com/lxc/incus/v6/internal/server/storage"
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
 	"github.com/lxc/incus/v6/internal/version"
 	"github.com/lxc/incus/v6/shared/api"
@@ -190,7 +189,7 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		for _, snap := range snaps {
-			render, _, err := snap.Render(storagePools.RenderSnapshotUsage(s, snap))
+			render, _, err := snap.RenderWithUsage()
 			if err != nil {
 				continue
 			}
@@ -586,7 +585,7 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func snapshotGet(s *state.State, snapInst instance.Instance) response.Response {
-	render, _, err := snapInst.Render(storagePools.RenderSnapshotUsage(s, snapInst))
+	render, _, err := snapInst.RenderWithUsage()
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -352,6 +352,17 @@ func (d *common) Snapshots() ([]instance.Instance, error) {
 		return nil, err
 	}
 
+	// Allow storage to pre-fetch snapshot details using bulk queries.
+	pool, err := d.getStoragePool()
+	if err != nil {
+		return nil, err
+	}
+
+	err = pool.CacheInstanceSnapshots(d)
+	if err != nil {
+		return nil, err
+	}
+
 	snapshots := make([]instance.Instance, 0, len(snapshotArgs))
 	for _, snapshotArg := range snapshotArgs {
 		// Populate profile info that was already loaded.
@@ -362,6 +373,18 @@ func (d *common) Snapshots() ([]instance.Instance, error) {
 			return nil, err
 		}
 
+		// Set the storage pool to the pre-loaded one (for caching).
+		snapLXC, ok := snapInst.(*lxc)
+		if ok {
+			snapLXC.storagePool = pool
+		}
+
+		snapQEMU, ok := snapInst.(*qemu)
+		if ok {
+			snapQEMU.storagePool = pool
+		}
+
+		// Pass through the current operation.
 		snapInst.SetOperation(d.op)
 
 		snapshots = append(snapshots, instance.Instance(snapInst))

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -3621,8 +3621,38 @@ func (d *lxc) getLxcState() (liblxc.State, error) {
 	}
 }
 
+// RenderWithUsage renders the API response including disk usage.
+func (d *lxc) RenderWithUsage() (any, any, error) {
+	resp, etag, err := d.Render()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Currently only snapshot data needs usage added.
+	snapResp, ok := resp.(*api.InstanceSnapshot)
+	if !ok {
+		return resp, etag, nil
+	}
+
+	pool, err := d.getStoragePool()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// It is important that the snapshot not be mounted here as mounting a snapshot can trigger a very
+	// expensive filesystem UUID regeneration, so we rely on the driver implementation to get the info
+	// we are requesting as cheaply as possible.
+	volumeState, err := pool.GetInstanceUsage(d)
+	if err != nil {
+		return resp, etag, nil
+	}
+
+	snapResp.Size = volumeState.Used
+	return snapResp, etag, nil
+}
+
 // Render renders the state of the instance.
-func (d *lxc) Render(options ...func(response any) error) (any, any, error) {
+func (d *lxc) Render() (any, any, error) {
 	// Ignore err as the arch string on error is correct (unknown)
 	architectureName, _ := osarch.ArchitectureName(d.architecture)
 	profileNames := make([]string, 0, len(d.profiles))
@@ -3649,13 +3679,6 @@ func (d *lxc) Render(options ...func(response any) error) (any, any, error) {
 		snapState.Profiles = profileNames
 		snapState.ExpiresAt = d.expiryDate
 
-		for _, option := range options {
-			err := option(&snapState)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-
 		return &snapState, d.ETag(), nil
 	}
 
@@ -3681,13 +3704,6 @@ func (d *lxc) Render(options ...func(response any) error) (any, any, error) {
 	instState.Profiles = profileNames
 	instState.Stateful = d.stateful
 	instState.Project = d.project.Name
-
-	for _, option := range options {
-		err := option(&instState)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
 
 	return &instState, d.ETag(), nil
 }

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -7650,7 +7650,7 @@ func (d *lxc) diskState() map[string]api.InstanceStateDisk {
 		var usage *storagePools.VolumeUsage
 
 		if dev.Config["path"] == "/" {
-			pool, err := storagePools.LoadByInstance(d.state, d)
+			pool, err := d.getStoragePool()
 			if err != nil {
 				d.logger.Error("Error loading storage pool", logger.Ctx{"err": err})
 				continue

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -118,7 +118,8 @@ type Instance interface {
 	Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, stderr *os.File) (Cmd, error)
 
 	// Status
-	Render(options ...func(response any) error) (any, any, error)
+	Render() (any, any, error)
+	RenderWithUsage() (any, any, error)
 	RenderFull(hostInterfaces []net.Interface) (*api.InstanceFull, any, error)
 	RenderState(hostInterfaces []net.Interface) (*api.InstanceState, error)
 	IsRunning() bool

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -64,6 +64,7 @@ type ConfigReader interface {
 	Type() instancetype.Type
 	Architecture() int
 	ID() int
+	Name() string
 
 	ExpandedConfig() map[string]string
 	ExpandedDevices() deviceConfig.Devices
@@ -133,7 +134,6 @@ type Instance interface {
 
 	// Properties.
 	Location() string
-	Name() string
 	CloudInitID() string
 	Description() string
 	CreationDate() time.Time

--- a/internal/server/response/swagger.go
+++ b/internal/server/response/swagger.go
@@ -1,6 +1,6 @@
 // Package response contains helpers for rendering HTTP responses.
 //
-//nolint:deadcode,unused
+//nolint:unused
 package response
 
 import (

--- a/internal/server/storage/backend_mock.go
+++ b/internal/server/storage/backend_mock.go
@@ -202,6 +202,11 @@ func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Ope
 	return nil
 }
 
+// CacheInstanceSnapshots is used to pre-fetch snapshot information ahead of bulk queries.
+func (b *mockBackend) CacheInstanceSnapshots(inst instance.ConfigReader) error {
+	return nil
+}
+
 func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, op *operations.Operation) error {
 	return nil
 }

--- a/internal/server/storage/drivers/driver_common.go
+++ b/internal/server/storage/drivers/driver_common.go
@@ -577,3 +577,8 @@ func (d *common) filesystemFreeze(path string) (func() error, error) {
 
 	return unfreezeFS, nil
 }
+
+// CacheVolumeSnapshots causes snapshot data to be cached for later use (for bulk queries).
+func (d *common) CacheVolumeSnapshots(vol Volume) error {
+	return nil
+}

--- a/internal/server/storage/drivers/driver_zfs.go
+++ b/internal/server/storage/drivers/driver_zfs.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/internal/migration"
@@ -57,6 +58,10 @@ var zfsDefaultSettings = map[string]string{
 
 type zfs struct {
 	common
+
+	// Temporary cache (typically lives for the duration of a query).
+	cache   map[string]map[string]int64
+	cacheMu sync.Mutex
 }
 
 // load is used to run one-time action per-driver rather than per-pool.

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -1646,6 +1646,53 @@ func (d *zfs) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	return nil
 }
 
+// CacheVolumeSnapshots fetches snapshot usage properties for all snapshots on the volume.
+func (d *zfs) CacheVolumeSnapshots(vol Volume) error {
+	// Lock the cache.
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+
+	if d.cache == nil {
+		d.cache = map[string]map[string]int64{}
+	}
+
+
+	// Get the usage data.
+	out, err := subprocess.RunCommand("zfs", "list", "-H", "-p", "-o", "name,used,referenced", "-t", "snapshot", d.dataset(vol, false))
+	if err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			continue
+		}
+
+		usedInt, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		referencedInt, err := strconv.ParseInt(fields[2], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		d.cache[fields[0]] = map[string]int64{
+			"used": usedInt,
+			"referenced": referencedInt,
+		}
+	}
+
+	return nil
+}
+
 // GetVolumeUsage returns the disk space used by the volume.
 func (d *zfs) GetVolumeUsage(vol Volume) (int64, error) {
 	// Determine what key to use.
@@ -1668,6 +1715,20 @@ func (d *zfs) GetVolumeUsage(vol Volume) (int64, error) {
 			}
 
 			return int64(stat.Blocks-stat.Bfree) * int64(stat.Bsize), nil
+		}
+	} else {
+		// Use the snapshot cache if present.
+		d.cacheMu.Lock()
+		defer d.cacheMu.Unlock()
+
+		if d.cache != nil {
+			cache, ok := d.cache[d.dataset(vol, false)]
+			if ok {
+				value, ok := cache[key]
+				if ok {
+					return value, nil
+				}
+			}
 		}
 	}
 

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -1656,7 +1656,6 @@ func (d *zfs) CacheVolumeSnapshots(vol Volume) error {
 		d.cache = map[string]map[string]int64{}
 	}
 
-
 	// Get the usage data.
 	out, err := subprocess.RunCommand("zfs", "list", "-H", "-p", "-o", "name,used,referenced", "-t", "snapshot", d.dataset(vol, false))
 	if err != nil {
@@ -1685,7 +1684,7 @@ func (d *zfs) CacheVolumeSnapshots(vol Volume) error {
 		}
 
 		d.cache[fields[0]] = map[string]int64{
-			"used": usedInt,
+			"used":       usedInt,
 			"referenced": referencedInt,
 		}
 	}

--- a/internal/server/storage/drivers/interface.go
+++ b/internal/server/storage/drivers/interface.go
@@ -95,6 +95,9 @@ type Driver interface {
 	// not mounted.
 	UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
 
+	// CacheVolumeSnapshots is used to temporarily pre-fetch and cache snapshot information.
+	CacheVolumeSnapshots(vol Volume) error
+
 	CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error
 	DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error
 	RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error

--- a/internal/server/storage/pool_interface.go
+++ b/internal/server/storage/pool_interface.go
@@ -88,6 +88,7 @@ type Pool interface {
 	UnmountInstance(inst instance.Instance, op *operations.Operation) error
 
 	// Instance snapshots.
+	CacheInstanceSnapshots(inst instance.ConfigReader) error
 	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -1045,30 +1045,6 @@ func FallbackMigrationType(contentType drivers.ContentType) migration.MigrationF
 	return migration.MigrationFSType_RSYNC
 }
 
-// RenderSnapshotUsage can be used as an optional argument to Instance.Render() to return snapshot usage.
-// As this is a relatively expensive operation it is provided as an optional feature rather than on by default.
-func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(response any) error {
-	return func(response any) error {
-		apiRes, ok := response.(*api.InstanceSnapshot)
-		if !ok {
-			return nil
-		}
-
-		pool, err := LoadByInstance(s, snapInst)
-		if err == nil {
-			// It is important that the snapshot not be mounted here as mounting a snapshot can trigger a very
-			// expensive filesystem UUID regeneration, so we rely on the driver implementation to get the info
-			// we are requesting as cheaply as possible.
-			volumeState, err := pool.GetInstanceUsage(snapInst)
-			if err == nil {
-				apiRes.Size = volumeState.Used
-			}
-		}
-
-		return nil
-	}
-}
-
 // InstanceMount mounts an instance's storage volume (if not already mounted).
 // Please call InstanceUnmount when finished.
 func InstanceMount(pool Pool, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -785,7 +785,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, sys
 }
 
 // InstanceContentType returns the instance's content type.
-func InstanceContentType(inst instance.Instance) drivers.ContentType {
+func InstanceContentType(inst instance.ConfigReader) drivers.ContentType {
 	contentType := drivers.ContentTypeFS
 	if inst.Type() == instancetype.VM {
 		contentType = drivers.ContentTypeBlock


### PR DESCRIPTION
This adds some logic to allow storage drivers to implement snapshot data pre-fetching.
In the case of ZFS, we're pulling all the usage data in one bulk query.

When running with a LOT of snapshots, this can cause rather extreme time savings:
```
root@u24:~# time incus snapshot list a01 >/dev/null
real	3m15.907s
user	0m0.791s
sys	0m0.489s

root@u24:~# time incus snapshot list a01 >/dev/null
real	0m3.911s
user	0m0.737s
sys	0m0.270s
```

The first run here is with the old logic, the second run is with the new logic in place.
In this particular case, I had 6000 snapshots on that one container.