### PR TITLE
incusd/operations: Fix WaitGet on op failure

### DIFF
--- a/cmd/incusd/operations.go
+++ b/cmd/incusd/operations.go
@@ -969,12 +969,9 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Wait for the operation.
-			err = op.Wait(ctx)
-			if err != nil {
-				_ = response.SmartError(err).Render(w)
-				return nil
-			}
+			_ = op.Wait(ctx)
 
+			// Render the current state.
 			_, body, err := op.Render()
 			if err != nil {
 				_ = response.SmartError(err).Render(w)


### PR DESCRIPTION
We were incorrectly returning a partial operation update when an operation would fail rather than match the get behavior.

Part of #1889