### PR TITLE
client/incus: Fix non-constant format strings

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -246,7 +246,7 @@ func incusParseResponse(resp *http.Response) (*api.Response, string, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return &response, "", api.StatusErrorf(resp.StatusCode, response.Error)
+		return &response, "", api.StatusErrorf(resp.StatusCode, "%v", response.Error)
 	}
 
 	return &response, etag, nil
@@ -300,7 +300,7 @@ func (r *ProtocolIncus) rawQuery(method string, url string, data any, ETag strin
 			req.Header.Set("Content-Type", "application/json")
 
 			// Log the data
-			logger.Debugf(logger.Pretty(data))
+			logger.Debugf("%s", logger.Pretty(data))
 		}
 	} else {
 		// No data to be sent along with the request
@@ -386,7 +386,7 @@ func (r *ProtocolIncus) queryStruct(method string, path string, data any, ETag s
 
 	// Log the data
 	logger.Debugf("Got response struct from Incus")
-	logger.Debugf(logger.Pretty(target))
+	logger.Debugf("%s", logger.Pretty(target))
 
 	return etag, nil
 }
@@ -436,7 +436,7 @@ func (r *ProtocolIncus) queryOperation(method string, path string, data any, ETa
 
 	// Log the data
 	logger.Debugf("Got operation from Incus")
-	logger.Debugf(logger.Pretty(op.Operation))
+	logger.Debugf("%s", logger.Pretty(op.Operation))
 
 	return &op, etag, nil
 }


### PR DESCRIPTION
Fixes "non-constant format string" errors in fmt calls.