### PR TITLE
docs: mDNS setup for cluster HA

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -164,6 +164,7 @@ macOS
 macvlan
 Makefile
 manpages
+mDNS
 Mbit
 MiB
 Mibit

--- a/doc/howto/cluster_access.md
+++ b/doc/howto/cluster_access.md
@@ -89,3 +89,11 @@ Traffic will then get balanced between all servers and as soon as a server goes 
 ```{note}
 To minimize fallback delay, one can make use of BFD alongside BGP to get sub-1s fallback time.
 ```
+
+### mDNS in L2 Network
+If you are running in an L2 network (for instance, in a typical home network) you can use mDNS
+and publish the same `.local` domain (something like `incus.local`) from multiple hosts.
+
+More than one host may send a reply in response to the  multicast request, and the client
+will receive multiple mDNS response packets - this way, at the cost of packet flood,
+you get a simple way to ensure you reach *some* cluster node.


### PR DESCRIPTION
This PR proposes an mDNS based setup for cluster high availability docs.

Ref: https://datatracker.ietf.org/doc/html/rfc6762