### PR TITLE
Support filtering storage volumes by a single keyword

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -18,20 +18,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  Gehäuse:"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 #, fuzzy
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  Mainboard:"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -56,7 +56,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -87,7 +87,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -113,7 +113,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -126,7 +126,7 @@ msgstr ""
 "### Beachten Sie, dass der Fingerabdruck angezeigt wird, aber nicht geändert "
 "werden kann."
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -135,7 +135,7 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -174,7 +174,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern."
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -190,7 +190,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgstr ""
 "###       template: template.tpl\n"
 "###       properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -307,7 +307,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -349,7 +349,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -362,7 +362,7 @@ msgstr ""
 "### Beachten Sie, dass der Name angezeigt wird, aber nicht geändert werden "
 "kann."
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -414,7 +414,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -444,7 +444,7 @@ msgstr ""
 "### Beachten Sie, dass die Felder name, target_project, target_network und "
 "status nicht geändert werden können."
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -470,7 +470,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -496,7 +496,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -534,7 +534,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -573,7 +573,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern."
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -612,7 +612,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -620,95 +620,95 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, fuzzy, c-format
 msgid "%q is not a block device"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, fuzzy, c-format
 msgid "%q is not an IP address"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q im Pool %q im Projekt %q (beinhaltet %d Snapshots)"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, quelle=%q)"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(kein Wert)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (Typ: %s): %s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty kann nicht mit einem image namen kombiniert werden"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 "--instance-only kann nicht verwendet werden, wenn die Quelle ein Snapshot ist"
@@ -718,26 +718,26 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 #, fuzzy
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Instanzen verwendet werden"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr "--target kann nur mit Clustern verwendet werden"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr "--target kann nicht mit Instanzen verwendet werden"
 
@@ -749,7 +749,7 @@ msgstr "<Alias>"
 msgid "<alias> <target>"
 msgstr "<Alias> <Ziel>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 #, fuzzy
 msgid "<remote>: <path>"
 msgstr ""
@@ -778,7 +778,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -787,34 +787,34 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr "<Ziel>"
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr "Ein Client Zertifikat ist bereits erstellt worden"
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr "Ein Name für den Client muss angegeben werden"
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 #, fuzzy
 msgid "A cluster member name must be provided"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
@@ -823,65 +823,65 @@ msgstr "ADRESSE"
 msgid "ADDRESSES"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr "APP"
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "Authentifizierungstyp"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Akzeptiere das Zertifikat"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 "Zugangsschlüssel (wird automatisch generiert, wenn nichts angegeben wird)"
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr "Zugangsschlüssel: %s"
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr "Zugriff auf erweiterte Konfiguration"
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 #, fuzzy
 msgid "Acknowledge warning"
 msgstr "Warnung gesehen"
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Aktion %q wird von diesem Programm nicht unterstützt"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "Aktion (Standard ist: GET)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Cluster Mitglied zu einer Cluster Gruppe hinzufügen:"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Füge einen Netzwerk Zonen Eintrag hinzu"
@@ -891,23 +891,23 @@ msgstr "Füge einen Netzwerk Zonen Eintrag hinzu"
 msgid "Add addresses to a network address set"
 msgstr "Einträge zu einem Netzwerkzonen-Datensatz hinzufügen"
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr "Backend zu einem Load Balancer hinzufügen"
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr "Backends zu einem load balancer hinzufügen"
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr "Einträge zu einem Netzwerkzonen-Datensatz hinzufügen"
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr "Füge Devices zu einer Instanz hinzu"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr "Mitglied zu einer Gruppe hinzufügen"
 
@@ -915,11 +915,11 @@ msgstr "Mitglied zu einer Gruppe hinzufügen"
 msgid "Add new aliases"
 msgstr "Erstelle neue Aliasse"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -940,16 +940,16 @@ msgstr ""
 "  incus remote add name-ihrer-wahl https://LOGIN:PASSWORT@example.com/"
 "angegebener/pfad --protocol=simplestreams\n"
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr "Vertrauenswürdigen Client hinzufügen"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -963,7 +963,7 @@ msgstr ""
 "- client (stndard)\n"
 "- metrics\n"
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -975,28 +975,28 @@ msgstr ""
 "Dies stellt einen Trust-Token aus, der vom Client verwendet wird, um sich "
 "selbst zum Trust Store hinzuzufügen.\"\n"
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr "Ports zu einem Network Forward hinzufügen"
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr "Ports zu einem Load Balancer hinzufügen"
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr "Profile zu Instanzen hinzufügen"
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr "Rollen einem Cluster Mitglied hinzufügen"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr "Regeln zu einer Zugangskontrollliste (ACL) hinzufügen"
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 #, fuzzy
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
@@ -1004,30 +1004,30 @@ msgstr ""
 "Zusätzliche Storage Pool Konfigurationsparameter hinzufügen (SCHLÜSSEL=WERT, "
 "leerlassen falls fertig):"
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr "IP-Adresse unter der der Server erreichbar sein soll (Standard: keine)"
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr "IP-Adresse unter der der Server erreichbar sein soll (ohne Port)"
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Adresse: %s"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr "Adresse: %v"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Administrator Zugangsschlüssel: %s"
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Administrator Geheimer Schlüssel: %s"
@@ -1042,116 +1042,116 @@ msgstr "Alias %s existiert bereits"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s existiert nicht"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "Aliasbezeichnung fehlt"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr "Alias: %s"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Aliase:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 "Alle existierenden Dateien sind verloren, wenn sie dem Cluster beitreten, "
 "Vorgang fortsetzen?"
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr "Alle Projekte"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr "Alle Server Adressen sind nicht erreichbar"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Alternativer Zertifikatsbezeichnung"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "Architektur: %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr "Soll der Server einem bestehenden Cluster beitreten?"
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, fuzzy, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "Sind Sie sicher, dass sie das Cluster Mitglied %q %s? (ja/nein) "
 "[default=nein]: "
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 "Da keines der genannten Programme gefunden werden konnte, finden Sie hier "
 "den SPICE Socket zum manuellen verbinden:"
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 #, fuzzy
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 "Es soll eine Virtuelle Maschine (VM) genutzt werden, aber das angefragte "
 "Image ist vom Typ: Container"
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr "Einem Clustermitglied eine oder mehrere Gruppen zuweisen"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr "Ein oder mehrere Profile einer Instanz zuweisen"
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Netzwerkschnittstellen (network interfaces) zu Instanzen hinzufügen"
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr "Netzwerkschnittstellen (network interfaces) zu Profilen hinzufügen"
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 #, fuzzy
 msgid "Attach new custom storage volumes to instances"
 msgstr "Storage Volumes zu Instanzen hinzufügen"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 #, fuzzy
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Storage Volumes zu Profilen hinzufügen"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen (network interfaces) zu Instanzen hinzufügen"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr "Konsole der Instanz öffnen"
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 #, fuzzy
 msgid ""
 "Attach to instance consoles\n"
@@ -1165,156 +1165,156 @@ msgstr ""
 "interagieren,\n"
 "sowie bereits vorhandene Protokolleinträge (logs) einzusehen."
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Authentifizierungstyp '%s' wird nicht vom Server unterstützt"
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "Automatische Aushandlung: %v"
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 #, fuzzy
 msgid "Auto update is only available in pull mode"
 msgstr "Die Option \"automatisches Update\" ist nur mit \"pull\" verfügbar"
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr "Automatischer Modus (nicht-interaktiv)"
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr "Verfügbare Projekte:"
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "Durchschnitt: %.2f %.2f %.2f"
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr "BASIS ABBILD"
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr "Backend Status:"
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr "Backup erfolgreich exportiert!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr "Sicherungen:"
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 "Ungültige Gerätüberschreibungs-Syntax, erwartet wird <Gerät>,"
 "<Schlüssel>=<Wert>: %s"
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ungültiges key/value Paar: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ungültiges key=value Paar: %s"
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Eigenschaft: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr "Link-Bündelung:"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr "Sowohl --all als auch ein Instanzname angegeben"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr "Netzwerk-Brücke:"
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 #, fuzzy
 msgid "Bucket description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Bus Adresse: %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "ABBRECHBAR"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "ALLGEMEINER NAME"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr "INHALTS-TYP"
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr "ANZAHL"
 
@@ -1323,73 +1323,73 @@ msgstr "ANZAHL"
 msgid "CPU TIME(s)"
 msgstr "Prozessorauslastung (%s):"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr "CPU NUTZUNG"
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "CPU Nutzung (in Sekunden)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr "CPUs:"
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 #, fuzzy
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA Version: %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "Zwischengespeichert: %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr "Zwischenspeicher:"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr "Kann Adresse nicht zuweisen %q: %w"
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr "Verzeichnis kann ohne --recursive nicht abgerufen werde"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr "Kann nicht aus der Umgebungsdatei lesen: %w"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Kann nicht von stdin lesen: %w"
@@ -1398,58 +1398,58 @@ msgstr "Kann nicht von stdin lesen: %w"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr "\"Kann --fast nicht zusammen mit --columns angeben.\""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr "Kann --project nicht zusammen mit --all-projects angeben"
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 "Kann die Spalte L nicht angeben, wenn keine Clusterbildung vorhanden ist"
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Kann uid/gid/mode im rekursiven Modus nicht bereitstellen"
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Kann Schlüssel '%s' nicht zurücksetzen, da er derzeit nicht gesetzt ist"
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 "Die Optionen --auto und --preseed können nicht zusammen verwendet werden"
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 "Die Option --dump kann nicht zusammen mit anderen Optionen genutzt werden"
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr "Die Option --minimal und --auto können nicht zusammen genutzt werden"
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 "Die Option --minimal und --preseed können nicht zusammen genutzt werden"
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr "Kann kein Image mit --empty verwenden"
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1457,33 +1457,33 @@ msgstr ""
 "\"Kann Konfiguration für Gerät %q nicht überschreiben: Gerät in den "
 "Profilgeräten nicht gefunden.\""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "Kann --destination-target nicht setzen, wenn der Zielserver nicht im Cluster "
 "ist"
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "\"Kann --target nicht setzen, wenn der Quellserver nicht im Cluster ist"
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Kann --volume-only nicht setzen, wenn ein Snapshot kopiert wird"
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "Kann Schlüssel nicht setzen: %s"
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr "Karte: %d:"
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr ""
@@ -1492,175 +1492,175 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "\"Zertifikat-Token für %s gelöscht\""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 #, fuzzy
 msgid "Certificate description"
 msgstr "Fingerprint des Zertifikats: %s"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerprint des Zertifikats: %s"
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr "Client-Zertifikat wird nun vom Server als vertrauenswürdig behandelt:"
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr "Client Version: %s\n"
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr "Cluster-Gruppe %s erstellt"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "Cluster-Gruppe %s gelöscht\""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "Cluster-Gruppe %s erstellt"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "\"Join-Token für Cluster %s:%s gelöscht\""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "%s als Mitglied zu den Cluster-Gruppen %s hinzugefügt"
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr "Cluster-Mitgliedsname"
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr "Clustering aktiviert"
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Spalten"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr "Kommandozeilen-Client für Incus"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1679,58 +1679,58 @@ msgstr ""
 "Eigene Befehle können über Aliase definiert werden. Verwenden Sie \"incus "
 "alias\", um diese zu verwalten."
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 #, fuzzy
 msgid "Config key/value to apply to the new network integration"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1739,43 +1739,43 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1783,12 +1783,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 #, fuzzy
 msgid "Copy instances within or in between servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1804,149 +1804,149 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 #, fuzzy
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, fuzzy, c-format
 msgid "Create a new %s pool?"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 #, fuzzy
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, fuzzy, c-format
 msgid "Create instance backup: %w"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 #, fuzzy
 msgid "Create instance snapshot"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1954,37 +1954,37 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 #, fuzzy
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1993,96 +1993,96 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -2090,29 +2090,29 @@ msgstr "BESCHREIBUNG"
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Erstellt: %s"
@@ -2126,11 +2126,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr "Befehle in einer Instanz ausführen"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2138,57 +2138,57 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 #, fuzzy
 msgid "Delete instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 #, fuzzy
 msgid "Delete instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2197,258 +2197,258 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Storage Volumes zu Profilen hinzufügen"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2457,55 +2457,55 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, fuzzy, c-format
 msgid "Device %s added to %s"
 msgstr "Gerät %s wurde zu %s hinzugefügt\n"
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2514,70 +2514,70 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr "Festplatte %d:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "Festplattennutzung:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr "Festplatte:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr "Festplatten:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2586,7 +2586,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2613,35 +2613,35 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr ""
@@ -2650,83 +2650,83 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 #, fuzzy
 msgid "Edit instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2736,67 +2736,67 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network address set configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 #, fuzzy
 msgid ""
 "Edit storage volume configurations as YAML\n"
@@ -2806,33 +2806,33 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2858,50 +2858,50 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 #, fuzzy
 msgid "Entry TTL"
 msgstr "Eingangs TTL"
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 "Festzulegende Umgebungsvariable (Environment variable) (z.B. HOME=/home/foo)"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Kurzlebiger Container"
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "Fehler beim Verbinden mit bestehendem Clustermitglied %q: %v"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr "Fehler beim Erstellen des Decoders: %v"
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr "Fehler beim Dekodieren der Datei(en): %v"
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim Festlegen der Parameter: %v"
@@ -2911,57 +2911,57 @@ msgstr "Fehler beim Festlegen der Parameter: %v"
 msgid "Error setting term size %s"
 msgstr "Fehler beim setzen der Größe des Terminals/der Konsole %s"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim Löschen der Parameter: %v"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Fehler beim Löschen des Parameters: %v"
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Fehler beim Aktualisieren der Template Datei: %s"
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, fuzzy, c-format
 msgid "Error: %v\n"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Evakuieren eines Clustermitglieds"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Evakuieren der Clustermitglieder: %s"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr "Ereignistyp der beobachtet werden soll"
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr "Eine SQL Abfrage bei der lokalen oder globalen Datenbank durchführen"
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 #, fuzzy
 msgid ""
 "Execute a SQL query against the local or global database\n"
@@ -3024,11 +3024,11 @@ msgstr ""
 "nicht anders angegeben) \n"
 " und funktioniert sowohl lokal als auch im Cluster Modus."
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr "Befehle in einer Instanz ausführen"
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 #, fuzzy
 msgid ""
 "Execute commands in instances\n"
@@ -3059,23 +3059,23 @@ msgstr ""
 "Modus wird nur aktiviert, wenn sowohl \"stdin\" als auch \"stdout\" "
 "Terminals sind (stderr wird ignoriert)."
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 #, fuzzy
 msgid "Expires at"
 msgstr "Wird gelöscht am"
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, fuzzy, c-format
 msgid "Expires: %s"
 msgstr "Wird gelöscht:"
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 #, fuzzy
 msgid "Expires: never"
 msgstr "Wird gelöscht: nie"
@@ -3085,11 +3085,11 @@ msgstr "Wird gelöscht: nie"
 msgid "Export a virtual machine's memory state"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr "Images exportieren und herunterladen"
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
@@ -3101,24 +3101,24 @@ msgstr ""
 "angegeben wird, wird die resultierende Datei im derzeit aktiven Ordner/Pfad "
 "gespeichert."
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr "Storage Volume exportieren"
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr "Backups einer Instanz exportieren"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Instanzen als Backup Dateien (.tar) exportieren."
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr "Storage Buckets exportieren"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Storage Buckets als Dateien (.tar) exportieren."
@@ -3130,243 +3130,243 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr "Storage Volume ohne Snapshots exportieren"
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup des Storage Bucket %s wird exportiert"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Backup %s wird exportiert"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 #, fuzzy
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 #, fuzzy
 msgid "FIRST SEEN"
 msgstr "ZUERST BEOBACHTET"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, fuzzy, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "SSH handshake mit Client %q gescheitert: %v"
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Check ob Instanz existiert fehlgeschlagen \"%s:%s\": %w"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, fuzzy, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, fuzzy, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, fuzzy, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, fuzzy, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, fuzzy, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, fuzzy, c-format
 msgid "Failed import request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, fuzzy, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, fuzzy, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, fuzzy, c-format
 msgid "Failed to close export file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, fuzzy, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, fuzzy, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, fuzzy, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, fuzzy, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3376,104 +3376,104 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to dump instance memory: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, fuzzy, c-format
 msgid "Failed to join cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, fuzzy, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, fuzzy, c-format
 msgid "Failed to parse servers: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, fuzzy, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, fuzzy, c-format
 msgid "Failed to rename export file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, fuzzy, c-format
 msgid "Failed to render the config: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, fuzzy, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, fuzzy, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, fuzzy, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, fuzzy, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, fuzzy, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3489,100 +3489,100 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, fuzzy, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, fuzzy, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, fuzzy, c-format
 msgid "Failed validation request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3606,7 +3606,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3616,36 +3616,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3658,7 +3658,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3667,227 +3667,227 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 #, fuzzy
 msgid ""
 "Get values for storage volume configuration keys\n"
@@ -3900,68 +3900,68 @@ msgid ""
 "container or virtual-machine)."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "Name"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3969,321 +3969,321 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 #, fuzzy
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 #, fuzzy
 msgid "Invalid database type"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "Ungültige Quelle %s"
@@ -4293,7 +4293,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
@@ -4307,60 +4307,60 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -4375,22 +4375,22 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid sorting type provided"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
@@ -4399,85 +4399,85 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 #, fuzzy
 msgid "Key description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architektur: %s\n"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4511,12 +4511,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4538,12 +4538,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4565,12 +4565,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4592,11 +4592,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4618,16 +4618,16 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliasse:\n"
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4636,11 +4636,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4664,12 +4664,12 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4692,11 +4692,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4720,16 +4720,16 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4752,11 +4752,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4777,11 +4777,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4806,11 +4806,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4836,11 +4836,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4864,11 +4864,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4896,22 +4896,22 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 #, fuzzy
 msgid "List instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 #, fuzzy
 msgid "List instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4934,12 +4934,12 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 #, fuzzy
 msgid "List instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -5012,8 +5012,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -5023,16 +5023,16 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -5055,12 +5055,12 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -5083,25 +5083,25 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -5117,11 +5117,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -5142,12 +5142,12 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -5169,12 +5169,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5197,12 +5197,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5216,15 +5216,27 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5240,11 +5252,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5270,11 +5282,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5298,12 +5310,12 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliasse:\n"
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5326,81 +5338,81 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 #, fuzzy
 msgid "Lower device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 #, fuzzy
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
@@ -5409,11 +5421,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5421,59 +5433,59 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 #, fuzzy
 msgid "Make the image public"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5483,27 +5495,27 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage command aliases"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 #, fuzzy
 msgid "Manage image aliases"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 #, fuzzy
 msgid "Manage images"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5523,38 +5535,38 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 #, fuzzy
 msgid "Manage instance and server configuration options"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 #, fuzzy
 msgid "Manage instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -5563,278 +5575,278 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Veröffentliche Abbild"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, fuzzy, c-format
 msgid "Member %q already has role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, fuzzy, c-format
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 #, fuzzy
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5847,179 +5859,179 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing network address set name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 #, fuzzy
 msgid "Monitor a local or remote server"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -6035,224 +6047,224 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 #, fuzzy
 msgid "Name of the OSD storage pool"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 #, fuzzy
 msgid "Name of the new storage pool"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 #, fuzzy
 msgid "Name of the shared LVM volume group:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 #, fuzzy
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -6277,176 +6289,176 @@ msgstr "Profil %s erstellt\n"
 msgid "Network address set description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, fuzzy, c-format
 msgid "Network integration %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, fuzzy, c-format
 msgid "Network integration %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, fuzzy, c-format
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6457,20 +6469,20 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 #, fuzzy
 msgid "OS Version"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6478,31 +6490,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6516,179 +6528,179 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Operating System:"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "PCI device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 #, fuzzy
 msgid "PCI devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, fuzzy, c-format
 msgid "Path %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 #, fuzzy
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 #, fuzzy
 msgid "Peer description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 #, fuzzy
 msgid "Please provide join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 #, fuzzy
 msgid "Port description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6704,272 +6716,272 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 #, fuzzy
 msgid "Profile description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 #, fuzzy
 msgid "Project description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 #, fuzzy
 msgid "Record description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6982,25 +6994,25 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -7010,13 +7022,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
@@ -7031,41 +7043,41 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -7080,50 +7092,50 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7132,54 +7144,54 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, fuzzy, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -7188,21 +7200,21 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -7211,236 +7223,236 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 #, fuzzy
 msgid "Restart instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 #, fuzzy
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 #, fuzzy
 msgid "Rule description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "ERSTELLT AM"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr ""
@@ -7449,40 +7461,40 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr ""
@@ -7491,26 +7503,26 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7519,7 +7531,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7528,16 +7540,16 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7546,12 +7558,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7565,11 +7577,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7578,12 +7590,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7592,12 +7604,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7607,12 +7619,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7621,12 +7633,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7635,12 +7647,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7649,16 +7661,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7667,12 +7679,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7681,12 +7693,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7695,12 +7707,12 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7709,12 +7721,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -7733,43 +7745,43 @@ msgstr "Profil %s erstellt\n"
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7778,152 +7790,152 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
@@ -7933,74 +7945,74 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network address set configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 #, fuzzy
 msgid ""
 "Show storage volume configurations\n"
@@ -8013,22 +8025,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 #, fuzzy
 msgid ""
 "Show storage volume state information\n"
@@ -8038,99 +8050,99 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -8139,13 +8151,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -8154,78 +8166,78 @@ msgstr ""
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 #, fuzzy
 msgid "Stop instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Profil %s erstellt\n"
@@ -8234,101 +8246,101 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, fuzzy, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, fuzzy, c-format
 msgid "Storage pool %q of type %q"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 #, fuzzy
 msgid "Storage pool to use or create"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -8336,15 +8348,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8352,37 +8364,37 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -8393,20 +8405,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, fuzzy, c-format
 msgid "The %s storage pool already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8420,7 +8432,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8429,63 +8441,63 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 #, fuzzy
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8494,108 +8506,108 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8610,18 +8622,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8631,30 +8643,30 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8668,278 +8680,278 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "USB device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 #, fuzzy
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, fuzzy, c-format
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, fuzzy, c-format
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -8949,79 +8961,79 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network address set configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 #, fuzzy
 msgid ""
 "Unset storage volume configuration keys\n"
@@ -9031,16 +9043,16 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -9049,89 +9061,89 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9140,89 +9152,89 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 #, fuzzy
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
@@ -9231,35 +9243,35 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 #, fuzzy
 msgid "Volume description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -9269,11 +9281,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -9290,37 +9302,37 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 #, fuzzy
 msgid "Where should this storage pool store its data?"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 #, fuzzy
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
@@ -9329,122 +9341,122 @@ msgstr ""
 "Laufenden Zustand des Containers aus dem Sicherungspunkt (falls vorhanden) "
 "wiederherstellen oder nicht"
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 #, fuzzy
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 #, fuzzy
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid "Zone description"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9452,7 +9464,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -9460,14 +9472,14 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9476,7 +9488,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
@@ -9484,7 +9496,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -9492,7 +9504,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr ""
@@ -9501,7 +9513,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -9510,7 +9522,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -9518,7 +9530,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -9527,8 +9539,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -9536,7 +9548,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -9544,7 +9556,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -9552,7 +9564,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -9560,7 +9572,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9568,7 +9580,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -9576,7 +9588,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr ""
@@ -9585,8 +9597,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -9594,7 +9606,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -9602,7 +9614,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9610,7 +9622,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9668,7 +9680,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9677,7 +9689,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -9686,7 +9698,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9694,8 +9706,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -9704,8 +9716,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -9713,7 +9725,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr ""
@@ -9721,7 +9733,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
@@ -9729,7 +9741,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -9737,7 +9749,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -9746,7 +9758,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -9755,7 +9767,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -9763,7 +9775,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -9771,7 +9783,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
@@ -9779,7 +9791,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9787,7 +9799,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -9795,7 +9807,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9803,10 +9815,10 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -9815,7 +9827,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -9823,7 +9835,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -9831,7 +9843,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -9839,7 +9851,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -9847,7 +9859,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
@@ -9855,7 +9867,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -9863,7 +9875,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
@@ -9872,7 +9884,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9881,7 +9893,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -9890,7 +9902,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
@@ -9899,7 +9911,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
@@ -9908,8 +9920,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
@@ -9918,7 +9930,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
@@ -9926,7 +9938,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
@@ -9935,8 +9947,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -9944,7 +9956,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
@@ -9962,7 +9974,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -9970,7 +9982,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9979,7 +9991,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -9988,7 +10000,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9996,7 +10008,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -10006,7 +10018,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10015,7 +10027,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -10024,9 +10036,9 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -10035,8 +10047,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -10045,7 +10057,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -10054,7 +10066,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -10062,7 +10074,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -10070,7 +10082,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -10079,7 +10091,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr ""
@@ -10088,8 +10100,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr ""
@@ -10097,7 +10109,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
@@ -10105,7 +10117,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
@@ -10113,7 +10125,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
@@ -10121,7 +10133,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
@@ -10129,10 +10141,10 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -10140,7 +10152,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -10148,7 +10160,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -10156,7 +10168,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -10164,7 +10176,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -10172,11 +10184,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -10184,7 +10196,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -10192,7 +10204,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -10202,9 +10214,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -10212,7 +10224,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -10220,7 +10232,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -10230,13 +10242,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -10244,7 +10256,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -10252,7 +10264,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -10260,7 +10272,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -10268,7 +10280,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -10276,7 +10288,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -10286,7 +10298,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -10294,7 +10306,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -10302,7 +10314,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -10310,7 +10322,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -10318,7 +10330,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -10326,7 +10338,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -10334,8 +10346,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10343,7 +10355,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -10351,7 +10363,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10359,8 +10371,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -10368,9 +10380,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -10378,7 +10390,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -10386,7 +10398,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -10395,7 +10407,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -10403,7 +10415,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -10411,7 +10423,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -10419,7 +10431,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -10427,7 +10439,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10435,7 +10447,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10443,7 +10455,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10451,7 +10463,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -10459,7 +10471,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10468,7 +10480,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10477,7 +10489,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10486,7 +10498,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10495,7 +10507,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10503,7 +10515,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10512,7 +10524,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10520,8 +10532,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10529,7 +10541,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10537,7 +10549,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10545,7 +10557,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10554,7 +10566,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10562,7 +10574,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10570,9 +10582,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10580,7 +10592,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -10588,7 +10600,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -10596,7 +10608,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -10604,7 +10616,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10612,7 +10624,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10620,7 +10632,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -10628,7 +10640,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10636,7 +10648,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -10644,8 +10656,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10653,7 +10665,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10661,7 +10673,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10669,7 +10681,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10677,7 +10689,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -10686,7 +10698,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -10695,7 +10707,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -10703,8 +10715,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -10712,7 +10724,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -10720,7 +10732,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -10728,7 +10740,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -10736,7 +10748,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -10744,7 +10756,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -10753,7 +10765,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -10762,7 +10774,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -10770,7 +10782,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -10778,7 +10790,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -10786,7 +10798,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -10795,36 +10807,36 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 #, fuzzy
 msgid "application"
 msgstr "Eigenschaften:\n"
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
@@ -10847,13 +10859,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -10869,7 +10881,7 @@ msgstr ""
 "    Setzt die Gruppen des Clustermitglied zurück und weist nur die Gruppe "
 "\"default\" zu."
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10877,7 +10889,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10888,13 +10900,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -10903,7 +10915,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -10911,15 +10923,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10929,7 +10941,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -10938,13 +10950,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10952,26 +10964,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -10980,13 +10992,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10995,7 +11007,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -11006,19 +11018,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -11029,7 +11041,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -11041,7 +11053,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 #, fuzzy
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
@@ -11059,7 +11071,7 @@ msgstr ""
 "\n"
 "lxc move <Quelle> <Ziel>\n"
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -11081,7 +11093,7 @@ msgstr ""
 "\tErstellt ein storage volume mit dem Namen \"v1\" im pool \"p1\" mit den "
 "Konfigurationsdetails aus der Datei \"config.yaml\"."
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -11093,7 +11105,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -11101,24 +11113,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -11127,7 +11139,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -11143,7 +11155,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -11151,7 +11163,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -11159,7 +11171,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 #, fuzzy
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
@@ -11168,7 +11180,7 @@ msgstr ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Zeigt Details der genannten operation UUID"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -11189,7 +11201,7 @@ msgstr ""
 "incus profile assign foo ''\n"
 "    Die Profile der Instanz \"foo\" zurücksetzen und kein Profil zuweisen."
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 #, fuzzy
 msgid ""
 "incus profile create p1\n"
@@ -11204,7 +11216,7 @@ msgstr ""
 "    Erstellt ein Profil namens \"p1\" unter Nutzung der Konfigurationsdatei "
 "\"config.yaml\""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -11224,7 +11236,7 @@ msgstr ""
 "   Mounted das Storage Volume \"some-volume\" im Storage pool \"some-pool\" "
 "in den Dateipfad \"/opt\" innerhalb der Instanz."
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -11233,7 +11245,7 @@ msgstr ""
 "   Automatisches Editieren eines Profils mithilfe der Konfigurationsdatei "
 "\"profile.yaml\""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 #, fuzzy
 msgid ""
 "incus project create p1\n"
@@ -11246,10 +11258,10 @@ msgstr ""
 "   Erstellt ein Projekt namens \"p1\"\n"
 "\n"
 "incus project create p1 < config.yaml\n"
-"    Erstellt ein Projekt namens \"p1\" mit der Konfigurationsdatei "
-"\"config.yaml\""
+"    Erstellt ein Projekt namens \"p1\" mit der Konfigurationsdatei \"config."
+"yaml\""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -11258,7 +11270,7 @@ msgstr ""
 "    Automatisches Editieren der Konfiguration eines Projekts mit der "
 "Konfigurationsdatei \"project.yaml\""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
@@ -11266,7 +11278,7 @@ msgstr ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Löscht die lokale Instanz \"c1\"."
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -11282,7 +11294,7 @@ msgstr ""
 "\tErstellt einen snapshot \"snap0\" von der Instanz \"u1\" mit der "
 "Konfigurationsdatei \"config.yaml\"."
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 #, fuzzy
 msgid ""
 "incus snapshot restore u1 snap0\n"
@@ -11294,7 +11306,7 @@ msgstr ""
 "incus snapshot restore u1 snap0\n"
 "Stellt den Zustand vom snapshot \"snap0\" für die Instanz \"u1\" wieder her."
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 #, fuzzy
 msgid ""
 "incus storage bucket create p1 b01\n"
@@ -11312,7 +11324,7 @@ msgstr ""
 "\tErstellt einen neuen storage bucket genannt \"b01\" im storage pool \"p1\" "
 "unter Nutzung der Konfigurationsdatei \"config.yaml\""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
@@ -11321,7 +11333,7 @@ msgstr ""
 "    Automatisches Editieren eines storage bucket mithilfe der "
 "Konfigurationsdetails aus der Datei \"bucket.yaml\"."
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
@@ -11330,7 +11342,7 @@ msgstr ""
 "    Automatisches Editieren eines storage bucket Schlüssels mithilfe der "
 "Konfigurationsdetails aus der Datei \"key.yaml\"."
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 #, fuzzy
 msgid ""
 "incus storage bucket export default b1\n"
@@ -11340,7 +11352,7 @@ msgstr ""
 "    Erstellen einer Sicherungsdatei (backup) vom storage bucket namens "
 "\"b1\" im pool \"default\"."
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
@@ -11348,7 +11360,7 @@ msgstr ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tErstellt einen neuen storage bucket aus der Datei \"backup0.tar.gz\"."
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -11363,10 +11375,10 @@ msgstr ""
 "\n"
 "incus storage bucket key create p1 b01 k1 < config.yaml\n"
 "\tErzeugt einen Schlüssel genannt \"k1\" für einen storage bucket \"b01\" im "
-"pool \"p1\" unter Nutzung der Konfigurationsdetails aus der Datei "
-"\"config.yaml\"."
+"pool \"p1\" unter Nutzung der Konfigurationsdetails aus der Datei \"config."
+"yaml\"."
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
@@ -11376,7 +11388,7 @@ msgstr ""
 "        Zeigt die Eigenschaften eines storage bucket Schlüssels genannt "
 "\"foo\" für einen storage bucket namens \"data\" im pool \"default\"."
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -11386,7 +11398,7 @@ msgstr ""
 "    Zeigt die Eigenschaften eines storage bucket namens \"data\" im pool "
 "\"default\"."
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 #, fuzzy
 msgid ""
 "incus storage create s1 dir\n"
@@ -11401,7 +11413,7 @@ msgstr ""
 "\tErstellt ein storage volume mit dem Namen \"v1\" im pool \"p1\" mit den "
 "Konfigurationsdetails aus der Datei \"config.yaml\"."
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -11410,7 +11422,7 @@ msgstr ""
 "    Automatisches Editieren der Konfiguration des storage pool mit den "
 "Konfigurationsdetails aus der Datei \"pool.yaml\"."
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 #, fuzzy
 msgid ""
 "incus storage volume create default foo\n"
@@ -11426,10 +11438,10 @@ msgstr ""
 "\n"
 "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
-"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei "
-"\"config.yaml\"."
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 #, fuzzy
 msgid ""
 "incus storage volume edit default container/c1\n"
@@ -11445,10 +11457,10 @@ msgstr ""
 "\n"
 "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
-"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei "
-"\"config.yaml\"."
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11458,7 +11470,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11468,7 +11480,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11478,7 +11490,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11488,7 +11500,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11502,7 +11514,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 #, fuzzy
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
@@ -11518,10 +11530,10 @@ msgstr ""
 "\n"
 "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
-"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei "
-"\"config.yaml\"."
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -11531,70 +11543,70 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr "Info"
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr "Name"
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr "nein"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 #, fuzzy
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (j/n/[fingerprint])?"
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr "bitte nutzen Sie ìncus profile`"
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr "Speicherplatz in Benutzung"
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr "sshfs wurde gestoppt"
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs mounted %q auf %q"
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs wurde nicht gefunden. Versuchen Sie stattdessen SSH SFTP Modus mit dem "
 "\"--listen\" Argument"
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr "Gesamter Speicherplatz"
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr "nicht erreichbar"
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr "wird benutzt von"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr "j"
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "ja"
 
@@ -11642,8 +11654,8 @@ msgstr "ja"
 
 #, fuzzy
 #~ msgid ""
-#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < "
-#~ "volume.yaml\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
 #~ "    Update a storage volume using the content of pool.yaml."
 #~ msgstr ""
 #~ "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -11655,8 +11667,8 @@ msgstr "ja"
 #~ "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 #~ msgstr ""
 #~ "incus storage volume import default backup0.tar.gz\n"
-#~ "\t\tErstellt ein neues benutzerdefiniertes Volume aus der Datei "
-#~ "\"backup0.tar.gz\"."
+#~ "\t\tErstellt ein neues benutzerdefiniertes Volume aus der Datei \"backup0."
+#~ "tar.gz\"."
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage or --target-project"
@@ -12588,8 +12600,8 @@ msgstr "ja"
 #~ "lxc image edit [remote:]<image>\n"
 #~ "    Edit image, either by launching external editor or reading STDIN.\n"
 #~ "    Example: lxc image edit <image> # launch editor\n"
-#~ "             cat image.yaml | lxc image edit <image> # read from "
-#~ "image.yml\n"
+#~ "             cat image.yaml | lxc image edit <image> # read from image."
+#~ "yml\n"
 #~ "\n"
 #~ "Lists the images at specified remote, or local images.\n"
 #~ "Filters are not yet supported.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -59,7 +59,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -91,7 +91,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -120,7 +120,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -132,7 +132,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -140,7 +140,7 @@ msgstr ""
 "### Esta es una representación YAML del grupo de clústeres.\n"
 "### Cualquier línea que empiece con un '#' será ignorada."
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -179,7 +179,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -196,7 +196,7 @@ msgstr ""
 "### Un ejemplo sería:\n"
 "###  description: My custom image"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
@@ -241,7 +241,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -314,7 +314,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -353,7 +353,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network integration.\n"
@@ -366,7 +366,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -415,7 +415,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -447,7 +447,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -476,7 +476,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -505,7 +505,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -540,7 +540,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -576,7 +576,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -612,99 +612,99 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, fuzzy, c-format
 msgid "%q is not a block device"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, fuzzy, c-format
 msgid "%q is not an IP address"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partición %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Puerto %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -714,26 +714,26 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--network-port can't be used without --network-address"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 #, fuzzy
 msgid "--target can only be used with clusters"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr "Aliases:"
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -766,45 +766,45 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 #, fuzzy
 msgid "<remote>: <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Certificado del cliente almacenado en el servidor: "
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 #, fuzzy
 msgid "A cluster member name must be provided"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -812,62 +812,62 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "Accion (predeterminados a GET)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
@@ -876,23 +876,23 @@ msgstr "Perfil %s creado"
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -901,11 +901,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -917,16 +917,16 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -935,7 +935,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -943,57 +943,57 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, fuzzy, c-format
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
@@ -1008,106 +1008,106 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Aliases:"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 #, fuzzy
 msgid "Attach new custom storage volumes to instances"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 #, fuzzy
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1115,155 +1115,155 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 #, fuzzy
 msgid "Backend description"
 msgstr "Descripción"
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 #, fuzzy
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, fuzzy, c-format
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 #, fuzzy
 msgid "Bucket description"
 msgstr "Descripción"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -1272,75 +1272,75 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr "CPU (%s):"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "CREADO"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 #, fuzzy
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
 "local"
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, fuzzy, c-format
 msgid "Can't read from environment file: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
@@ -1349,258 +1349,258 @@ msgstr "No se peude leer desde stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr "No se puede especificar --fast con --columns"
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 #, fuzzy
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 #, fuzzy
 msgid "Certificate description"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Columnas"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 #, fuzzy
 msgid "Command line client for Incus"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1611,57 +1611,57 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 #, fuzzy
 msgid "Config key/value to apply to the new network integration"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1669,43 +1669,43 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1713,11 +1713,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1733,147 +1733,147 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 #, fuzzy
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, fuzzy, c-format
 msgid "Create a new %s pool?"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, fuzzy, c-format
 msgid "Create instance backup: %w"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 #, fuzzy
 msgid "Create instance snapshot"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1881,33 +1881,33 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1916,89 +1916,89 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -2006,29 +2006,29 @@ msgstr "DESCRIPCIÓN"
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Auto actualización: %s"
@@ -2043,11 +2043,11 @@ msgstr "Comandos:"
 msgid "Debug commands for instances"
 msgstr "Aliases:"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2055,54 +2055,54 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr "Eliminar imágenes"
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 #, fuzzy
 msgid "Delete instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 #, fuzzy
 msgid "Delete instances"
 msgstr "Eliminar imágenes"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2111,376 +2111,376 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descripción"
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "El dispostivo ya existe: %s"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr "Discos:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2489,7 +2489,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2516,111 +2516,111 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2629,66 +2629,66 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2697,32 +2697,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2746,47 +2746,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, fuzzy, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2796,57 +2796,57 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 msgid "Error setting term size %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, fuzzy, c-format
 msgid "Error: %v\n"
 msgstr "Error: %v\n"
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2875,11 +2875,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2894,23 +2894,23 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
@@ -2919,37 +2919,37 @@ msgstr "Expira: nunca"
 msgid "Export a virtual machine's memory state"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 #, fuzzy
 msgid "Export instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2961,241 +2961,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, fuzzy, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, fuzzy, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, fuzzy, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, fuzzy, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, fuzzy, c-format
 msgid "Failed import request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, fuzzy, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, fuzzy, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, fuzzy, c-format
 msgid "Failed to close export file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, fuzzy, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, fuzzy, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, fuzzy, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, fuzzy, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -3205,104 +3205,104 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to dump instance memory: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, fuzzy, c-format
 msgid "Failed to join cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, fuzzy, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, fuzzy, c-format
 msgid "Failed to parse servers: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, fuzzy, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, fuzzy, c-format
 msgid "Failed to rename export file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, fuzzy, c-format
 msgid "Failed to render the config: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, fuzzy, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, fuzzy, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, fuzzy, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, fuzzy, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, fuzzy, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3318,97 +3318,97 @@ msgstr "Acepta certificado"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, fuzzy, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, fuzzy, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, fuzzy, c-format
 msgid "Failed validation request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3432,7 +3432,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3442,36 +3442,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3484,7 +3484,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3493,220 +3493,220 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3718,68 +3718,68 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3787,318 +3787,318 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "Expira: %s"
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "Expira: %s"
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 #, fuzzy
 msgid "Incus - Command line client"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "Descripción"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "Nombre del contenedor es: %s"
@@ -4108,7 +4108,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid format %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -4122,59 +4122,59 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -4189,105 +4189,105 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid sorting type provided"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 #, fuzzy
 msgid "Key description"
 msgstr "Descripción"
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitectura: %s"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4321,12 +4321,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4348,12 +4348,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4375,12 +4375,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4402,11 +4402,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4428,16 +4428,16 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliases:"
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4446,11 +4446,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4474,12 +4474,12 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4502,11 +4502,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4530,16 +4530,16 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4562,11 +4562,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4587,11 +4587,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4616,11 +4616,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4646,11 +4646,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4674,11 +4674,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4706,20 +4706,20 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4742,12 +4742,12 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 #, fuzzy
 msgid "List instances"
 msgstr "Aliases:"
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4820,8 +4820,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4831,16 +4831,16 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4863,12 +4863,12 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4891,25 +4891,25 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4925,11 +4925,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4950,11 +4950,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4976,12 +4976,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5004,12 +5004,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5023,14 +5023,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5046,11 +5058,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5076,11 +5088,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5104,12 +5116,12 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliases:"
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5132,88 +5144,88 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr "Registro:"
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5221,57 +5233,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Nombre del Miembro del Cluster"
@@ -5280,23 +5292,23 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5316,34 +5328,34 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -5352,268 +5364,268 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
@@ -5626,175 +5638,175 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing network address set name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Aliases:"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5810,218 +5822,218 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
@@ -6046,171 +6058,171 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Network address set description"
 msgstr "Descripción"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr "Descripción"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, fuzzy, c-format
 msgid "Network integration %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, fuzzy, c-format
 msgid "Network integration %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6221,20 +6233,20 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 #, fuzzy
 msgid "OS Version"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6242,31 +6254,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6280,174 +6292,174 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Contraseña admin para %s:"
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, fuzzy, c-format
 msgid "Path %s doesn't exist"
 msgstr "El dispostivo ya existe: %s"
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 #, fuzzy
 msgid "Peer description"
 msgstr "Descripción"
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 #, fuzzy
 msgid "Please provide join token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 #, fuzzy
 msgid "Port description"
 msgstr "Descripción"
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6463,267 +6475,267 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 #, fuzzy
 msgid "Profile description"
 msgstr "Descripción"
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 #, fuzzy
 msgid "Project description"
 msgstr "Descripción"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Creando el contenedor"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 #, fuzzy
 msgid "Record description"
 msgstr "Descripción"
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6736,24 +6748,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -6763,13 +6775,13 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6784,41 +6796,41 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
@@ -6831,47 +6843,47 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6879,53 +6891,53 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "Aliases:"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6934,20 +6946,20 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6955,293 +6967,293 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 #, fuzzy
 msgid "Restart instances"
 msgstr "Aliases:"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "Aliases:"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 #, fuzzy
 msgid "Rule description"
 msgstr "Descripción"
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "CREADO EN"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7250,7 +7262,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7259,15 +7271,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7276,11 +7288,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7294,11 +7306,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7307,12 +7319,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7321,12 +7333,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7336,12 +7348,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7350,12 +7362,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7364,12 +7376,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7378,16 +7390,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7396,11 +7408,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7409,12 +7421,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7423,11 +7435,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7436,11 +7448,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7458,40 +7470,40 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7500,144 +7512,144 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
@@ -7647,72 +7659,72 @@ msgstr "Perfil %s creado"
 msgid "Show network address set configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7724,21 +7736,21 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7747,97 +7759,97 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 #, fuzzy
 msgid "Snapshot description"
 msgstr "Descripción"
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
@@ -7846,13 +7858,13 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7860,76 +7872,76 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Perfil %s creado"
@@ -7938,97 +7950,97 @@ msgstr "Perfil %s creado"
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 #, fuzzy
 msgid "Storage pool to use or create"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -8036,15 +8048,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8052,36 +8064,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -8092,20 +8104,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8119,7 +8131,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8128,62 +8140,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8192,107 +8204,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8307,18 +8319,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8328,28 +8340,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8363,271 +8375,271 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Contraseña admin para %s: "
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8636,77 +8648,77 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8715,16 +8727,16 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8733,87 +8745,87 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8822,121 +8834,121 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 #, fuzzy
 msgid "Volume description"
 msgstr "Descripción"
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8946,11 +8958,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8967,256 +8979,256 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid "Zone description"
 msgstr "Descripción"
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9252,174 +9264,174 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9429,554 +9441,554 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9999,13 +10011,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -10014,7 +10026,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10022,7 +10034,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10033,13 +10045,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -10048,7 +10060,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -10056,15 +10068,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10074,7 +10086,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -10083,13 +10095,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10097,26 +10109,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -10125,13 +10137,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10140,7 +10152,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -10151,19 +10163,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10174,7 +10186,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -10186,7 +10198,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -10200,7 +10212,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -10216,7 +10228,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -10228,7 +10240,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -10236,24 +10248,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -10262,7 +10274,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -10278,7 +10290,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -10286,7 +10298,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10294,13 +10306,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10312,7 +10324,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10321,7 +10333,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10332,13 +10344,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10347,19 +10359,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -10369,13 +10381,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10385,31 +10397,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10419,21 +10431,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -10442,13 +10454,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10458,7 +10470,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10468,7 +10480,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10478,7 +10490,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10488,7 +10500,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10498,7 +10510,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10508,7 +10520,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10522,7 +10534,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10532,7 +10544,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10542,67 +10554,67 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  Châssis :"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  Firmware :"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  Carte mère :"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -53,7 +53,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -110,7 +110,7 @@ msgstr ""
 "### config:\n"
 "###      size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -123,7 +123,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -131,7 +131,7 @@ msgstr ""
 "### Ceci est une représentation yaml du cluster.\n"
 "### Toute ligne commençant par un '# sera ignorée."
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -170,7 +170,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###   description: Mon image personnalisée"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -230,7 +230,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -310,7 +310,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -356,7 +356,7 @@ msgstr ""
 "### Notez que l'adresse d'écoute (listen_address) et l'origine (location) ne "
 "peuvent pas être modifiées."
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -368,7 +368,7 @@ msgstr ""
 "###\n"
 "### Prenez note que le nom est affiché mais ne peut pas être modifié"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -426,7 +426,7 @@ msgstr ""
 "### Notez que l'adresse d'écoute (listen_address) et la localisation "
 "(lacation) ne peuvent pas être changées."
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -455,7 +455,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié."
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -503,7 +503,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -539,7 +539,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -578,7 +578,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -617,7 +617,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -625,93 +625,93 @@ msgstr ""
 "### Ceci est une représentation yaml d'un membre du cluster.\n"
 "### Toute ligne commençant par un '#' sera ignorée."
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, en ligne: %v, nœud NUMA : %v)"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr "%q n'est pas périphérique de type bloc"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr "%q n'est pas une adresse IP"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q pool %q du projet %q (incluant %d copie instantanée)"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d disponible)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (principal=%q, source=%q)"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(aucun)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Niveau %d (type: %s): %s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 "--console ne peut être pas utilisée pendant que l'arrêt de l'instance est "
 "forcé"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr "--console ne peut être utilisé avec --all"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot"
 
@@ -719,25 +719,25 @@ msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port ne peut pas être utilisé sans --network-address"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 #, fuzzy
 msgid "--target can only be used with clusters"
 msgstr "--target ne peut pas être utilisé qu'avec des clusters"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -749,7 +749,7 @@ msgstr "<alias>"
 msgid "<alias> <target>"
 msgstr "<alias> <cible>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr "<local|global> <requête>"
 
@@ -769,43 +769,43 @@ msgstr "<serveur_distant> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<serveur distant> <nouveau nom>"
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr "<serveur_distant>: <chemin>"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<chemin_source>... [<serveur_distant>:]<instance>/<chemin>"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 "<archive tar>|<dossier>|<URL> [<rootfs archive tar>] [<serveur distant>:] "
 "[clé=valeur...]"
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr "<cible>"
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr "=> Requête %d:"
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr "Un certificat client est déjà présent"
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr "Un nom de client doit être fournit"
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr "Vous devez fournir le nom d'un membre appartenant à un cluster"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
@@ -814,61 +814,61 @@ msgstr "ADRESSE"
 msgid "ADDRESSES"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr "TYPE D'AUTHENTIFICATION"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr "Clé d'accès (auto-généré si vide)"
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr "Clé d'accès: %s"
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr "Accéder à la configuration étendue"
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr "Accusé réception d'avertissement"
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "L'action '%q' n'est pas supporté par le serveur"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "Action (GET par défaut)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr "Ajoutez un membre d'un cluster à un groupe de cluster"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr "Ajoutez un enregistrement d'une zone réseau"
 
@@ -877,23 +877,23 @@ msgstr "Ajoutez un enregistrement d'une zone réseau"
 msgid "Add addresses to a network address set"
 msgstr "Ajoutez des entrées à la zone d'enregistrement réseau"
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr "Ajoutez un backend à un équilibreur de charge"
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr "Ajoutez des backends à un équilibreur de charge"
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr "Ajoutez des entrées à la zone d'enregistrement réseau"
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr "Ajoutez des périphériques à l'instance"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr "Ajoutez des membres à un groupe"
 
@@ -901,11 +901,11 @@ msgstr "Ajoutez des membres à un groupe"
 msgid "Add new aliases"
 msgstr "Ajouter de nouveaux alias"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -923,19 +923,18 @@ msgstr ""
 "\n"
 "L'authentification HTTP Basic (RFC 26176) peut être utilisée si elle est "
 "combinée avec le protocole « simplestreams » :\n"
-"  incus remote add ressource_distante_identifiant https://"
-"UTILISATEUR:MOTDEPASSE@exemple.com/complement/de/chemin --"
-"protocol=simplestreams\n"
+"  incus remote add ressource_distante_identifiant https://UTILISATEUR:"
+"MOTDEPASSE@exemple.com/complement/de/chemin --protocol=simplestreams\n"
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -949,7 +948,7 @@ msgstr ""
 "- client (défaut)\n"
 "- métrique\n"
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -961,58 +960,58 @@ msgstr ""
 "Cela va générer un jeton de confiance a utiliser par le client pour "
 "s'ajouter au dépôt de confiance.\n"
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr "Ajoutez des ports à la redirection"
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr "Ajoutez des ports à l'équilibreur de charge"
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr "Ajouter des profils aux instances"
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr "Ajoutez des roles à un membre d'un cluster"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr "Ajoutez des règles à une liste de contrôle d'accès (ACL)"
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 "Propriétés de configuration additionnelles d'un emplacement de stockage "
 "(clé=valeur, vide quand fini)"
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr "Adresses à associé à (défaut: aucun)"
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr "Adresses à associé à (sans inclure les ports)"
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr "Addresse : %s"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr "Addresse : %v"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Clef d'accès administrateur : %s"
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Clef d'accès secrète administrateur : %s"
@@ -1027,105 +1026,105 @@ msgstr "L'alias %s existe déjà"
 msgid "Alias %s doesn't exist"
 msgstr "L'alias %s n'existe pas"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "Nom d'alias manquant"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr "Alias : %s"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr "L'alias %s existe déjà"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 "Toutes les données seront perdues après avoir rejoint le cluster, voulez-"
 "vous continuer ?"
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr "Tous les projets"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr "Toutes les adresses serveurs sont indisponibles"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "Architecture : %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr "Rejoingez-vous un cluster existant ?"
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "Êtes-vous sûr de %s le membre du cluster %q ? (oui/non) [défaut=non] : "
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "Aucun n'a pu être trouvé, la socket SPICE peut être trouvé à:"
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr "Machine virtuelle a été demandé mais l'image est de type conteneur"
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr "Attribuer des ensemble de groupes aux membres du cluster"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr "Attribuer un ensemble de profils à des instances"
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr "Attribuer des interfaces réseaux à des instances"
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr "Attacher des interfaces réseaux aux profiles"
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr "Attacher de nouveaux volumes de stockage à des instances"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Attacher de nouveaux volumes de stockage aux profils"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr "Attacher de nouvelles interfaces aux instances"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr "Connexion aux consoles de l'instance"
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1138,158 +1137,158 @@ msgstr ""
 "instance\n"
 "ainsi qu'a récupérer les logs précédents"
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "Auto-négociation: %v"
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 "La mise à jour automatique est uniquement disponible en mode hissage (pull)"
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto : %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr "Mode automatique (non-interactif)"
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr "Projets disponibles :"
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "Moyenne : %.2f %.2f %.2f"
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr "Image de base"
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 #, fuzzy
 msgid "Backend description"
 msgstr "Description"
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 #, fuzzy
 msgid "Backend health:"
 msgstr "État du backend :"
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "Sauvegarder l'instance : %s"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Sauvegarder le bucket de stockage : %s"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 "Mauvais appareil remplacez la syntaxe, syntaxe attendue <appareil>,"
 "<clé>=<valeur>: %s"
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Mauvaise association clef=valeur: %q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Mauvaise paire clé=valeur: %s"
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr "Liaison:"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr "À la fois--all et le nom d'instance on été donné"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr "Pont:"
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 #, fuzzy
 msgid "Bucket description"
 msgstr "Description"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Adresse du bus : %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Octets émis"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "ANNULABLE"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "NOM COMMUN"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr "Type de contenu"
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr "NOMBRE"
 
@@ -1298,74 +1297,74 @@ msgstr "NOMBRE"
 msgid "CPU TIME(s)"
 msgstr "TEMPS CPU(s)"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr "CPU :"
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr "CPUs :"
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "CRÉÉ"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "En cache : %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr "Caches mémoire :"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr "Impossible de se lier à l’adresse %q: %w"
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "Impossible de surcharger la configuration ou les profiles lors du renommage "
 "local"
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr "Impossible de fournir un nom à l'image cible"
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossible de récupérer un répertoire sans --recursive"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr "Impossible de lire depuis le fichier d'environnement : %w"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %w"
@@ -1374,56 +1373,56 @@ msgstr "Impossible de lire depuis stdin : %w"
 msgid "Can't remove the default remote"
 msgstr "Impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr "Impossible de spécifier --fast avec --columns"
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr "Impossible de spécifier --project avec --all-projects"
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr "Impossible de spécifier un autre serveur distant pour un renommage"
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 "Impossible de spécifier la colonne L lorsque le serveur ne fait pas partie "
 "d'un cluster"
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Impossible de spécifier uid/gid/mode dans le mode récursif"
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clef '%s', elle n'est pas définie actuellement."
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr "Impossible d'utiliser --auto et --preseed ensemble"
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr "Impossible d'utiliser --dump avec d'autres fanions"
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr "Impossible d'utiliser --minimal et --auto ensemble"
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr "Impossible d'utiliser --minimal et --preseed ensemble"
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr "Impossible d'utiliser une image avec --empty"
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1431,56 +1430,56 @@ msgstr ""
 "Impossible de surcharger l'appareil %q : Appareil introuvable dans les "
 "profils"
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "Impossible d'utiliser --destination-target quand le serveur distant n'est "
 "pas dans un cluster"
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "Impossible de mettre --target quand le server source n'est pas dans un "
 "cluster"
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr "Cartes %d:"
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "Cartes : %s (%s)"
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Jeton d'ajout du certificat pour %s supprimé"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 #, fuzzy
 msgid "Certificate description"
 msgstr "Empreinte du certificat : %s"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "Incompatibilité d'empreinte de certificat entre le jeton et le serveur %q"
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
@@ -1488,153 +1487,153 @@ msgstr ""
 "Incompatibilité d'empreinte de certificat entre le jeton et le membre du "
 "cluster %q"
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr "Châssis"
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr "Test si le démon est prêt (tentative %d)"
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr "Choisir %s:"
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr "Jeton d'ajout du certificat pour le client %s  :"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client approuvé par le serveur :"
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr "Version du client : %s\n"
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr "Groupe de serveurs %s créé"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "Groupe de serveurs %s supprimé"
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Le groupe de serveurs %s n'est pas actuellement appliqué à %s"
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Groupe de serveurs %s renommée en %s"
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "Groupe de serveurs %s créé"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "Jeton de connexion de cluster pour %s:%s supprimé"
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "Membre de cluster %s ajouté aux groupes %s"
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Membre du cluster %s ajouté au groupe %s"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Le membre du cluster %s est déjà dans le groupe %s"
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Le membre du cluster %s est supprimé du groupe %s"
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr "Nom du membre du cluster"
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr "Clustering activé"
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Colonnes"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr "Client en ligne de commande pour Incus"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1654,55 +1653,55 @@ msgstr ""
 "Des commandes personnalisées peuvent être définies par le biais d'alias, "
 "utilisez \"incus alias\" pour les gérer."
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuration clé/valeur à associer à la nouvelle instance"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 #, fuzzy
 msgid "Config key/value to apply to the new network integration"
 msgstr "Configuration clé/valeur à associer à la nouvelle intégration réseau"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr "Configuration clef/valeur à associer au nouveau projet"
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuration clef/valeur à associer pour l'instance cible"
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr "Fanions de configuration nécessite --auto"
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr "Configurer le démon"
 
@@ -1711,42 +1710,42 @@ msgstr "Configurer le démon"
 msgid "Configure the refresh delay in seconds"
 msgstr "Configurer le démon"
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "Connexion au démon (tentative %d)"
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr "Type de contenu, bloc ou système de fichier"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr "Type de contenu : %s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "Contrôle: %s (%s)"
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr "Copie une instance avec état"
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr "Copie de volumes de stockage personnalisés"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr "Copie les images entre les serveurs"
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1758,11 +1757,11 @@ msgstr ""
 "Le fanion auto-update indique au serveur que l'image doit restée à jour.\n"
 "Cela nécessite que la source soit un alias et d'être publique."
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr "Copier des instances au sein d'un même serveur ou entre serveurs"
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1790,148 +1789,148 @@ msgstr ""
 "Le mode de transfert pull est le mode par défaut car il est compatible avec "
 "toutes les versions du serveur.\n"
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 "Copier les périphériques hérités et surcharge les clés de configuration du "
 "profile"
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr "Copier les profiles"
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr "Copier l'instance sans ses instantanés"
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr "Copier le volume sans ses instantanés"
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr "Copie dans un projet différent de la source"
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr "Copier des images de machines virtuelles"
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie du volume de stockage : %s"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr "Coeur %d"
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr "Cœurs : %v"
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de fermer le fichier de certificat serveur %q: %w"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'accéder au certificat : %s"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'accéder à la clé de certificat %s"
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible de lire le fichier de certificat: %s avec l'erreur: %v"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible de lire le fichier clé de certificat: %s avec l'erreur: %v"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 "Impossible d'écrire un nouveau certificat pour le serveur distant '%s' suite "
 "à l'erreur : %v"
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible d'écrire le fichier de certificat serveur %q: %w"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr "Impossible de trouver une entrée correspondante"
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr "Impossible de statfs %s: %w"
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr "Créer un groupe de serveurs"
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr "Créer un nouvel agrégat de stockage %s ?"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr "Créer une nouvelle machine virtuelle"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr "Crée des alias pour les images existantes"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr "Créer une instance vide"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 #, fuzzy
 msgid "Create and start instances from images"
 msgstr "Créer et démarrer des instances à partir d'images"
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr "Créer tous les répertoires nécessaires"
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Créer des fichiers et répertoires dans les instances"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr "Créer une sauvegarde de l'instance : %w"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 #, fuzzy
 msgid "Create instance snapshot"
 msgstr "Créer un instantané d'instance"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 #, fuzzy
 msgid ""
 "Create instance snapshots\n"
@@ -1958,37 +1957,37 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Création d'instances à partir d'images"
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Création d'une clef pour un stockage de type bucket"
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr "Créer de nouvelles ACL réseau"
 
@@ -1997,97 +1996,97 @@ msgstr "Créer de nouvelles ACL réseau"
 msgid "Create new network address sets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 #, fuzzy
 msgid "Create new networks"
 msgstr "Créer de nouveaux réseaux"
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "Nombre actuel de VFs: %d"
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "ADRESSE CIBLE PAR DÉFAUT"
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2095,29 +2094,29 @@ msgstr "DESCRIPTION"
 msgid "DISK"
 msgstr "DISQUE"
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr "UTILISATION DISQUE"
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "PILOTE"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr "DRM:"
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr "Le démon ne fonctionne toujours pas après %ds d'attente (%v)"
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr "Le démon continue de fonctionner après %ds d'attente"
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "État : %s"
@@ -2132,11 +2131,11 @@ msgstr "Commandes :"
 msgid "Debug commands for instances"
 msgstr "Exécuter les commandes dans les instances"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr "ID VLAN par défaut"
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2145,60 +2144,60 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "Supprimer une opération en tâche de fond (essayera d'annuler)"
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr "Supprime un groupe de serveurs"
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 #, fuzzy
 msgid "Delete image aliases"
 msgstr "Supprimer les alias d'image"
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 #, fuzzy
 msgid "Delete instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 #, fuzzy
 msgid "Delete instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr "Supprimer les ACLs réseau"
 
@@ -2207,296 +2206,296 @@ msgstr "Supprimer les ACLs réseau"
 msgid "Delete network address sets"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr "Supprime les redirections réseaux"
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr "Supprime les réseaux"
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr "Supprime les profiles"
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr "Supprime les pool de stockage"
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 #, fuzzy
 msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Description"
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr "Détacher les interfaces réseaux des instances"
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr "Détacher les interfaces réseau des profils"
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Périphérique %s ajouté à %s"
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Addresse : %s"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
@@ -2504,7 +2503,7 @@ msgstr ""
 "Le périphériques du ou des profiles ne peut pas être modifié pour une "
 "instance. Surchargez le périphérique ou modifiez le profil"
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
@@ -2512,80 +2511,80 @@ msgstr ""
 "Le périphériques du ou des profiles ne peut pas être supprimé pour une "
 "instance. Surchargez le périphérique ou modifiez le profil"
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 "Le périphérique du ou des profils ne peut pas être récupérés pour l'instance"
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr "Dossier dans lequel exécuter la commande (/root par défaut)"
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 "Désactivez l'authentification lorsque vous utilisez SSH SFTP en mode écoute"
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr "Désactiver l'allocation pseudo-terminal"
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2594,7 +2593,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display resource usage info per instance"
 msgstr "Afficher l'utilisation des ressources par instance"
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2621,117 +2620,117 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr "Voulez-vous configurer un nouveau pool de stockage locale?"
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr "Voulez-vous configurer une nouveau pool de stockage à distance?"
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr "Voulez-vous configurer un nouveau pool de stockage?"
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr "Voulez-vous continuer sans provisionnement virtuel?"
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr "Ne pas afficher les informations sur l'état d'avancement"
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Pilote: %v (%v)"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Pilote: %v (%v)"
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr "Copié de la configuration YAML vers stdout"
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr "ENTRÉES"
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "EXISTANT: %q (principal=%q, source=%q)"
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr "Modifier un groupe de serveurs"
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr "Modifier les propriétés de l'image"
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 #, fuzzy
 msgid "Edit instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2741,68 +2740,68 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network address set configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr "Modifier les configurations réseau au format YAML"
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr "Modifier les configurations de profil au format YAML"
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr "Modifier la clé du bucket de stockage au format YAML"
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr "Modifier les configurations du pool de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr "Modifier les configurations de volume de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2811,34 +2810,34 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "Entrée en colonne vide (commande redondante, de tête ou de queue ) dans '%s '"
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr "Activer la mise en cluster sur un seul serveur non mis en cluster"
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2877,48 +2876,48 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr "Entrée TTL"
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "Erreur de connexion à un membre existant du cluster %q : %v"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr "Erreur lors de la création d'un décodeur: %v"
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr "Erreur lors du décodage des données: %v"
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr "Erreur lors de la récupération des alias : %w"
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "Erreur lors du paramétrages des propriétés: %v"
@@ -2928,39 +2927,39 @@ msgstr "Erreur lors du paramétrages des propriétés: %v"
 msgid "Error setting term size %s"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier: %s"
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, fuzzy, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "Erreur lors de l'exécution de l'expansion de l'alias : %s\n"
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, fuzzy, c-format
 msgid "Error: %v\n"
 msgstr "Erreur : %v\n"
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2972,20 +2971,20 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Évacuation du membre du cluster : %s"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr "Type d'évènements à surveiller"
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr "Exécuter une requête SQL contre la base de données locale ou globale"
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 #, fuzzy
 msgid ""
 "Execute a SQL query against the local or global database\n"
@@ -3053,11 +3052,11 @@ msgstr ""
 "mode local\n"
 "et cluster."
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr "Exécuter les commandes dans les instances"
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 #, fuzzy
 msgid ""
 "Execute commands in instances\n"
@@ -3081,23 +3080,23 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
@@ -3106,12 +3105,12 @@ msgstr "N'expire jamais"
 msgid "Export a virtual machine's memory state"
 msgstr "Copier des images de machines virtuelles"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 #, fuzzy
 msgid ""
 "Export and download images\n"
@@ -3123,27 +3122,27 @@ msgstr ""
 "La cible de sortie est facultative et par défaut dans le répertoire de "
 "travail."
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -3155,251 +3154,251 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr "DOMAINE D'ÉCHEC"
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 #, fuzzy
 msgid "FILENAME"
 msgstr "NOM"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr "PREMIÈRE VUE"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 #, fuzzy
 msgid "FQDN"
 msgstr "FQDN (nom de domaine pleinement qualifié)"
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "Échec de l'authentification SSH avec le client %q : %v"
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "Échec de l'acceptation du canal client %q : %v"
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Échec de la vérification de l'existence de l'instance \"%s:%s\" : %w"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 "Échec de la vérification de l'existence de l'instantané d'instance \"%s:"
 "%s\" : %w"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "Échec de la connexion au SFTP de l'instance pour le client %q : %v"
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Échec de la connexion au SFTP de l'instance : %w"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "Échec de la connexion au démon (tentative %d) : %v"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, fuzzy, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 "Échec de la conversion de l'opération de jeton en jeton d'ajout de "
 "certificat : %w"
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 "Échec de la conversion de l'opération de jeton en jeton de connexion : %w"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Échec de la suppression de l'instance %q dans le projet %q : %w"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Échec de la suppression du volume source après la copie : %w"
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec de la génération de la clé hôte SSH : %w"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "Échec de la génération du certificat de confiance : %w"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "Échec de l'obtention des pools de stockage existants : %w"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "Échec de la récupération du status du pair : %w"
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr "Échec de la demande d'importation : %w"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Échec du chargement du réseau %q : %w"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 "Échec du chargement du profil %q pour la modification du périphérique : %w"
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec du chargement du pool de stockage %q : %w"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec de l'analyse de la clé d'hôte SSH : %w"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "Échec de l'analyse de la réponse de validation : %w"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec de l'exécution de la commande : %w"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec du démarrage de sshfs : %w"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec de l'acceptation de la connexion entrante : %w"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr "Échec de l'ajout d'un serveur distant"
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "Échec de l'ajout d'un certificat de serveur au cluster : %w"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, fuzzy, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr "Impossible de vérifier que le démon est prêt (tentative %d): %v"
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr "Échec de la fermeture du fichier d'exportation : %w"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec de la fermeture du fichier de certificat du serveur %q : %w"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "Échec de la configuration du cluster : %w"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Échec de la connexion au membre du cluster : %w"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 "Échec de la connexion pour obtenir des informations sur le serveur : %w"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "Échec de la connexion au démon local : %w"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Échec de la connexion au nœud de cluster cible %q : %w"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec de la création de %q : %w"
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Échec de la création de l'alias %s : %w"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr "Échec de la création de la sauvegarde : %v"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -3410,105 +3409,105 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr "Échec de la mise à jour de l'état du membre du cluster : %w"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Échec de la récupération de la sauvegarde de l'unité de stockage : %w"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 "Échec de la récupération du fichier de sauvegarde du volume de stockage : %w"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec de la recherche du projet : %w"
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr "Échec de l'adhésion au cluster : %w"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec de la mise en écoute des demandes de connexion : %w"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, fuzzy, c-format
 msgid "Failed to load configuration: %s"
 msgstr "Échec du chargement de la configuration : %s"
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, fuzzy, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "Échec de l'analyse de la réponse du dump : %w"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr "Échec de l'analyse des serveurs : %w"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "Échec de l'analyse du preseed : %w"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "Échec de la lecture à partir de l'entrée standard : %w"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec du rafraîchissement de l'instance cible '%s' : %v"
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec de la suppression de l'alias %s : %w"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr "Échec du renommage du fichier d'exportation : %w"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr "Échec du rendu de la configuration : %w"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "Échec de la demande de dump : %w"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "Échec de la récupération des informations sur le cluster : %w"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "Échec de la récupération de la configuration actuelle du cluster : %w"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "Échec de la récupération de la configuration actuelle du serveur : %w"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "Échec de la récupération de la configuration actuelle du serveur : %w"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3526,104 +3525,104 @@ msgstr "Échec de la récupération de la liste des réseaux : %w"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "Échec de la récupération de la liste des pools de stockage : %w"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 "Échec de l'établissement d'une relation de confiance avec le cluster : %w"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "Échec de la mise à jour de l'état du membre du cluster : %w"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "Échec du parcours des fichiers du répertoire %s : %s"
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec de l'écriture du fichier de certificat serveur %q : %w"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr "Échec de la demande de validation : %w"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "Nom : %s"
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr "Le filtrage n'est pas encore pris en charge"
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 #, fuzzy
 msgid "Force a particular evacuation action"
 msgstr "Forcer une action d'évacuation particulière"
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr "Forcer la création de fichiers ou de répertoires"
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 #, fuzzy
 msgid "Force delete the project and everything it contains."
 msgstr "Suppression forcée du projet et de toutes les données associées"
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "Force deleting files, directories, and subdirectories"
 msgstr "Forcer la création de fichiers ou de répertoires"
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr "Force la suppression d'un membre même s'il est dans un état dégradé"
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 #, fuzzy
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3667,7 +3666,7 @@ msgstr ""
 "\n"
 "Êtes-vous vraiment sûr de vouloir forcer la suppression de %s ? (oui/non) : "
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3678,37 +3677,37 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "Format (csv|json|table|yaml|compact)"
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 #, fuzzy
 msgid "Format (json|pretty|yaml)"
 msgstr "Format (json|pretty|yaml)"
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 #, fuzzy
 msgid "Format (man|md|rest|yaml)"
 msgstr "Format (man|md|rest|yaml)"
@@ -3723,7 +3722,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3733,229 +3732,229 @@ msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 "L'alias trouvé %q fait référence à un argument en dehors du nombre donné"
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, fuzzy, c-format
 msgid "Free: %v"
 msgstr "Libre : %v"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "Fréquence : %vMhz"
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr "GPU :"
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr "GPUs :"
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr "Générer les pages de manuel pour toutes les commandes"
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr "Obtenir un résumé de l'allocation des ressources"
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Nom du réseau"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr "Obtenir les propriétés de l'image"
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 #, fuzzy
 msgid "Get runtime information on networks"
 msgstr "Obtenir les informations opérationnelles des réseaux"
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr "Obtenir la clé en tant que propriété ACL du réseau"
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr "Obtenir la clé en tant que propriété du réseau"
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr "Obtenir la clé en tant que propriété du profil"
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr "Obtenir la clé en tant que propriété du projet"
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr "Obtenir la clé en tant que propriété d'instance"
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du pool de stockage"
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du volume de stockage"
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3967,73 +3966,73 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 "La cible donnée %q ne correspond pas à l'emplacement du volume source %q"
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 "ID du groupe avec lequel la commande doit être exécutée (valeur par défaut : "
 "0)"
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "La copie d'E/S de SSH vers l'instance a échoué : %v"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "La copie d'E/S de l'instance vers SSH a échoué : %v"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "La copie d'E/S de l'instance vers sshfs a échoué : %v"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "La copie d'E/S de sshfs vers l'instance a échoué : %v"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 #, fuzzy
 msgid "ID"
 msgstr "PID"
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, fuzzy, c-format
 msgid "ID: %d"
 msgstr "Pid : %d"
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr "ID : %s"
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -4041,64 +4040,64 @@ msgstr "IMAGES"
 msgid "INSTANCE NAME"
 msgstr "NOM DE L'INSTANCE"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 #, fuzzy
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr "IPv4"
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr "IPv6"
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "Expire : %s"
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "Expire : %s"
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 "Si une instance est en cours d'exécution, la stopper d'abord puis la "
 "reconstruire"
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "Si l'alias de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -4107,89 +4106,89 @@ msgstr ""
 "Si c'est la première fois que vous lancez LXD, vous devriez aussi lancer : "
 "sudo lxd init"
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "Ignorer toute expiration automatique configurée pour l'instance"
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 "Ignorer toute expiration automatique configurée pour le volume de stockage"
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr "Ignorer les erreurs de copie pour les fichiers non permanents"
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr "L'image est déjà à jour."
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr "Date d'expiration de l'image (format : rfc3339)"
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr "Identifiant d'image manquant"
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -4200,185 +4199,185 @@ msgstr ""
 "L'importation de répertoire n'est disponible que sous Linux et doit être "
 "effectuée en tant que root."
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr "Le type d'importation doit être \"backup\" ou \"iso\""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 #, fuzzy
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "Type d'importation : \"backup\" ou \"iso\" (par défaut \"backup\")"
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 #, fuzzy
 msgid "Include environment variables from file"
 msgstr "Inclure les variables environnements à partir d'un fichier"
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 #, fuzzy
 msgid "Include less common commands"
 msgstr "Afficher les commandes moins communes"
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr "Incus - Client en ligne de commande"
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr "Infiniband :"
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "Instance déconnectée pour le client %q"
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 #, fuzzy
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 "Impossible de spécifier un chemin cible dans l'instance quand le mode "
 "d'écoute SFTP est utilisé"
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr "Type d'instance"
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schéma d'URL invalide \"%s\" in \"%s\""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, fuzzy, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, fuzzy, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "Format de colonne de clé de configuration non valide (trop de champs) : '%s'"
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 #, fuzzy
 msgid "Invalid database type"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "Le nom du conteneur est : %s"
@@ -4388,7 +4387,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
@@ -4403,34 +4402,34 @@ msgstr "Entrée invalide, veuillez entrer un entier positif"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "Largeur maximale non valide (doit être -1, 0 ou un entier positif) '%s' dans "
 "'%s'"
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "Largeur maximale non valide (doit être un entier) '%s' dans '%s'"
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, fuzzy, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -4438,29 +4437,29 @@ msgstr ""
 "Nom invalide dans \"%s\", la chaîne vide n'est autorisée que lorsque "
 "maxWidth est défini."
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -4475,106 +4474,106 @@ msgstr "Cible invalide %s"
 msgid "Invalid sorting type provided"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr "Rejoindre un cluster existant nécessite d'être root"
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr "Version du noyau"
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 #, fuzzy
 msgid "Key description"
 msgstr "Description"
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 #, fuzzy
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr "LIMITE"
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr "ADRESSE D’ÉCOUTE"
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architecture : %s"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, fuzzy, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "Vitesse de la liaison : %dMbit/s (%s duplex)"
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr "Liste des baux DHCP"
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4608,12 +4607,12 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "List aliases"
 msgstr "Alias :"
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4635,12 +4634,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4662,12 +4661,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4689,11 +4688,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr "Liste de tous les membres du cluster"
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4715,16 +4714,16 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias :"
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4733,11 +4732,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4761,12 +4760,12 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4789,11 +4788,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4817,16 +4816,16 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4849,11 +4848,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4874,11 +4873,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4903,11 +4902,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4933,11 +4932,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4961,11 +4960,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4993,22 +4992,22 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 #, fuzzy
 msgid "List instance devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 #, fuzzy
 msgid "List instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -5031,12 +5030,12 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 #, fuzzy
 msgid "List instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -5109,8 +5108,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -5176,20 +5175,20 @@ msgstr ""
 "Colonnes en mode rapide : nsacPt\n"
 "\n"
 "Exemple :\n"
-"    lxc list -c n,volatile.base_image:\\BASE "
-"IMAGE\\:0,s46,volatile.eth0.hwaddr:MAC"
+"    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
+"hwaddr:MAC"
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -5212,12 +5211,12 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -5240,25 +5239,25 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -5274,11 +5273,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -5299,12 +5298,12 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -5326,12 +5325,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5354,12 +5353,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5373,15 +5372,27 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5397,11 +5408,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5427,11 +5438,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5455,12 +5466,12 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias :"
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5483,90 +5494,90 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr "Journal :"
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 #, fuzzy
 msgid "Lower device"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 #, fuzzy
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5574,58 +5585,58 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Copie de l'image : %s"
@@ -5634,27 +5645,27 @@ msgstr "Copie de l'image : %s"
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 #, fuzzy
 msgid "Manage image aliases"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 #, fuzzy
 msgid "Manage images"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5674,38 +5685,38 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 #, fuzzy
 msgid "Manage instance and server configuration options"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 #, fuzzy
 msgid "Manage instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
@@ -5715,277 +5726,277 @@ msgstr "Nom du réseau"
 msgid "Manage network address sets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, fuzzy, c-format
 msgid "Member %q already has role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, fuzzy, c-format
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 #, fuzzy
 msgid "Missing name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
@@ -5998,183 +6009,183 @@ msgstr "Nom du réseau"
 msgid "Missing network address set name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "Résumé manquant."
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 #, fuzzy
 msgid "Mode"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, fuzzy, c-format
 msgid "Model: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 #, fuzzy
 msgid "Monitor a local or remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -6190,225 +6201,225 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr "NOM"
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr "NON"
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 #, fuzzy
 msgid "Name of the OSD storage pool"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 #, fuzzy
 msgid "Name of the new storage pool"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 #, fuzzy
 msgid "Name of the shared LVM volume group:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 #, fuzzy
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, fuzzy, c-format
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -6433,175 +6444,175 @@ msgstr "Le réseau %s a été créé"
 msgid "Network address set description"
 msgstr "Description"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr "Description"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, fuzzy, c-format
 msgid "Network integration %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, fuzzy, c-format
 msgid "Network integration %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6612,20 +6623,20 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 #, fuzzy
 msgid "OS Version"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6633,41 +6644,41 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 #, fuzzy
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 #, fuzzy
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -6682,180 +6693,180 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Operating System:"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "PCI device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr "Paquets émis"
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 #, fuzzy
 msgid "Partitions:"
 msgstr "Options :"
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, fuzzy, c-format
 msgid "Path %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 #, fuzzy
 msgid "Pause instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 #, fuzzy
 msgid "Peer description"
 msgstr "Description"
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr "Veuillez fournir le jeton de connexion :"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "Veuillez entrer 'o', 'n' ou l'empreinte :"
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 #, fuzzy
 msgid "Port description"
 msgstr "Description"
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6871,273 +6882,273 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr "Le traitement des alias a échoué : %s"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 #, fuzzy
 msgid "Profile description"
 msgstr "Description"
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 #, fuzzy
 msgid "Project description"
 msgstr "Description"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "Création du conteneur"
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Création du conteneur"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 #, fuzzy
 msgid "Record description"
 msgstr "Description"
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -7150,27 +7161,27 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -7180,13 +7191,13 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
@@ -7201,42 +7212,42 @@ msgstr "le serveur distant %s est statique et ne peut être modifié"
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, fuzzy, c-format
 msgid "Removable: %v"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
@@ -7251,50 +7262,50 @@ msgstr "Création du conteneur"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -7303,55 +7314,55 @@ msgstr "Création du conteneur"
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, fuzzy, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -7360,20 +7371,20 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -7382,49 +7393,49 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 #, fuzzy
 msgid "Restart instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 #, fuzzy
 msgid ""
 "Restore instance from snapshots\n"
@@ -7447,254 +7458,254 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 #, fuzzy
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 #, fuzzy
 msgid "Rule description"
 msgstr "Description"
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "Publié : %s"
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "CRÉÉ À"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 #, fuzzy
 msgid "STATEFUL"
 msgstr "ÉTAT"
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr "STATIQUE"
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 #, fuzzy
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Créé : %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 #, fuzzy
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7703,7 +7714,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7712,16 +7723,16 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7730,12 +7741,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7749,12 +7760,12 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7763,12 +7774,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7777,12 +7788,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7792,12 +7803,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7806,12 +7817,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7820,12 +7831,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7834,17 +7845,17 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7853,12 +7864,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7867,12 +7878,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7881,12 +7892,12 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7895,12 +7906,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7918,43 +7929,43 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7963,154 +7974,154 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 #, fuzzy
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
@@ -8120,77 +8131,77 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network address set configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -8202,22 +8213,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -8226,102 +8237,102 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 #, fuzzy
 msgid "Show the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 #, fuzzy
 msgid "Snapshot description"
 msgstr "Description"
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "Certaines instances n'ont pas réussi à %s"
@@ -8330,13 +8341,13 @@ msgstr "Certaines instances n'ont pas réussi à %s"
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr "Source :"
 
@@ -8345,79 +8356,79 @@ msgstr "Source :"
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "État : %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 #, fuzzy
 msgid "Stop instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 #, fuzzy
 msgid "Stop the instance if currently running"
 msgstr "Arrêter le conteneur s'il est en cours d'exécution"
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr "L'arrêt de l'instance a échoué !"
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "L'arrêt de l'instance a échoué : %s"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Profil %s créé"
@@ -8426,100 +8437,100 @@ msgstr "Profil %s créé"
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, fuzzy, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, fuzzy, c-format
 msgid "Storage pool %q of type %q"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 #, fuzzy
 msgid "Storage pool to use or create"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -8529,15 +8540,15 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8545,37 +8556,37 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -8586,20 +8597,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, fuzzy, c-format
 msgid "The %s storage pool already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8613,7 +8624,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8622,36 +8633,36 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 #, fuzzy
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 #, fuzzy
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 "Le conteneur est en cours d'exécution, l'arrêter d'abord ou ajouter --force."
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 #, fuzzy
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
@@ -8660,32 +8671,32 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -8694,108 +8705,108 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8810,11 +8821,11 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr "L'interface demandée n'existe pas. Veuillez en choisir une autre."
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
@@ -8822,7 +8833,7 @@ msgid ""
 msgstr ""
 "Le pont réseau demandé \"%s\" existe déjà. Veuillez choisir un autre nom."
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8834,28 +8845,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\". Vouliez-vous un alias ?"
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8869,47 +8880,47 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 #, fuzzy
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
@@ -8917,234 +8928,234 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, fuzzy, c-format
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, fuzzy, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "USB device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 #, fuzzy
 msgid "USB devices:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
@@ -9154,82 +9165,82 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network address set configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -9238,16 +9249,16 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Obtenir la clé en tant que propriété du cluster"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -9256,89 +9267,89 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9347,123 +9358,123 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 #, fuzzy
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 #, fuzzy
 msgid "Volume description"
 msgstr "Description"
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, fuzzy, c-format
 msgid "WWN: %s"
 msgstr "Nom : %s"
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -9473,11 +9484,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -9494,37 +9505,37 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 #, fuzzy
 msgid "Where should this storage pool store its data?"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 #, fuzzy
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
@@ -9533,121 +9544,121 @@ msgstr ""
 "Restaurer ou pas l'état de fonctionnement du conteneur depuis l'instantané "
 "(s'il est disponible)"
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 #, fuzzy
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr "OUI"
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr "Il est impossible de passer -t et -T simultanément"
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 #, fuzzy
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom d'image ou utilisez --empty"
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid "Zone description"
 msgstr "Description"
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9655,7 +9666,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -9663,19 +9674,19 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<serveur distant>:]"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
@@ -9683,7 +9694,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -9691,40 +9702,40 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr "[<serveur distant>:] <certificat>"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr "[<serveur distant>:] <nom>"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<serveur distant>:] [<filtre>...]"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<serveur distant>:] [<filtres>...]"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr "[<serveur distant>:]<ACL>"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<serveur distant>:]<ACL> <direction> <clé=valeur>..."
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<serveur distant>:] <ACL> <clé>"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<serveur distant>:]<ACL> <clé>=<valeur>"
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9732,7 +9743,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -9740,7 +9751,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr ""
@@ -9752,8 +9763,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -9761,7 +9772,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -9769,7 +9780,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9777,7 +9788,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9838,7 +9849,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9850,7 +9861,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -9862,7 +9873,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9870,8 +9881,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -9883,8 +9894,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -9892,7 +9903,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr ""
@@ -9900,7 +9911,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
@@ -9908,7 +9919,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -9916,7 +9927,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -9928,7 +9939,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -9940,7 +9951,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -9948,7 +9959,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -9956,7 +9967,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
@@ -9964,7 +9975,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9972,7 +9983,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -9980,7 +9991,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9988,10 +9999,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -10003,7 +10014,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -10011,7 +10022,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -10019,7 +10030,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -10027,7 +10038,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -10035,7 +10046,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
@@ -10043,7 +10054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -10051,7 +10062,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
@@ -10063,7 +10074,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -10075,7 +10086,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -10087,7 +10098,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
@@ -10099,7 +10110,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
@@ -10111,8 +10122,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
@@ -10124,7 +10135,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
@@ -10132,7 +10143,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
@@ -10144,8 +10155,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -10153,7 +10164,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
@@ -10177,7 +10188,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -10185,7 +10196,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -10197,7 +10208,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -10209,7 +10220,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -10217,7 +10228,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -10230,7 +10241,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10242,7 +10253,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -10251,9 +10262,9 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -10265,8 +10276,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -10278,7 +10289,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -10290,7 +10301,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -10298,7 +10309,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -10306,7 +10317,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -10318,7 +10329,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr ""
@@ -10330,8 +10341,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr ""
@@ -10339,7 +10350,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
@@ -10347,7 +10358,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
@@ -10355,7 +10366,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
@@ -10363,7 +10374,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
@@ -10371,10 +10382,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -10382,7 +10393,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -10390,7 +10401,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -10398,7 +10409,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -10406,7 +10417,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -10414,11 +10425,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -10426,7 +10437,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -10434,7 +10445,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -10444,9 +10455,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -10454,7 +10465,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -10462,7 +10473,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -10472,13 +10483,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -10486,7 +10497,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -10494,7 +10505,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -10502,7 +10513,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -10510,7 +10521,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -10518,7 +10529,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -10528,7 +10539,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -10536,7 +10547,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -10544,7 +10555,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -10552,7 +10563,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -10560,7 +10571,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -10568,7 +10579,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -10576,8 +10587,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10585,7 +10596,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -10593,7 +10604,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10601,8 +10612,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -10610,9 +10621,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -10620,7 +10631,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -10628,7 +10639,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -10640,7 +10651,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -10648,7 +10659,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -10656,7 +10667,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -10664,7 +10675,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -10672,7 +10683,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10680,7 +10691,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10688,7 +10699,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10696,7 +10707,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -10704,7 +10715,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10716,7 +10727,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10728,7 +10739,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10740,7 +10751,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10752,7 +10763,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10760,7 +10771,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10772,7 +10783,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10780,8 +10791,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10789,7 +10800,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10797,7 +10808,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10805,7 +10816,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10817,7 +10828,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10825,7 +10836,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10833,9 +10844,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10843,7 +10854,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -10851,7 +10862,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -10859,7 +10870,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -10867,7 +10878,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10875,7 +10886,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10883,7 +10894,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -10891,7 +10902,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10899,7 +10910,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -10907,8 +10918,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10916,7 +10927,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10924,7 +10935,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10932,7 +10943,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10940,7 +10951,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -10952,7 +10963,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -10964,7 +10975,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -10972,8 +10983,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -10981,7 +10992,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -10989,7 +11000,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -10997,7 +11008,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -11005,7 +11016,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -11013,7 +11024,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -11025,7 +11036,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -11037,7 +11048,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -11045,7 +11056,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -11053,7 +11064,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -11061,7 +11072,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -11073,38 +11084,38 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 #, fuzzy
 msgid "application"
 msgstr "Propriétés :"
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr "désactivé"
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr "activé"
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 #, fuzzy
 msgid "ephemeral"
 msgstr "Type : éphémère"
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"
@@ -11127,13 +11138,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -11142,7 +11153,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -11150,7 +11161,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -11161,13 +11172,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -11176,7 +11187,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -11184,15 +11195,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -11202,7 +11213,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -11211,13 +11222,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -11225,26 +11236,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -11253,13 +11264,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 #, fuzzy
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
@@ -11278,7 +11289,7 @@ msgstr ""
 "lxc info [<serveur distant>:]\n"
 "    Pour l'information du serveur LXD."
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -11289,19 +11300,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -11312,7 +11323,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -11324,7 +11335,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 #, fuzzy
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
@@ -11350,7 +11361,7 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -11366,7 +11377,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -11378,7 +11389,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -11386,24 +11397,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -11412,7 +11423,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -11428,7 +11439,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -11436,7 +11447,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -11444,13 +11455,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -11462,7 +11473,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -11471,7 +11482,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -11482,13 +11493,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -11497,19 +11508,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -11519,13 +11530,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -11535,31 +11546,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -11569,21 +11580,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -11592,13 +11603,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -11608,7 +11619,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -11618,7 +11629,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11628,7 +11639,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11638,7 +11649,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11648,7 +11659,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11658,7 +11669,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11672,7 +11683,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -11682,7 +11693,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -11692,69 +11703,69 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 #, fuzzy
 msgid "n"
 msgstr "non"
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr "non"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (o/n/[empreinte]) ?"
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr "veuillez utiliser `incus profile`"
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr "espace utilisé"
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr "sshfs s'est arrêté"
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs monté %q sur %q"
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs non trouvé. Essayez le mode SSH SFTP en utilisant l'option --listen"
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr "espace total"
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr "inaccessible"
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr "utilisé par"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr "o"
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "oui"
 
@@ -12494,9 +12505,9 @@ msgstr "oui"
 #~ "lxc config trust list "
 #~ "[<remote>:]                                           Lister tous les "
 #~ "certificats de confiance.\n"
-#~ "lxc config trust add [<remote>:] "
-#~ "<certfile.crt>                             Ajouter certfile.crt aux hôtes "
-#~ "de confiance.\n"
+#~ "lxc config trust add [<remote>:] <certfile."
+#~ "crt>                             Ajouter certfile.crt aux hôtes de "
+#~ "confiance.\n"
 #~ "lxc config trust remove [<remote>:] [hostname|"
 #~ "fingerprint]                  Supprimer le certificat des hôtes de "
 #~ "confiance.\n"
@@ -12508,8 +12519,8 @@ msgstr "oui"
 #~ "share/c1 path=opt\n"
 #~ "\n"
 #~ "Pour positionner une clé de configuration dans la configuration lxc :\n"
-#~ "    lxc config set [<remote>:]<container> raw.lxc "
-#~ "'lxc.aa_allow_incomplete = 1'\n"
+#~ "    lxc config set [<remote>:]<container> raw.lxc 'lxc."
+#~ "aa_allow_incomplete = 1'\n"
 #~ "\n"
 #~ "Pour écouter sur le port 8443 en IPv4 et IPv6 (vous pouvez omettre 8443 "
 #~ "c'est la valeur par défaut) :\n"
@@ -12699,8 +12710,8 @@ msgstr "oui"
 #~ "lxc image edit [<remote>:]<image>\n"
 #~ "    Edit image, either by launching external editor or reading STDIN.\n"
 #~ "    Example: lxc image edit <image> # launch editor\n"
-#~ "             cat image.yaml | lxc image edit <image> # read from "
-#~ "image.yaml\n"
+#~ "             cat image.yaml | lxc image edit <image> # read from image."
+#~ "yaml\n"
 #~ "\n"
 #~ "lxc image alias create [<remote>:]<alias> <fingerprint>\n"
 #~ "    Create a new alias for an existing image.\n"
@@ -12790,8 +12801,8 @@ msgstr "oui"
 #~ "    Éditer l'image, soit en lançant un éditeur externe ou en lisant "
 #~ "STDIN.\n"
 #~ "    Exemple : lxc image edit <image> # lance l'éditeur\n"
-#~ "              cat image.yaml | lxc image edit <image> # lit depuis "
-#~ "image.yaml\n"
+#~ "              cat image.yaml | lxc image edit <image> # lit depuis image."
+#~ "yaml\n"
 #~ "\n"
 #~ "lxc image alias create [<remote>:]<alias> <fingerprint>\n"
 #~ "    Créer un nouvel alias pour une image existante.\n"
@@ -13385,8 +13396,8 @@ msgstr "oui"
 #~ "  f - Base Image Fingerprint (short)\n"
 #~ "  F - Base Image Fingerprint (long)\n"
 #~ "\n"
-#~ "Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-#~ "\":\n"
+#~ "Custom columns are defined with \"[config:|devices:]key[:name][:"
+#~ "maxWidth]\":\n"
 #~ "  KEY: The (extended) config or devices key to display. If [config:|"
 #~ "devices:] is omitted then it defaults to config key.\n"
 #~ "  NAME: Name to display in the column header.\n"
@@ -13452,8 +13463,8 @@ msgstr "oui"
 #~ "Colonnes en mode rapide : nsacPt\n"
 #~ "\n"
 #~ "Exemple :\n"
-#~ "    lxc list -c n,volatile.base_image:\\BASE "
-#~ "IMAGE\\:0,s46,volatile.eth0.hwaddr:MAC"
+#~ "    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
+#~ "hwaddr:MAC"
 
 #~ msgid "Failed to generate 'lxc.%s.1': %v"
 #~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  Chassis:"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  Motherboard:"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -44,7 +44,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -75,7 +75,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -83,13 +83,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -110,7 +110,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -120,7 +120,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -144,7 +144,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -187,7 +187,7 @@ msgid ""
 "###  user.foo: bar\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -211,7 +211,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -219,7 +219,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -270,7 +270,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -284,7 +284,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -298,7 +298,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -318,7 +318,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -339,7 +339,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -360,97 +360,97 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, node NUMA: %v)"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr "%q bukan suatu peranti blok"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr "%q bukan suatu alamat IP"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q pada pool %q dalam proyek %q (termasuk %d snapshot)"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d lagi)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d tersedia)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, sumber=%q)"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s bukan direktori"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' bukan tipe berkas yang didukung"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(nihil)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partisi %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--console tidak bisa dipakai saat memaksa mematikan instansi"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr "--console tidak bisa dipakai dengan --allx"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr "--console hanya bekerja dengan satu instansi"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty tidak bisa dikombinasikan dengan nama image"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded tidak bisa dipakai dengan server"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -458,24 +458,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgstr "<alias>"
 msgid "<alias> <target>"
 msgstr "<alias> <target>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr "<lokal|global> <query>"
 
@@ -507,42 +507,42 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <nama-baru>"
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr "<remote>: <path>"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<path sumber>... [<remote>:]<instansi>/<path>"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 "<tarball>|<direktori>|<URL> [<rootfs tarball>] [<remote>:] [kunci=nilai...]"
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr "<target>"
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr "=> Query %d:"
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr ""
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr "ALAMAT"
 
@@ -551,61 +551,61 @@ msgstr "ALAMAT"
 msgid "ADDRESSES"
 msgstr "ALAMAT"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr "APP"
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARSITEKTUR"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr "TIPE AUTH"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Terima sertifikat"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -613,23 +613,23 @@ msgstr ""
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -637,11 +637,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -653,15 +653,15 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -670,7 +670,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -678,56 +678,56 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -742,102 +742,102 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr "Alias: %s"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr "Semua proyek"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arsitektur: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arsitektur: %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -845,154 +845,154 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 #, fuzzy
 msgid "Backend description"
 msgstr "deskripsi"
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr "Cadangan:"
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr "Bond:"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr "Merek: %v"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr "Bridge:"
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 #, fuzzy
 msgid "Bucket description"
 msgstr "deskripsi"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Alamat Bus: %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Byte diterima"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Byte dikirim"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "NAMA UMUM"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr "CACAH"
 
@@ -1000,72 +1000,72 @@ msgstr "CACAH"
 msgid "CPU TIME(s)"
 msgstr ""
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr "PENGGUNAAN CPU"
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "Penggunaan CPU (dalam detik)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "Penggunaan CPU:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr "CPU:"
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "DIBUAT"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "DIBUAT PADA"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versi CUDA: %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "Disinggahkan: %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr "Singgahan:"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1074,255 +1074,255 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr "Kartu %d:"
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "Kartu: %s (%s)"
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 #, fuzzy
 msgid "Certificate description"
 msgstr "deskripsi"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "deskripsi"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Kolom"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1333,54 +1333,54 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1388,42 +1388,42 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1431,11 +1431,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1451,141 +1451,141 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr "Core %d"
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr "Core:"
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1593,31 +1593,31 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1625,86 +1625,86 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr "Buat profil"
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr "Buat proyek"
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr "Buat pool penyimpanan"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Dibuat: %s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "Membuat %s"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr "Membuat %s: %%s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr "Membuat instansi"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "DESKRIPSI"
 
@@ -1712,29 +1712,29 @@ msgstr "DESKRIPSI"
 msgid "DISK"
 msgstr "DISK"
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr "PENGGUNAAN DISK"
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr "DRM:"
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr "Tanggal: %s"
@@ -1747,11 +1747,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr "ID VLAN baku"
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1759,51 +1759,51 @@ msgstr ""
 msgid "Delay:"
 msgstr "Tundaan:"
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr "Hapus berkas dalam instansi"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr "Hapus alias image"
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr "Hapus image"
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr "Hapus templat berkas instansi"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr "Hapus snapshot instansi"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr "Hapus instansi"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr "Hapus kunci dari suatu bucket penyimpanan"
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr "Hapus ACL jaringan"
 
@@ -1812,361 +1812,361 @@ msgstr "Hapus ACL jaringan"
 msgid "Delete network address sets"
 msgstr "Hapus zona jaringan"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr "Hapus penerusan jaringan"
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr "Hapus integrasi jaringan"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr "Hapus load balancer jaringan"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr "Hapus peering jaringan"
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr "Hapus record zona jaringan"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr "Hapus zona jaringan"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr "Hapus jaringan"
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr "Hapus profil"
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr "Hapus bucket penyimpanan"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr "Hapus pool penyimpanan"
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr "Hapus peringatan"
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Deskripsi"
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr "Deskripsi: %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr "Perangkat %d:"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr "Perangkat: %s"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "Impor direktori tidak tersedia di platform ini"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "Nonaktifkan autentikasi saat menggunakan pendengar SSH SFTP"
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "Penggunaan disk:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr "Disk:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr "Disk:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2174,7 +2174,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2200,110 +2200,110 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr "Driver: %v"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Driver: %v (%v)"
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr "ENTRI"
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr "KEDALUWARSA PADA"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "TANGGAL KEDALUWARSA"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2311,60 +2311,60 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2373,32 +2373,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2422,47 +2422,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2472,56 +2472,56 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2550,11 +2550,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2569,22 +2569,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr "Kedaluwarsa pada"
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr "Kedaluwarsa: %s"
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr "Kedaluwarsa: tidak pernah"
 
@@ -2592,34 +2592,34 @@ msgstr "Kedaluwarsa: tidak pernah"
 msgid "Export a virtual machine's memory state"
 msgstr ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr "Ekspor dan unduh image"
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr ""
 
@@ -2630,241 +2630,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr "NAMA_BERKAS"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr "SIDIKJARI"
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr "PERTAMA TERLIHAT"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2874,104 +2874,104 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -2987,96 +2987,96 @@ msgstr ""
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3100,7 +3100,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3110,36 +3110,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3152,7 +3152,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3161,200 +3161,200 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3366,66 +3366,66 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3433,306 +3433,306 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 #, fuzzy
 msgid "Image alias description"
 msgstr "deskripsi"
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "deskripsi"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -3742,7 +3742,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3756,58 +3756,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3819,104 +3819,104 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 #, fuzzy
 msgid "Key description"
 msgstr "deskripsi"
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3948,11 +3948,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3974,11 +3974,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4000,11 +4000,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4026,11 +4026,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4052,15 +4052,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4068,11 +4068,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4096,11 +4096,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4123,11 +4123,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4151,15 +4151,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4182,11 +4182,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4207,11 +4207,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4236,11 +4236,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4266,11 +4266,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4294,11 +4294,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4326,19 +4326,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4361,11 +4361,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4438,8 +4438,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4449,15 +4449,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4480,11 +4480,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4507,23 +4507,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4539,11 +4539,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4564,11 +4564,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4590,11 +4590,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4617,11 +4617,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4635,14 +4635,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -4658,11 +4670,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -4688,11 +4700,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4716,11 +4728,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -4743,88 +4755,88 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 #, fuzzy
 msgid "Load balancer description"
 msgstr "deskripsi"
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4832,57 +4844,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -4890,23 +4902,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -4926,32 +4938,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -4959,249 +4971,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5212,164 +5224,164 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5385,218 +5397,218 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr "deskripsi"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5621,171 +5633,171 @@ msgstr "Profil %s diganti nama menjadi %s"
 msgid "Network address set description"
 msgstr "deskripsi"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr "deskripsi"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr "Hapus penerusan jaringan"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5796,19 +5808,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -5816,31 +5828,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5853,173 +5865,173 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 #, fuzzy
 msgid "Peer description"
 msgstr "deskripsi"
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 #, fuzzy
 msgid "Port description"
 msgstr "deskripsi"
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6035,261 +6047,261 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr "ID Produk: %v"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr "Produk: %s"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr "Produk: %v"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "Produk: %v (%v)"
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ditambahkan ke %s"
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s dibuat"
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s dihapus"
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s saat ini tidak diterapkan ke %s"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s dihapus dari %s"
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s diganti nama menjadi %s"
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 #, fuzzy
 msgid "Profile description"
 msgstr "deskripsi"
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr "Profil yang akan diterapkan ke image baru"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr "Profil yang akan diterapkan ke instansi baru"
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr "Profil yang akan diterapkan ke instansi target"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s diterapkan ke %s"
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr "Proyek %s dibuat"
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 #, fuzzy
 msgid "Project description"
 msgstr "deskripsi"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 #, fuzzy
 msgid "Record description"
 msgstr "deskripsi"
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6302,24 +6314,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6329,13 +6341,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6350,40 +6362,40 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6395,44 +6407,44 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6440,49 +6452,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6490,19 +6502,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6510,282 +6522,282 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr "Pulihkan anggota klaster"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 #, fuzzy
 msgid "Rule description"
 msgstr "deskripsi"
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6794,7 +6806,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6803,15 +6815,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6820,11 +6832,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6838,11 +6850,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Tampilkan konfigurasi trust"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6851,11 +6863,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6864,11 +6876,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -6878,11 +6890,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6891,11 +6903,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6904,11 +6916,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6917,15 +6929,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6934,11 +6946,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6947,11 +6959,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6960,11 +6972,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6973,11 +6985,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6995,39 +7007,39 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7035,135 +7047,135 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7172,64 +7184,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr "Tampilkan konfigurasi trust"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7241,19 +7253,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7262,95 +7274,95 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr "Tampilkan proyek saat ini"
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr "Tampilkan remote baku"
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr "Tampilkan konfigurasi yang diperluas"
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr "Tampilkan daftar akses instansi"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr "Tampilkan entri log terkini instansi"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr "Tampilkan sumber daya yang tersedia ke server"
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr "Tampilkan sumber daya yang tersedia ke pool penyimpanan"
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr "Tampilkan ruang terpakai dan bebas dalam byte"
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr "Tampilkan konfigurasi trust"
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr "Tampilkan informasi yang berguna tentang suatu anggota klaster"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr "Tampilkan informasi yang berguna tentang image"
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr "Tampilkan informasi yang berguna tentang pool penyimpanan"
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr "Tampilkan peringatan"
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr "Ukuran dalam GiB dari perangkat loop baru"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr "Ukuran: %.2fMiB"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr "Ukuran: %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 #, fuzzy
 msgid "Snapshot description"
 msgstr "deskripsi"
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr "Volume penyimpanan snapshot"
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "Snapshot itu hanya-baca dan tidak bisa diubah konfigurasinya"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr "Snapshot:"
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr "Soket %d:"
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "Beberapa instansi gagal %s"
@@ -7359,13 +7371,13 @@ msgstr "Beberapa instansi gagal %s"
 msgid "Sorting Method:"
 msgstr "Metode Pengurutan:"
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7373,75 +7385,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7450,95 +7462,95 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr "deskripsi"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7546,15 +7558,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7562,36 +7574,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7602,20 +7614,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -7629,7 +7641,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -7638,62 +7650,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7702,107 +7714,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -7817,18 +7829,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -7838,28 +7850,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7873,265 +7885,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8139,67 +8151,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8208,15 +8220,15 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8224,78 +8236,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8304,120 +8316,120 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr "VF: %d"
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr "ID VLAN"
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr "Pemfilteran VLAN"
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr "ID Vendor: %v"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr "Vendor: %s"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr "Vendor: %v"
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "Vendor: %v (%v)"
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr "Versi: %s"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr "Versi: %v"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr "Hanya Volume"
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 #, fuzzy
 msgid "Volume description"
 msgstr "deskripsi"
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8427,11 +8439,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8448,236 +8460,236 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid "Zone description"
 msgstr "deskripsi"
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>]"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>] [<path>]"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <berkas cadangan> [<nama instansi>]"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.kunci>"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr "[<remote>:] <cert>"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <nama>"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <arah> <kunci>=<nilai>..."
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <kunci>"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <kunci>=<nilai>..."
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <nama-baru>"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [kunci=nilai...]"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<path API>"
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zona>"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zona> <kunci>"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <kunci>=<nilai>..."
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zona> [kunci=nilai...]"
 
@@ -8712,142 +8724,142 @@ msgstr "[<remote>:]<alias> <nama-baru>"
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr "[<remote>:]<Zona> [kunci=nilai...]"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <sidikjari>"
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <nama-baru>"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<sidikjari>"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<grup>"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr "[<remote>:]<grup> <kunci>"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<nama>]"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instansi>"
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "[<remote>:]<instansi> <perangkat> <kunci>"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "[<remote>:]<instansi> <perangkat> <kunci>=<nilai>..."
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "[<remote>:]<instansi> <perangkat> <tipe> [kunci=nilai...]"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instansi> <perangkat> [kunci=nilai...]"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr "[<remote>:]<instansi> <instansi>"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instansi> <nama>..."
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "[<remote>:]<instansi> <nama snapshot lama> <nama snapshot baru>"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instansi> <profil>"
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instansi> <profil>"
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr "[<remote>:]<instansi> <nama snapshot>"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "[<remote>:]<instansi> <snapshot>"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr "[<remote>:]<instansi> <templat>"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "[<remote>:]<instansi> [<remote>:][<instansi>]"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "[<remote>:]<instansi> [<nama snapshot>]"
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "[<remote>:]<instansi> [[<remote>:]<instansi>...]"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "[<remote>:]<instansi> [flags] [--] <baris perintah>"
 
@@ -8856,458 +8868,458 @@ msgstr "[<remote>:]<instansi> [flags] [--] <baris perintah>"
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr "[<remote>:]<instansi> <templat>"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<jaringan> <profil> [<nama perangkat>] [<nama antar muka>]"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<jaringan> [kunci=nilai...]"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operasi>"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <berkas cadangan> [<bucket>]"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <berkas cadangan> [<volume nama>]"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <kunci>"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <kunci>=<nilai>..."
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "[<remote>:]<pool> <bucket> [<path>]"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [kunci=nilai...]"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [kunci=nilai...]"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <kunci>"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <kunci> <nilai>"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <nama lama> <nama baru>"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>]"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot lama> <snapshot baru>"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr "aplikasi"
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr "deskripsi"
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr "dinonaktifkan"
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr "driver"
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr "difungsikan"
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr "galat: %v"
@@ -9330,13 +9342,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9345,7 +9357,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9353,7 +9365,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9364,13 +9376,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9379,7 +9391,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9387,15 +9399,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9405,7 +9417,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9414,13 +9426,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9428,26 +9440,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9456,13 +9468,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9471,7 +9483,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9482,19 +9494,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9505,7 +9517,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9517,7 +9529,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9531,7 +9543,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9547,7 +9559,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9559,7 +9571,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9567,24 +9579,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9593,7 +9605,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9609,7 +9621,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9617,7 +9629,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9625,13 +9637,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9643,7 +9655,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9652,7 +9664,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9663,13 +9675,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9678,19 +9690,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9700,13 +9712,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9716,31 +9728,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9750,21 +9762,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -9773,13 +9785,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9789,7 +9801,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9799,7 +9811,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9809,7 +9821,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9819,7 +9831,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9829,7 +9841,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9839,7 +9851,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9853,7 +9865,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9863,7 +9875,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9873,66 +9885,66 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr "y"
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "ya"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2025-03-22 22:30-0400\n"
+        "POT-Creation-Date: 2025-04-07 21:21+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,19 +16,19 @@ msgstr  "Project-Id-Version: incus\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid   "  Chassis:"
 msgstr  ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid   "  Firmware:"
 msgstr  ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid   "  Motherboard:"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid   "### This is a YAML representation of a storage bucket.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -40,7 +40,7 @@ msgid   "### This is a YAML representation of a storage bucket.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid   "### This is a YAML representation of a storage pool.\n"
         "### Any line starting with a '#' will be ignored.\n"
         "###\n"
@@ -56,7 +56,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -69,19 +69,19 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid   "### This is a YAML representation of the certificate.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### Note that the fingerprint is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 msgid   "### This is a YAML representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -101,7 +101,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -110,7 +110,7 @@ msgid   "### This is a YAML representation of the image properties.\n"
         "###  description: My custom image"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid   "### This is a YAML representation of the instance metadata.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -133,7 +133,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid   "### This is a YAML representation of the network ACL.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -173,7 +173,7 @@ msgid   "### This is a YAML representation of the network address set.\n"
         "###  user.foo: bar\n"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -195,14 +195,14 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid   "### This is a YAML representation of the network integration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -234,7 +234,7 @@ msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid   "### This is a YAML representation of the network peer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -249,7 +249,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -262,7 +262,7 @@ msgid   "### This is a YAML representation of the network zone record.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid   "### This is a YAML representation of the network zone.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -275,7 +275,7 @@ msgid   "### This is a YAML representation of the network zone.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -294,7 +294,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -314,7 +314,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -334,96 +334,96 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid   "%q is not a block device"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid   "%q is not an IP address"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid   "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr  ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid   "%s (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid   "(none)"
 msgstr  ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid   "- Level %d (type: %s): %s"
 msgstr  ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid   "- Partition %d"
 msgstr  ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid   "- Port %d (%s)"
 msgstr  ""
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid   "--console can't be used while forcing instance shutdown"
 msgstr  ""
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid   "--console can't be used with --all"
 msgstr  ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid   "--instance-only can't be passed when the source is a snapshot"
 msgstr  ""
 
@@ -431,23 +431,23 @@ msgstr  ""
 msgid   "--network-port can't be used without --network-address"
 msgstr  ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid   "--target can only be used with clusters"
 msgstr  ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616 cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -459,7 +459,7 @@ msgstr  ""
 msgid   "<alias> <target>"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid   "<local|global> <query>"
 msgstr  ""
 
@@ -479,40 +479,40 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid   "<remote>: <path>"
 msgstr  ""
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid   "<target>"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid   "=> Query %d:"
 msgstr  ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid   "A client certificate is already present"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid   "A client name must be provided"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid   "A cluster member name must be provided"
 msgstr  ""
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid   "ADDRESS"
 msgstr  ""
 
@@ -520,61 +520,61 @@ msgstr  ""
 msgid   "ADDRESSES"
 msgstr  ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid   "ALIAS"
 msgstr  ""
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid   "ALIASES"
 msgstr  ""
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid   "APP"
 msgstr  ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid   "Accept certificate"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid   "Access key (auto-generated if empty)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid   "Access key: %s"
 msgstr  ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid   "Access the expanded configuration"
 msgstr  ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid   "Acknowledge warning"
 msgstr  ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid   "Action %q isn't supported by this tool"
 msgstr  ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid   "Action (defaults to GET)"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid   "Add a network zone record entry"
 msgstr  ""
 
@@ -582,23 +582,23 @@ msgstr  ""
 msgid   "Add addresses to a network address set"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid   "Add instance devices"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid   "Add member to group"
 msgstr  ""
 
@@ -606,11 +606,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -619,15 +619,15 @@ msgid   "Add new remote servers\n"
         "  incus remote add some-name https://LOGIN:PASSWORD@example.com/some/path --protocol=simplestreams\n"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid   "Add new trusted client"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid   "Add new trusted client certificate"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid   "Add new trusted client certificate\n"
         "\n"
         "The following certificate types are supported:\n"
@@ -635,60 +635,60 @@ msgid   "Add new trusted client certificate\n"
         "- metrics\n"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid   "Add new trusted client\n"
         "\n"
         "This will issue a trust token to be used by the client to add itself to the trust store.\n"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1094 cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119 cmd/incus/network_load_balancer.go:1120
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid   "Add profiles to instances"
 msgstr  ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid   "Add rules to an ACL"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid   "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid   "Address to bind to (default: none)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid   "Address to bind to (not including port)"
 msgstr  ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid   "Address: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid   "Address: %v"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid   "Admin secret key: %s"
 msgstr  ""
@@ -703,245 +703,245 @@ msgstr  ""
 msgid   "Alias %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167 cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173 cmd/incus/image_alias.go:419
 msgid   "Alias name missing"
 msgstr  ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid   "Alias: %s"
 msgstr  ""
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid   "Aliases:"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid   "All existing data is lost when joining a cluster, continue?"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid   "All projects"
 msgstr  ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507 cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509 cmd/incus/info.go:655
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid   "Are you joining an existing cluster?"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid   "Attach network interfaces to instances"
 msgstr  ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid   "Attach new custom storage volumes to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid   "Attach new custom storage volumes to profiles"
 msgstr  ""
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid   "Attach to instance consoles"
 msgstr  ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid   "Attach to instance consoles\n"
         "\n"
         "This command allows you to interact with the boot console of an instance\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid   "Auto negotiation: %v"
 msgstr  ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid   "Automatic (non-interactive) mode"
 msgstr  ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid   "Available projects:"
 msgstr  ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid   "Average: %.2f %.2f %.2f"
 msgstr  ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid   "Backend description"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid   "Backend health:"
 msgstr  ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid   "Backing up storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561 cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590 cmd/incus/storage_volume.go:3215
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid   "Backups:"
 msgstr  ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459 cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389 cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415 cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166 cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471 cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397 cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423 cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192 cmd/incus/storage_bucket.go:162
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305 cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179 cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183 cmd/incus/storage_volume.go:667
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid   "Bond:"
 msgstr  ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid   "Both --all and instance name given"
 msgstr  ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid   "Brand: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid   "Bridge:"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid   "Bucket description"
 msgstr  ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid   "Bytes sent"
 msgstr  ""
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid   "CANCELABLE"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid   "COUNT"
 msgstr  ""
 
@@ -949,71 +949,71 @@ msgstr  ""
 msgid   "CPU TIME(s)"
 msgstr  ""
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid   "CPU usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid   "CPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid   "CPUs:"
 msgstr  ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid   "CREATED"
 msgstr  ""
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid   "CREATED AT"
 msgstr  ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid   "Caches:"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:147 cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149 cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid   "Can't bind address %q: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid   "Can't read from environment file: %w"
 msgstr  ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid   "Can't read from stdin: %w"
 msgstr  ""
@@ -1022,201 +1022,201 @@ msgstr  ""
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732 cmd/incus/warning.go:234
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid   "Can't use --auto and --preseed together"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid   "Can't use --dump with other flags"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid   "Can't use --minimal and --auto together"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid   "Can't use --minimal and --preseed together"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid   "Cannot set --volume-only when copying a snapshot"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid   "Card: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid   "Certificate description"
 msgstr  ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid   "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr  ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid   "Chassis"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid   "Checking if the daemon is ready (attempt %d)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid   "Choose %s:"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid   "Cluster group %s created"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid   "Cluster group %s deleted"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid   "Cluster group %s isn't currently applied to %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid   "Cluster group description"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid   "Cluster member %s added to cluster groups %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid   "Cluster member %s added to group %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid   "Cluster member %s is already in group %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61 cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64 cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931 cmd/incus/network.go:1513 cmd/incus/network.go:1606 cmd/incus/network.go:1678 cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531 cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011 cmd/incus/network_load_balancer.go:259 cmd/incus/network_load_balancer.go:341 cmd/incus/network_load_balancer.go:517 cmd/incus/network_load_balancer.go:652 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:906 cmd/incus/network_load_balancer.go:984 cmd/incus/network_load_balancer.go:1098 cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110 cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843 cmd/incus/storage.go:945 cmd/incus/storage.go:1038 cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405 cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750 cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158 cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582 cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976 cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335 cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884 cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140 cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347 cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731 cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897 cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538 cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63 cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66 cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950 cmd/incus/network.go:1540 cmd/incus/network.go:1635 cmd/incus/network.go:1709 cmd/incus/network_forward.go:260 cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542 cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854 cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033 cmd/incus/network_load_balancer.go:264 cmd/incus/network_load_balancer.go:348 cmd/incus/network_load_balancer.go:528 cmd/incus/network_load_balancer.go:667 cmd/incus/network_load_balancer.go:834 cmd/incus/network_load_balancer.go:926 cmd/incus/network_load_balancer.go:1006 cmd/incus/network_load_balancer.go:1123 cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113 cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858 cmd/incus/storage.go:962 cmd/incus/storage.go:1057 cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216 cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414 cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765 cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935 cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182 cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387 cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611 cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597 cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993 cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356 cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946 cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418 cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808 cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978 cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid   "Cluster member name"
 msgstr  ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096 cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424 cmd/incus/config_trust.go:617 cmd/incus/image.go:1093 cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105 cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:139 cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:694 cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565 cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433 cmd/incus/config_trust.go:628 cmd/incus/image.go:1114 cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126 cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64 cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439 cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114 cmd/incus/network_zone.go:118 cmd/incus/operation.go:144 cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751 cmd/incus/snapshot.go:323 cmd/incus/storage.go:707 cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936 cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640 cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid   "Columns"
 msgstr  ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid   "Command line client for Incus"
 msgstr  ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid   "Command line client for Incus\n"
         "\n"
         "All of Incus's features can be driven through the various commands below.\n"
@@ -1225,44 +1225,44 @@ msgid   "Command line client for Incus\n"
         "Custom commands can be defined through aliases, use \"incus alias\" to control those."
 msgstr  ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid   "Compression algorithm to use (`none` for uncompressed)"
 msgstr  ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid   "Config key/value to apply to the new network integration"
 msgstr  ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356 cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726 cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781 cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608 cmd/incus/project.go:409 cmd/incus/storage.go:375 cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322 cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364 cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744 cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797 cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737 cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622 cmd/incus/project.go:417 cmd/incus/storage.go:383 cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349 cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid   "Configuration flags require --auto"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid   "Configure the daemon"
 msgstr  ""
 
@@ -1270,53 +1270,53 @@ msgstr  ""
 msgid   "Configure the refresh delay in seconds"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid   "Connecting to the daemon (attempt %d)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid   "Copy custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid   "Copy images between servers"
 msgstr  ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid   "Copy images between servers\n"
         "\n"
         "The auto-update flag instructs the server to keep this image up to date.\n"
         "It requires the source to be an alias and for it to be public."
 msgstr  ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid   "Copy instances within or in between servers"
 msgstr  ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid   "Copy instances within or in between servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -1327,171 +1327,171 @@ msgid   "Copy instances within or in between servers\n"
         "The pull transfer mode is the default as it is compatible with all server versions.\n"
 msgstr  ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid   "Copy profiles"
 msgstr  ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67 cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid   "Core %d"
 msgstr  ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid   "Cores:"
 msgstr  ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid   "Couldn't statfs %s: %w"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid   "Create a cluster group"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid   "Create a new %s pool?"
 msgstr  ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid   "Create a virtual machine"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid   "Create an empty instance"
 msgstr  ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid   "Create files and directories in instances"
 msgstr  ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid   "Create instance backup: %w"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid   "Create instance snapshot"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid   "Create instance snapshots\n"
         "\n"
         "When --stateful is used, attempt to checkpoint the instance's\n"
         "running state, including process memory state, TCP connections, ..."
 msgstr  ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid   "Create instances from images"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid   "Create key for a storage bucket"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid   "Create network integrations"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid   "Create new instance file templates"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid   "Create new network ACLs"
 msgstr  ""
 
@@ -1499,75 +1499,75 @@ msgstr  ""
 msgid   "Create new network address sets"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid   "Create new network forwards"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:332 cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339 cmd/incus/network_load_balancer.go:340
 msgid   "Create new network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid   "Create new network peering"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid   "Create new network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid   "Create new network zones"
 msgstr  ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid   "Create new networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid   "Create profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid   "Create projects"
 msgstr  ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid   "Create storage pools"
 msgstr  ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664 cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666 cmd/incus/storage_volume.go:1475
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid   "Creating the instance"
 msgstr  ""
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511 cmd/incus/config_trust.go:442 cmd/incus/image.go:1122 cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136 cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164 cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454 cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133 cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933 cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569 cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527 cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512 cmd/incus/config_trust.go:451 cmd/incus/image.go:1143 cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157 cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164 cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455 cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136 cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953 cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580 cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1575,29 +1575,29 @@ msgstr  ""
 msgid   "DISK"
 msgstr  ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid   "DISK USAGE"
 msgstr  ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid   "DRIVER"
 msgstr  ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid   "DRM:"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid   "Daemon still not running after %ds timeout (%v)"
 msgstr  ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid   "Daemon still running after %ds timeout"
 msgstr  ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid   "Date: %s"
 msgstr  ""
@@ -1610,11 +1610,11 @@ msgstr  ""
 msgid   "Debug commands for instances"
 msgstr  ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1622,51 +1622,51 @@ msgstr  ""
 msgid   "Delay:"
 msgstr  ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid   "Delete a cluster group"
 msgstr  ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid   "Delete custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid   "Delete files in instances"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid   "Delete images"
 msgstr  ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid   "Delete instance file templates"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid   "Delete instance snapshots"
 msgstr  ""
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid   "Delete instances"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid   "Delete network ACLs"
 msgstr  ""
 
@@ -1674,196 +1674,196 @@ msgstr  ""
 msgid   "Delete network address sets"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid   "Delete network forwards"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid   "Delete network integrations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:813 cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830 cmd/incus/network_load_balancer.go:831
 msgid   "Delete network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid   "Delete network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid   "Delete network zones"
 msgstr  ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid   "Delete networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid   "Delete profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid   "Delete projects"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid   "Delete storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid   "Delete storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322 cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511 cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693 cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998 cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241 cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453 cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621 cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900 cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:360 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278 cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597 cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800 cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302 cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694 cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30 cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135 cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377 cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343 cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614 cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928 cmd/incus/network.go:1086 cmd/incus/network.go:1289 cmd/incus/network.go:1447 cmd/incus/network.go:1507 cmd/incus/network.go:1603 cmd/incus/network.go:1675 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255 cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386 cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577 cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874 cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033 cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93 cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247 cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523 cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680 cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909 cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617 cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:333 cmd/incus/network_load_balancer.go:441 cmd/incus/network_load_balancer.go:509 cmd/incus/network_load_balancer.go:619 cmd/incus/network_load_balancer.go:649 cmd/incus/network_load_balancer.go:814 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:903 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1095 cmd/incus/network_load_balancer.go:1170 cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253 cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663 cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321 cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628 cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950 cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285 cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462 cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538 cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30 cmd/incus/operation.go:63 cmd/incus/operation.go:114 cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359 cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642 cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970 cmd/incus/profile.go:1030 cmd/incus/profile.go:1119 cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105 cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443 cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802 cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995 cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514 cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102 cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409 cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837 cmd/incus/storage.go:941 cmd/incus/storage.go:1035 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270 cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487 cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848 cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044 cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219 cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426 cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580 cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769 cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964 cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324 cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569 cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881 cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124 cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287 cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472 cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567 cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815 cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982 cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268 cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327 cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522 cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710 cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021 cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268 cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484 cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36 cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189 cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341 cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622 cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763 cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903 cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52 cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96 cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752 cmd/incus/config.go:884 cmd/incus/config_device.go:26 cmd/incus/config_device.go:81 cmd/incus/config_device.go:225 cmd/incus/config_device.go:324 cmd/incus/config_device.go:409 cmd/incus/config_device.go:513 cmd/incus/config_device.go:631 cmd/incus/config_device.go:638 cmd/incus/config_device.go:773 cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:69 cmd/incus/config_template.go:139 cmd/incus/config_template.go:195 cmd/incus/config_template.go:297 cmd/incus/config_template.go:371 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608 cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815 cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43 cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33 cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306 cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704 cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140 cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386 cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38 cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350 cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627 cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947 cmd/incus/network.go:1107 cmd/incus/network.go:1312 cmd/incus/network.go:1472 cmd/incus/network.go:1534 cmd/incus/network.go:1632 cmd/incus/network.go:1706 cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97 cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397 cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060 cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93 cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247 cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94 cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337 cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029 cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86 cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231 cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417 cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:340 cmd/incus/network_load_balancer.go:450 cmd/incus/network_load_balancer.go:520 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:923 cmd/incus/network_load_balancer.go:1003 cmd/incus/network_load_balancer.go:1104 cmd/incus/network_load_balancer.go:1120 cmd/incus/network_load_balancer.go:1197 cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30 cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258 cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94 cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327 cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507 cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642 cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971 cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117 cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574 cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112 cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368 cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657 cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991 cmd/incus/profile.go:1053 cmd/incus/profile.go:1144 cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108 cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452 cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817 cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016 cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45 cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686 cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301 cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525 cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105 cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418 cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852 cmd/incus/storage.go:958 cmd/incus/storage.go:1054 cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101 cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277 cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867 cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245 cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455 cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58 cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259 cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589 cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782 cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981 cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592 cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943 cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190 cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357 cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545 cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642 cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894 cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065 cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid   "Detach custom storage volumes from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid   "Detach custom storage volumes from profiles"
 msgstr  ""
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid   "Device %d:"
 msgstr  ""
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid   "Device %s overridden for %s"
 msgstr  ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid   "Device Address: %v"
 msgstr  ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293 cmd/incus/config_device.go:557 cmd/incus/config_device.go:578 cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299 cmd/incus/config_device.go:569 cmd/incus/config_device.go:590 cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid   "Device doesn't exist"
 msgstr  ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid   "Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid   "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid   "Device: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid   "Didn't get name of new instance from the server"
 msgstr  ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid   "Disable pseudo-terminal allocation"
 msgstr  ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid   "Disk usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid   "Disk:"
 msgstr  ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid   "Disks:"
 msgstr  ""
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid   "Display clusters from all projects"
 msgstr  ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid   "Display images from all projects"
 msgstr  ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid   "Display instances from all projects"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid   "Display profiles from all projects"
 msgstr  ""
 
@@ -1871,7 +1871,7 @@ msgstr  ""
 msgid   "Display resource usage info per instance"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid   "Display storage pool buckets from all projects"
 msgstr  ""
 
@@ -1896,106 +1896,106 @@ msgid   "Displays CPU usage, memory usage, and disk usage per instance\n"
         "  u - CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid   "Do you want to configure a new local storage pool?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid   "Do you want to configure a new remote storage pool?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid   "Do you want to configure a new storage pool?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid   "Do you want to continue without thin provisioning?"
 msgstr  ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid   "Down delay"
 msgstr  ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid   "Driver: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid   "Dump YAML config to stdout"
 msgstr  ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid   "During incremental copy, exclude source snapshots earlier than latest target snapshot"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid   "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid   "ENTRIES"
 msgstr  ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid   "EXISTING: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634 cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645 cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid   "EXPIRES AT"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid   "Edit files in instances"
 msgstr  ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid   "Edit image properties"
 msgstr  ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid   "Edit instance file templates"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid   "Edit instance metadata files"
 msgstr  ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
@@ -2003,79 +2003,79 @@ msgstr  ""
 msgid   "Edit network address set configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid   "Edit network integration configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:648 cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663 cmd/incus/network_load_balancer.go:664
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid   "Edit storage bucket configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid   "Edit storage bucket key as YAML"
 msgstr  ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid   "Edit storage volume configurations as YAML\n"
         "\n"
         "If the type is not specified, incus assumes the type is \"custom\".\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125 cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454 cmd/incus/config_trust.go:642 cmd/incus/image.go:1140 cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151 cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88 cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464 cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144 cmd/incus/network_zone.go:151 cmd/incus/operation.go:171 cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777 cmd/incus/snapshot.go:350 cmd/incus/storage.go:733 cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941 cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679 cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150 cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463 cmd/incus/config_trust.go:653 cmd/incus/image.go:1161 cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172 cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465 cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147 cmd/incus/network_zone.go:154 cmd/incus/operation.go:176 cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778 cmd/incus/snapshot.go:357 cmd/incus/storage.go:746 cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961 cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755 cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid   "Enable clustering on a single non-clustered server"
 msgstr  ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid   "Enable clustering on a single non-clustered server\n"
         "\n"
         "  This command turns a non-clustered server into the first member of a new\n"
@@ -2094,39 +2094,39 @@ msgstr  ""
 msgid   "Enter new delay in seconds:"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid   "Entry TTL"
 msgstr  ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid   "Ephemeral instance"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid   "Error connecting to existing cluster member %q: %v"
 msgstr  ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid   "Error creating decoder: %v"
 msgstr  ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid   "Error decoding data: %v"
 msgstr  ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581 cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404 cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672 cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638 cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260 cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907 cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052 cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034 cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609 cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404 cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673 cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652 cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288 cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923 cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2160
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2136,49 +2136,49 @@ msgstr  ""
 msgid   "Error setting term size %s"
 msgstr  ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025 cmd/incus/network.go:1575 cmd/incus/network_acl.go:546 cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666 cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632 cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254 cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901 cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046 cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028 cmd/incus/network.go:1603 cmd/incus/network_acl.go:560 cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667 cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646 cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282 cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917 cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111 cmd/incus/storage_volume.go:2154
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid   "Error while executing alias expansion: %s\n"
 msgstr  ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid   "Error: %v\n"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid   "Event type to listen for"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid   "Execute a SQL query against the local or global database"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid   "Execute a SQL query against the local or global database\n"
         "\n"
         "  The local database is specific to the cluster member you target the\n"
@@ -2205,11 +2205,11 @@ msgid   "Execute a SQL query against the local or global database\n"
         "  set of database queries to fix some data inconsistency."
 msgstr  ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid   "Execute commands in instances"
 msgstr  ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid   "Execute commands in instances\n"
         "\n"
         "The command is executed directly using exec, so there is no shell and\n"
@@ -2222,21 +2222,21 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486 cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508 cmd/incus/storage_volume.go:1558
 msgid   "Expires at"
 msgstr  ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid   "Expires: never"
 msgstr  ""
 
@@ -2244,33 +2244,33 @@ msgstr  ""
 msgid   "Export a virtual machine's memory state"
 msgstr  ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid   "Export and download images"
 msgstr  ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid   "Export custom storage volume"
 msgstr  ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid   "Export instance backups"
 msgstr  ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid   "Export storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid   "Export storage buckets as tarball."
 msgstr  ""
 
@@ -2279,240 +2279,240 @@ msgid   "Export the current memory state of a running virtual machine into a dum
         "		This can be useful for debugging or analysis purposes."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid   "Exporting backup of storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124 cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145 cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid   "FQDN"
 msgstr  ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid   "Failed checking instance exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid   "Failed connecting to the daemon (attempt %d): %v"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid   "Failed converting token operation to certificate add token: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid   "Failed converting token operation to join token: %w"
 msgstr  ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid   "Failed deleting instance %q in project %q: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid   "Failed generating trust certificate: %w"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid   "Failed getting existing storage pools: %w"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid   "Failed import request: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid   "Failed loading network %q: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid   "Failed parsing validation response: %w"
 msgstr  ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid   "Failed to add server cert to cluster: %w"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid   "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr  ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid   "Failed to close export file: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid   "Failed to configure cluster: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid   "Failed to connect to get server info: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid   "Failed to connect to local daemon: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid   "Failed to connect to target cluster node %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid   "Failed to create backup: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid   "Failed to delete original instance after copying it: %w"
 msgstr  ""
@@ -2522,102 +2522,102 @@ msgstr  ""
 msgid   "Failed to dump instance memory: %w"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid   "Failed to fetch storage bucket backup: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid   "Failed to join cluster: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid   "Failed to load configuration: %s"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid   "Failed to parse dump response: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid   "Failed to parse servers: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid   "Failed to parse the preseed: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid   "Failed to read from stdin: %w"
 msgstr  ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid   "Failed to rename export file: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid   "Failed to render the config: %w"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid   "Failed to request dump: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid   "Failed to retrieve cluster information: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid   "Failed to retrieve current cluster config: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid   "Failed to retrieve current server config: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49 cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79 cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50 cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80 cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid   "Failed to retrieve current server configuration: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid   "Failed to retrieve current server network configuration for project %q: %w"
 msgstr  ""
@@ -2632,95 +2632,95 @@ msgstr  ""
 msgid   "Failed to retrieve list of storage pools: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid   "Failed to setup trust relationship with cluster: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid   "Failed to update cluster member state: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid   "Failed validation request: %w"
 msgstr  ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid   "Family: %v"
 msgstr  ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid   "Fetch instance backup file: %w"
 msgstr  ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137 cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141 cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid   "Force a particular evacuation action"
 msgstr  ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid   "Force delete the project and everything it contains."
 msgstr  ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid   "Force deleting files, directories, and subdirectories"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid   "Force the instance to stop"
 msgstr  ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid   "Force the removal of running instances"
 msgstr  ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -2739,7 +2739,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid   "Forces a connection to the console, even if there is already an active session"
 msgstr  ""
 
@@ -2747,19 +2747,19 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151 cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616 cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135 cmd/incus/network.go:1106 cmd/incus/network.go:1310 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871 cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539 cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508 cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585 cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154 cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627 cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137 cmd/incus/network.go:1127 cmd/incus/network.go:1333 cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61 cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113 cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890 cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550 cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322 cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617 cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr  ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid   "Format (json|pretty|yaml)"
 msgstr  ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid   "Format (man|md|rest|yaml)"
 msgstr  ""
 
@@ -2771,7 +2771,7 @@ msgstr  ""
 msgid   "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr  ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid   "Forward delay"
 msgstr  ""
 
@@ -2780,198 +2780,198 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534 cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536 cmd/incus/info.go:542
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid   "Frequency: %vMhz"
 msgstr  ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid   "GLOBAL"
 msgstr  ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid   "GPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid   "GPUs:"
 msgstr  ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid   "Generate the client certificate"
 msgstr  ""
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid   "Get current load balancer status"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid   "Get current load-balacner status"
 msgstr  ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid   "Get image properties"
 msgstr  ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid   "Get the key as a cluster group property"
 msgstr  ""
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid   "Get the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid   "Get the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid   "Get the key as a network peer property"
 msgstr  ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid   "Get the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid   "Get the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid   "Get the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid   "Get the key as a storage bucket property"
 msgstr  ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid   "Get the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid   "Get values for cluster group configuration keys"
 msgstr  ""
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid   "Get values for network ACL configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid   "Get values for network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:440 cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449 cmd/incus/network_load_balancer.go:450
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid   "Get values for storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid   "Get values for storage volume configuration keys\n"
         "\n"
         "If the type is not specified, incus assumes the type is \"custom\".\n"
@@ -2980,66 +2980,66 @@ msgid   "Get values for storage volume configuration keys\n"
         "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid   "Host interface"
 msgstr  ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid   "Hostname"
 msgstr  ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid   "ID"
 msgstr  ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid   "ID: %d"
 msgstr  ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid   "ID: %s"
 msgstr  ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid   "IMAGES"
 msgstr  ""
 
@@ -3047,299 +3047,299 @@ msgstr  ""
 msgid   "INSTANCE NAME"
 msgstr  ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid   "IOMMU group: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid   "IP addresses"
 msgstr  ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid   "IP addresses:"
 msgstr  ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid   "IPV4"
 msgstr  ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid   "IPV6"
 msgstr  ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid   "IPv4 uplink address"
 msgstr  ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid   "IPv6 uplink address"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid   "If an instance is running, stop it and then rebuild it"
 msgstr  ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid   "If this is your first time running Incus on this machine, you should also run: incus admin init"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid   "Image alias description"
 msgstr  ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid   "Image already up to date."
 msgstr  ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid   "Import backups of storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid   "Import custom storage volumes."
 msgstr  ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root."
 msgstr  ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid   "Import images into the image store"
 msgstr  ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid   "Import instance backups"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid   "Import storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid   "Import type needs to be \"backup\" or \"iso\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid   "Importing ISO images requires a volume name to be set"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid   "Importing bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid   "Importing instance: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid   "Include environment variables from file"
 msgstr  ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid   "Include less common commands"
 msgstr  ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid   "Incus - Command line client"
 msgstr  ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid   "Infiniband:"
 msgstr  ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid   "Instance Only"
 msgstr  ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid   "Instance description"
 msgstr  ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid   "Instance type"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid   "Invalid IP address or DNS name"
 msgstr  ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512 cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541 cmd/incus/storage_volume.go:3166
 #, c-format
 msgid   "Invalid URL %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid   "Invalid argument %q"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid   "Invalid arguments"
 msgstr  ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517 cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546 cmd/incus/storage_volume.go:3171
 #, c-format
 msgid   "Invalid backup name segment in path %q: %w"
 msgstr  ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid   "Invalid boolean value: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid   "Invalid cluster join token: %w"
 msgstr  ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid   "Invalid database type"
 msgstr  ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid   "Invalid expiration date: %w"
 msgstr  ""
@@ -3349,7 +3349,7 @@ msgstr  ""
 msgid   "Invalid format %q"
 msgstr  ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid   "Invalid format: %s"
 msgstr  ""
@@ -3363,55 +3363,55 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid   "Invalid join token: %w"
 msgstr  ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid   "Invalid key=value configuration: %s"
 msgstr  ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid   "Invalid peer type"
 msgstr  ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252 cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029 cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272 cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094 cmd/incus/storage_volume.go:3024
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -3423,100 +3423,100 @@ msgstr  ""
 msgid   "Invalid sorting type provided"
 msgstr  ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid   "Invalid type %q"
 msgstr  ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid   "IsSM: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid   "Joining an existing cluster requires root privileges"
 msgstr  ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid   "Kernel Version"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid   "Key description"
 msgstr  ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid   "LAST SEEN"
 msgstr  ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid   "LIMIT"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338 cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147 cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528 cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361 cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150 cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539 cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid   "LOCATION"
 msgstr  ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid   "Last used: never"
 msgstr  ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid   "Launching the instance"
-msgstr  ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid   "Link detected: %v"
 msgstr  ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid   "Link detected: %v"
+msgstr  ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid   "List DHCP leases"
 msgstr  ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid   "List DHCP leases\n"
         "\n"
         "Default column layout: hmitL\n"
@@ -3547,11 +3547,11 @@ msgstr  ""
 msgid   "List aliases"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid   "List all active certificate add tokens\n"
         "\n"
         "Default column layout: ntE\n"
@@ -3572,11 +3572,11 @@ msgid   "List all active certificate add tokens\n"
         "  E - Expires At"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid   "List all active cluster member join tokens\n"
         "\n"
         "Default column layout: nte\n"
@@ -3597,11 +3597,11 @@ msgid   "List all active cluster member join tokens\n"
         "  E - Expires At"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid   "List all the cluster groups\n"
         "\n"
         "Default column layout: ndm\n"
@@ -3622,11 +3622,11 @@ msgid   "List all the cluster groups\n"
         "  m - Member"
 msgstr  ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid   "List all the cluster members\n"
         "\n"
         "	The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3647,15 +3647,15 @@ msgid   "List all the cluster members\n"
         "    m - Message"
 msgstr  ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid   "List all warnings"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid   "List available network ACL"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid   "List available network ACLS"
 msgstr  ""
 
@@ -3663,11 +3663,11 @@ msgstr  ""
 msgid   "List available network address sets"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid   "List available network forwards"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid   "List available network forwards\n"
         "\n"
         "Default column layout: ldDp\n"
@@ -3690,11 +3690,11 @@ msgid   "List available network forwards\n"
         "L - Location of the network zone (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid   "List available network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid   "List available network load balancers\n"
         "\n"
         "Default column layout: ldp\n"
@@ -3716,11 +3716,11 @@ msgid   "List available network load balancers\n"
         "  L - Location of the operation (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid   "List available network peers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid   "List available network peers\n"
         "\n"
         "Default column layout: ndpts\n"
@@ -3743,15 +3743,15 @@ msgid   "List available network peers\n"
         "  s - State"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid   "List available network zone records"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid   "List available network zoneS"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid   "List available network zone\n"
         "\n"
         "Default column layout: nDSdus\n"
@@ -3773,11 +3773,11 @@ msgid   "List available network zone\n"
         "  u - Used by"
 msgstr  ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid   "List available networks"
 msgstr  ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid   "List available networks\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3797,11 +3797,11 @@ msgid   "List available networks\n"
         "u - Used by (count)"
 msgstr  ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid   "List available storage pools"
 msgstr  ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid   "List available storage pools\n"
         "\n"
         "Default column layout: nDSdus\n"
@@ -3825,11 +3825,11 @@ msgid   "List available storage pools\n"
         "  s - state"
 msgstr  ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid   "List background operations"
 msgstr  ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid   "List background operations\n"
         "\n"
         "Default column layout: itdscCl\n"
@@ -3854,11 +3854,11 @@ msgid   "List background operations\n"
         "  L - Location of the operation (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid   "List image aliases"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid   "List image aliases\n"
         "\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
@@ -3881,11 +3881,11 @@ msgid   "List image aliases\n"
         "  d - Description"
 msgstr  ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid   "List images"
 msgstr  ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -3912,19 +3912,19 @@ msgid   "List images\n"
         "    t - Type"
 msgstr  ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid   "List instance devices"
 msgstr  ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid   "List instance file templates"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid   "List instance snapshots"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid   "List instance snapshots\n"
         "\n"
         "Default column layout: nTEs\n"
@@ -3946,11 +3946,11 @@ msgid   "List instance snapshots\n"
         "  s - Stateful"
 msgstr  ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid   "List instances"
 msgstr  ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid   "List instances\n"
         "\n"
@@ -4026,15 +4026,15 @@ msgid   "List instances\n"
         "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid   "List network ACLs across all projects"
 msgstr  ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid   "List network allocations in use"
 msgstr  ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid   "List network allocations in use\n"
         "Default column layout: uatnm\n"
         "\n"
@@ -4056,11 +4056,11 @@ msgid   "List network allocations in use\n"
         "  m - Mac Address"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid   "List network integrations"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid   "List network integrations\n"
         "\n"
         "Default column layout: ndtu\n"
@@ -4082,23 +4082,23 @@ msgid   "List network integrations\n"
         "	u - Used by"
 msgstr  ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid   "List networks in all projects"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid   "List of projects to restrict the certificate to"
 msgstr  ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid   "List profiles"
 msgstr  ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid   "List profiles\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4113,11 +4113,11 @@ msgid   "List profiles\n"
         "u - Used By"
 msgstr  ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid   "List projects"
 msgstr  ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid   "List projects\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4137,11 +4137,11 @@ msgid   "List projects\n"
         "u - Used By"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid   "List storage bucket keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid   "List storage bucket keys\n"
         "\n"
         "Default column layout: ndr\n"
@@ -4162,11 +4162,11 @@ msgid   "List storage bucket keys\n"
         "  r - Role"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid   "List storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid   "List storage buckets\n"
         "\n"
         "Default column layout: ndL\n"
@@ -4188,11 +4188,11 @@ msgid   "List storage buckets\n"
         "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid   "List storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid   "List storage volume snapshots\n"
         "\n"
         "	The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4205,13 +4205,22 @@ msgid   "List storage volume snapshots\n"
         "		E - Expiry"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid   "List storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid   "List storage volumes\n"
         "\n"
+        "A single keyword like \"vol\" which will list any storage volume with a name starting by \"vol\".\n"
+        "A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+        "A key/value pair where the key is a storage volume field name. Multiple values must be delimited by ','.\n"
+        "\n"
+        "Examples:\n"
+        "  - \"type=custom\" will list all custom storage volumes\n"
+        "  - \"type=custom content_type=block\" will list all custom block storage volumes\n"
+        "\n"
+        "== Columns ==\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
         "that control which image attributes to output when displaying in table\n"
         "or csv format.\n"
@@ -4227,11 +4236,11 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid   "List the available remotes"
 msgstr  ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid   "List the available remotes\n"
         "\n"
         "Default column layout: nupaPsg\n"
@@ -4256,11 +4265,11 @@ msgid   "List the available remotes\n"
         "  g - Global"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid   "List trusted clients"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid   "List trusted clients\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4282,11 +4291,11 @@ msgid   "List trusted clients\n"
         "	p - Newline-separated list of projects"
 msgstr  ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid   "List warnings"
 msgstr  ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid   "List warnings\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4308,87 +4317,87 @@ msgid   "List warnings\n"
         "    t - Type"
 msgstr  ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid   "Load balancer description"
 msgstr  ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid   "Load:"
 msgstr  ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid   "Log:"
 msgstr  ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid   "Logical router"
 msgstr  ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid   "Logical switch"
 msgstr  ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid   "Login with username %q and password %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid   "Login without username and password"
 msgstr  ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid   "Low level administration tools for inspecting and recovering clusters."
 msgstr  ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid   "Low-level cluster administration commands"
 msgstr  ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid   "Lower device"
 msgstr  ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid   "Lower devices"
 msgstr  ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid   "MAC address"
 msgstr  ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid   "MANAGED"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid   "MEMBERS"
 msgstr  ""
 
@@ -4396,57 +4405,57 @@ msgstr  ""
 msgid   "MEMORY"
 msgstr  ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid   "MEMORY USAGE"
 msgstr  ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid   "MESSAGE"
 msgstr  ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid   "MII Frequency"
 msgstr  ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid   "MTU"
 msgstr  ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid   "Make image public"
 msgstr  ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid   "Make the image public"
 msgstr  ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid   "Manage and attach instances to networks"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid   "Manage cluster groups"
 msgstr  ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid   "Manage cluster members"
 msgstr  ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid   "Manage cluster roles"
 msgstr  ""
 
@@ -4454,23 +4463,23 @@ msgstr  ""
 msgid   "Manage command aliases"
 msgstr  ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid   "Manage devices"
 msgstr  ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid   "Manage image aliases"
 msgstr  ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid   "Manage images"
 msgstr  ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid   "Manage images\n"
         "\n"
         "Instances are created from images. Those images were themselves\n"
@@ -4488,31 +4497,31 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19 cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20 cmd/incus/admin_other.go:21
 msgid   "Manage incus daemon"
 msgstr  ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid   "Manage instance and server configuration options"
 msgstr  ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid   "Manage instance file templates"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid   "Manage instance metadata files"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid   "Manage instance snapshots"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid   "Manage network ACL rules"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid   "Manage network ACLs"
 msgstr  ""
 
@@ -4520,209 +4529,209 @@ msgstr  ""
 msgid   "Manage network address sets"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid   "Manage network forward ports"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid   "Manage network forwards"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid   "Manage network integrations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:887 cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906 cmd/incus/network_load_balancer.go:907
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1079 cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103 cmd/incus/network_load_balancer.go:1104
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid   "Manage network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid   "Manage network zone record entries"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid   "Manage network zone records"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid   "Manage network zones"
 msgstr  ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid   "Manage profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid   "Manage projects"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid   "Manage storage bucket keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid   "Manage storage bucket keys."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid   "Manage storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid   "Manage storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid   "Manage storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid   "Manage storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid   "Manage storage volumes\n"
         "\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid   "Manage trusted clients"
 msgstr  ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid   "Manage warnings"
 msgstr  ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid   "Manually trigger the generation of a client certificate"
 msgstr  ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid   "Maximum number of VFs: %d"
 msgstr  ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid   "Mdev profiles:"
 msgstr  ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid   "Member %q already has role %q"
 msgstr  ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid   "Memory usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid   "Memory:"
 msgstr  ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid   "Minimal configuration (non-interactive)"
 msgstr  ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid   "Minimum level for log messages (only available when using pretty format)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid   "Minimum size is 1GiB"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237 cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432 cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776 cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082 cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262 cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442 cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792 cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289 cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid   "Missing bucket name"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313 cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314 cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519 cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658 cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82 cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553 cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659 cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83 cmd/incus/cluster_role.go:151
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219 cmd/incus/config_template.go:115 cmd/incus/config_template.go:170 cmd/incus/config_template.go:224 cmd/incus/config_template.go:325 cmd/incus/config_template.go:396 cmd/incus/profile.go:145 cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225 cmd/incus/config_template.go:119 cmd/incus/config_template.go:176 cmd/incus/config_template.go:232 cmd/incus/config_template.go:335 cmd/incus/config_template.go:408 cmd/incus/profile.go:149 cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid   "Missing instance name"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187 cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212 cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid   "Missing key name"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364 cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568 cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874 cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052 cmd/incus/network_load_balancer.go:296 cmd/incus/network_load_balancer.go:367 cmd/incus/network_load_balancer.go:469 cmd/incus/network_load_balancer.go:554 cmd/incus/network_load_balancer.go:722 cmd/incus/network_load_balancer.go:854 cmd/incus/network_load_balancer.go:944 cmd/incus/network_load_balancer.go:1021 cmd/incus/network_load_balancer.go:1136 cmd/incus/network_load_balancer.go:1211 cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372 cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580 cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892 cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075 cmd/incus/network_load_balancer.go:302 cmd/incus/network_load_balancer.go:375 cmd/incus/network_load_balancer.go:479 cmd/incus/network_load_balancer.go:566 cmd/incus/network_load_balancer.go:738 cmd/incus/network_load_balancer.go:872 cmd/incus/network_load_balancer.go:965 cmd/incus/network_load_balancer.go:1044 cmd/incus/network_load_balancer.go:1162 cmd/incus/network_load_balancer.go:1239 cmd/incus/network_load_balancer.go:1349
 msgid   "Missing listen address"
 msgstr  ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264 cmd/incus/config_device.go:358 cmd/incus/config_device.go:432 cmd/incus/config_device.go:544 cmd/incus/config_device.go:673 cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270 cmd/incus/config_device.go:366 cmd/incus/config_device.go:442 cmd/incus/config_device.go:556 cmd/incus/config_device.go:687 cmd/incus/config_device.go:810
 msgid   "Missing name"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284 cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423 cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678 cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846 cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292 cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435 cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696 cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868 cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid   "Missing network ACL name"
 msgstr  ""
 
@@ -4730,107 +4739,107 @@ msgstr  ""
 msgid   "Missing network address set name"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203 cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377 cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645 cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204 cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646 cmd/incus/network_integration.go:757
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491 cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763 cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401 cmd/incus/network.go:1479 cmd/incus/network.go:1545 cmd/incus/network.go:1637 cmd/incus/network_forward.go:208 cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564 cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870 cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048 cmd/incus/network_load_balancer.go:211 cmd/incus/network_load_balancer.go:292 cmd/incus/network_load_balancer.go:363 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:550 cmd/incus/network_load_balancer.go:718 cmd/incus/network_load_balancer.go:850 cmd/incus/network_load_balancer.go:940 cmd/incus/network_load_balancer.go:1017 cmd/incus/network_load_balancer.go:1132 cmd/incus/network_load_balancer.go:1207 cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209 cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601 cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501 cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779 cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425 cmd/incus/network.go:1505 cmd/incus/network.go:1573 cmd/incus/network.go:1667 cmd/incus/network_forward.go:212 cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368 cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576 cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888 cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071 cmd/incus/network_load_balancer.go:215 cmd/incus/network_load_balancer.go:298 cmd/incus/network_load_balancer.go:371 cmd/incus/network_load_balancer.go:475 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:734 cmd/incus/network_load_balancer.go:868 cmd/incus/network_load_balancer.go:961 cmd/incus/network_load_balancer.go:1040 cmd/incus/network_load_balancer.go:1158 cmd/incus/network_load_balancer.go:1235 cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213 cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380 cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615 cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid   "Missing network name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533 cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785 cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983 cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364 cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544 cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802 cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005 cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609 cmd/incus/network_zone.go:1668
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid   "Missing network zone record name"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376 cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605 cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384 cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619 cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447 cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981 cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233 cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428 cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680 cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985 cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621 cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024 cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620 cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397 cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617 cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855 cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457 cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999 cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239 cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438 cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694 cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204 cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410 cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207 cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631 cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823 cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042 cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653 cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693 cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935 cmd/incus/storage_volume.go:3014
 msgid   "Missing pool name"
 msgstr  ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562 cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070 cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576 cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094 cmd/incus/profile.go:1177
 msgid   "Missing profile name"
 msgstr  ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363 cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838 cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371 cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854 cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid   "Missing project name"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid   "Missing required arguments"
 msgstr  ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid   "Missing target directory"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid   "Missing target network or integration"
 msgstr  ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid   "Mode"
 msgstr  ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid   "Model: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid   "Model: %v"
 msgstr  ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid   "Monitor a local or remote server"
 msgstr  ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid   "Monitor a local or remote server\n"
         "\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670 cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684 cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid   "Move custom storage volumes between pools"
 msgstr  ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid   "Move instances within or in between servers"
 msgstr  ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid   "Move instances within or in between servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -4841,200 +4850,200 @@ msgid   "Move instances within or in between servers\n"
         "The pull transfer mode is the default as it is compatible with all server versions.\n"
 msgstr  ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115 cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438 cmd/incus/config_trust.go:632 cmd/incus/list.go:589 cmd/incus/network.go:1131 cmd/incus/network_acl.go:172 cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453 cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:932 cmd/incus/profile.go:759 cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763 cmd/incus/snapshot.go:339 cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140 cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:643 cmd/incus/list.go:511 cmd/incus/network.go:1152 cmd/incus/network_acl.go:176 cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454 cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140 cmd/incus/network_zone.go:952 cmd/incus/profile.go:776 cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764 cmd/incus/snapshot.go:346 cmd/incus/storage.go:732 cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951 cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid   "NAME"
 msgstr  ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid   "NAT"
 msgstr  ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid   "NETWORKS"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid   "NEW: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid   "NIC:"
 msgstr  ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid   "NICs:"
 msgstr  ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204 cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618 cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645 cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209 cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656 cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid   "NO"
 msgstr  ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291 cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293 cmd/incus/info.go:380
 #, c-format
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid   "NVIDIA information:"
 msgstr  ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484 cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506 cmd/incus/storage_volume.go:1556
 msgid   "Name"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid   "Name of the CEPHfs volume:"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid   "Name of the OSD storage pool"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid   "Name of the existing %s pool or dataset:"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:620 cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623 cmd/incus/admin_init_interactive.go:724
 msgid   "Name of the existing CEPH cluster"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid   "Name of the existing CEPHfs cluster"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid   "Name of the existing OSD storage pool"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid   "Name of the existing bridge or host interface:"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid   "Name of the new storage pool"
 msgstr  ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid   "Name of the shared LVM volume group:"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid   "Name of the storage backend (%s):"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid   "Name of the storage backend to use (%s)"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980 cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000 cmd/incus/storage_volume.go:1446
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid   "Name: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid   "Network ACL description"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid   "Network Zone %s deleted"
 msgstr  ""
@@ -5058,168 +5067,168 @@ msgstr  ""
 msgid   "Network address set description"
 msgstr  ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid   "Network description"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid   "Network forward description"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid   "Network integration %s created"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid   "Network integration %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid   "Network integration %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid   "Network name"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid   "Network peer %s created"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid   "Network peer %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid   "Network peer %s is in unexpected state %q"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid   "Network usage:"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid   "No %s storage backends available"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid   "No device found for this network"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid   "No load-balancer health information available"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid   "No matching backend found"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid   "No matching port(s) found"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid   "No matching rule(s) found"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid   "No storage backends available"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid   "No text editor found, please set the EDITOR environment variable"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid   "No unknown storage pools or volumes found. Nothing to do."
 msgstr  ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid   "No value found in %q"
 msgstr  ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -5228,19 +5237,19 @@ msgstr  ""
 msgid   "None of --storage-pool, --storage-create-device or --storage-create-loop may be used with the 'dir' backend"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid   "Number of placement groups"
 msgstr  ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid   "OS"
 msgstr  ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid   "OS Version"
 msgstr  ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid   "OVN:"
 msgstr  ""
 
@@ -5248,31 +5257,31 @@ msgstr  ""
 msgid   "One or more provided address isn't currently in the set"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid   "Only https URLs are supported for oci and simplestreams"
 msgstr  ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -5284,167 +5293,167 @@ msgstr  ""
 msgid   "Open the web interface"
 msgstr  ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid   "Operating System:"
 msgstr  ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid   "Override the source project"
 msgstr  ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid   "PCI device:"
 msgstr  ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid   "PCI devices:"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid   "PEER"
 msgstr  ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid   "PID"
 msgstr  ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid   "PORTS"
 msgstr  ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid   "PROCESSES"
 msgstr  ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130 cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170 cmd/incus/network_zone.go:136 cmd/incus/profile.go:760 cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704 cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151 cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170 cmd/incus/network_zone.go:139 cmd/incus/profile.go:777 cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739 cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid   "PROJECT"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid   "PROJECTS"
 msgstr  ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid   "Packets sent"
 msgstr  ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid   "Partitions:"
 msgstr  ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid   "Password rejected for %q"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid   "Path %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid   "Path to the existing block device:"
 msgstr  ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid   "Pause instances"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid   "Peer description"
 msgstr  ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid   "Please create those missing entries and then hit ENTER:"
 msgstr  ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid   "Please provide join token:"
 msgstr  ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid   "Pool name cannot be empty"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid   "Port description"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid   "Port to bind to"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid   "Port to bind to (default: %d)"
 msgstr  ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid   "Port type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid   "Ports:"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid   "Pre-seed mode, expects YAML config from stdin"
 msgstr  ""
 
@@ -5460,246 +5469,246 @@ msgstr  ""
 msgid   "Press CTRL-C to exit"
 msgstr  ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:357 cmd/incus/image.go:465 cmd/incus/network.go:814 cmd/incus/network_acl.go:727 cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782 cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609 cmd/incus/project.go:410 cmd/incus/storage.go:376 cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323 cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423 cmd/incus/config.go:278 cmd/incus/config.go:353 cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262 cmd/incus/config_trust.go:365 cmd/incus/image.go:475 cmd/incus/network.go:830 cmd/incus/network_acl.go:745 cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818 cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798 cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738 cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623 cmd/incus/project.go:418 cmd/incus/storage.go:384 cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350 cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid   "Print help"
 msgstr  ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid   "Print the raw response"
 msgstr  ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid   "Product ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid   "Product: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid   "Product: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid   "Profile description"
 msgstr  ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid   "Profiles:"
 msgstr  ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid   "Profiles: "
 msgstr  ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid   "Project description"
 msgstr  ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid   "Properties:"
 msgstr  ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid   "Property not found"
 msgstr  ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid   "Protocol: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid   "Provided certificate path doesn't exist: %s"
 msgstr  ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid   "Proxy timeout (exits when no connections)"
 msgstr  ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid   "Public image server"
 msgstr  ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid   "Publish instances as images"
 msgstr  ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid   "Push files into instances"
 msgstr  ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid   "RESOURCE"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid   "RESTRICTED"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid   "ROLE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid   "ROLES"
 msgstr  ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid   "Rebuild as an empty instance"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid   "Record description"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid   "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid   "Recover missing instances and volumes from existing and unknown storage pools\n"
         "\n"
         "  This command is mostly used for disaster recovery. It will ask you about unknown storage pools and attempt to\n"
@@ -5707,24 +5716,24 @@ msgid   "Recover missing instances and volumes from existing and unknown storage
         "  pools but are not in the database. It will then offer to recreate these database records."
 msgstr  ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid   "Refresh images"
 msgstr  ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -5734,12 +5743,12 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931 cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931 cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
@@ -5754,38 +5763,38 @@ msgstr  ""
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid   "Remote trust token"
 msgstr  ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid   "Removable: %v"
 msgstr  ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid   "Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
@@ -5797,43 +5806,43 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid   "Remove all ports that match"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid   "Remove member from group"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1169 cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196 cmd/incus/network_load_balancer.go:1197
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -5841,48 +5850,48 @@ msgstr  ""
 msgid   "Remove remotes"
 msgstr  ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid   "Remove snapshot %s from %s (yes/no): "
 msgstr  ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid   "Remove trusted client"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376 cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385 cmd/incus/image_alias.go:386
 msgid   "Rename aliases"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid   "Rename custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid   "Rename instance snapshots"
 msgstr  ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid   "Rename instances"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid   "Rename network ACLs"
 msgstr  ""
 
@@ -5890,19 +5899,19 @@ msgstr  ""
 msgid   "Rename network address sets"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid   "Rename network integrations"
 msgstr  ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid   "Rename networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid   "Rename profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid   "Rename projects"
 msgstr  ""
 
@@ -5910,310 +5919,310 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid   "Rename storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid   "Resources:"
 msgstr  ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid   "Restart instances"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid   "Restore cluster member"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid   "Restore instance from snapshots\n"
         "\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid   "Restore instance snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid   "Restrict the certificate to one or more projects"
 msgstr  ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid   "Resume instances"
 msgstr  ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid   "Rows affected: %d"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid   "Rule description"
 msgstr  ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid   "Run a local API proxy"
 msgstr  ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid   "Run a local API proxy for the remote"
 msgstr  ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid   "Run again a specific project"
 msgstr  ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid   "Run against all instances"
 msgstr  ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid   "Run against all projects"
 msgstr  ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid   "SEVERITY"
 msgstr  ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid   "SIZE"
 msgstr  ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid   "SKU: %v"
 msgstr  ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid   "SOURCE"
 msgstr  ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid   "SSH SFTP listening on %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid   "STARTED AT"
 msgstr  ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138 cmd/incus/network_peer.go:136 cmd/incus/operation.go:157 cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159 cmd/incus/network_peer.go:139 cmd/incus/operation.go:162 cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid   "STATE"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid   "STATEFUL"
 msgstr  ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid   "STATIC"
 msgstr  ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid   "STATUS"
 msgstr  ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid   "STP"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid   "Scanning for unknown volumes..."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid   "Secret key (auto-generated if empty)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid   "Secret key: %s"
 msgstr  ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid   "Send a raw query to the server"
 msgstr  ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid   "Serial Number: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid   "Serial: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid   "Serial: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277 cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305 cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid   "Server isn't part of a cluster"
 msgstr  ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid   "Server protocol (incus, oci or simplestreams)"
 msgstr  ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid   "Server: %s"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid   "Set a cluster group's configuration keys"
 msgstr  ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid   "Set device configuration keys"
 msgstr  ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid   "Set image properties"
 msgstr  ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid   "Set network ACL configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid   "Set network ACL configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6224,125 +6233,125 @@ msgstr  ""
 msgid   "Set network address set configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid   "Set network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid   "Set network integration configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network integration set [<remote>:]<network integration> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid   "Set network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid   "Set network peer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid   "Set storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid   "Set storage bucket configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid   "Set storage pool configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6356,39 +6365,39 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid   "Set the key as a cluster group property"
 msgstr  ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid   "Set the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
@@ -6396,135 +6405,135 @@ msgstr  ""
 msgid   "Set the key as a network address set property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid   "Set the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid   "Set the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid   "Set the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid   "Set the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid   "Set the key as a storage bucket property"
 msgstr  ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid   "Setup device based storage using DEVICE"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid   "Setup loop based storage with SIZE in GiB"
 msgstr  ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid   "Show all information messages"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid   "Show cluster group configurations"
 msgstr  ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid   "Show details of a cluster member"
 msgstr  ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid   "Show details on a background operation"
 msgstr  ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid   "Show events from all projects"
 msgstr  ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid   "Show full device configuration"
 msgstr  ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid   "Show image properties"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid   "Show instance or server configurations"
 msgstr  ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid   "Show instance snapshot configuration"
 msgstr  ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid   "Show less common commands"
 msgstr  ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid   "Show network ACL configurations"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid   "Show network ACL log"
 msgstr  ""
 
@@ -6532,63 +6541,63 @@ msgstr  ""
 msgid   "Show network address set configuration"
 msgstr  ""
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid   "Show network configurations"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid   "Show network forward configurations"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid   "Show network integration options"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:255 cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260 cmd/incus/network_load_balancer.go:261
 msgid   "Show network load balancer configurations"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid   "Show network peer configurations"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid   "Show network zone configurations"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid   "Show network zone record configuration"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid   "Show project options"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid   "Show storage bucket configurations"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid   "Show storage bucket key configurations"
 msgstr  ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid   "Show storage volume configurations\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
@@ -6597,113 +6606,113 @@ msgid   "Show storage volume configurations\n"
         "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid   "Show storage volume snapshhot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid   "Show storage volume snapshot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid   "Show storage volume state information\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid   "Show the current project"
 msgstr  ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid   "Show the default remote"
 msgstr  ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid   "Show the instance's access list"
 msgstr  ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid   "Show the instance's recent log entries"
 msgstr  ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid   "Show the used and free space in bytes"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid   "Show trust configurations"
 msgstr  ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid   "Show useful information about images"
 msgstr  ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid   "Show warning"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid   "Size in GiB of the new loop device"
 msgstr  ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid   "Size: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid   "Snapshot description"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid   "Snapshots:"
 msgstr  ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid   "Some instances failed to %s"
 msgstr  ""
@@ -6712,11 +6721,11 @@ msgstr  ""
 msgid   "Sorting Method:"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid   "Source of the storage pool (block device, volume group, dataset, path, ... as applicable):"
 msgstr  ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid   "Source:"
 msgstr  ""
 
@@ -6724,75 +6733,75 @@ msgstr  ""
 msgid   "Start instances"
 msgstr  ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid   "Started: %s"
 msgstr  ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid   "State"
 msgstr  ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid   "Stateful"
 msgstr  ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid   "Stop instances"
 msgstr  ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid   "Stop the instance if currently running"
 msgstr  ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid   "Stopping instance failed!"
 msgstr  ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid   "Stopping the instance failed: %s"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid   "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid   "Storage bucket %q created"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid   "Storage bucket %q deleted"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid   "Storage bucket key %q added"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid   "Storage bucket key %q removed"
 msgstr  ""
@@ -6801,93 +6810,93 @@ msgstr  ""
 msgid   "Storage has already been configured"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid   "Storage pool %q is already on recover list"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid   "Storage pool %q of type %q"
 msgstr  ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid   "Storage pool %s created"
 msgstr  ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid   "Storage pool %s deleted"
 msgstr  ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid   "Storage pool description"
 msgstr  ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34 cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35 cmd/incus/move.go:65
 msgid   "Storage pool name"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid   "Storage pool to use or create"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid   "Storage volume snapshot %s deleted from %s"
 msgstr  ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid   "Store the instance state"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid   "Successfully updated cluster certificates"
 msgstr  ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid   "Supported modes: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -6895,15 +6904,15 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid   "System:"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid   "TAKEN AT"
 msgstr  ""
 
@@ -6911,31 +6920,31 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130 cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132 cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78 cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135 cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684 cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151 cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153 cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79 cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138 cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719 cmd/incus/warning.go:225
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid   "Taken at"
 msgstr  ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid   "Target path must be a directory"
 msgstr  ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid   "Tell the daemon to shutdown all instances and exit"
 msgstr  ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid   "Tell the daemon to shutdown all instances and exit\n"
         "\n"
         "  This will tell the daemon to start a clean shutdown of all instances,\n"
@@ -6945,20 +6954,20 @@ msgid   "Tell the daemon to shutdown all instances and exit\n"
         "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid   "The %s storage pool already exists"
 msgstr  ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid   "The LVM thin provisioning tools couldn't be found on the system"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid   "The LVM thin provisioning tools couldn't be found.\n"
         "LVM can still be used without thin provisioning but this will disable over-provisioning,\n"
         "increase the space requirements and creation time of images, instances and snapshots.\n"
@@ -6967,65 +6976,65 @@ msgid   "The LVM thin provisioning tools couldn't be found.\n"
         "and make sure that your user can see and run the \"thin_check\" command before running \"init\" again."
 msgstr  ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid   "The \"cluster\" subcommand requires access to internal server data.\n"
         "To do so, it's actually part of the \"incusd\" binary rather than \"incus\".\n"
         "\n"
         "You can invoke it through \"incusd cluster\"."
 msgstr  ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid   "The client automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180 cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184 cmd/incus/config_device.go:454
 msgid   "The device already exists"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid   "The following unknown storage pools have been found:"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid   "The following unknown volumes have been found:"
 msgstr  ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid   "The instance is currently running, stop it first or pass --force"
 msgstr  ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid   "The is no config key to set on an instance snapshot."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid   "The key %q does not exist on cluster group %q"
 msgstr  ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr  ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
@@ -7034,106 +7043,106 @@ msgstr  ""
 msgid   "The minimum refresh rate is 10s"
 msgstr  ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid   "The property %q does not exist on the cluster group %q: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid   "The property %q does not exist on the instance %q: %v"
 msgstr  ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid   "The property %q does not exist on the network %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid   "The property %q does not exist on the network integration %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid   "The property %q does not exist on the network peer %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid   "The property %q does not exist on the network zone %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid   "The property %q does not exist on the storage bucket %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid   "The property with tag %q does not exist"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid   "The recovery process will be scanning the following storage pools:"
 msgstr  ""
 
@@ -7147,16 +7156,16 @@ msgstr  ""
 msgid   "The requested backend '%s' isn't supported by init"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid   "The requested interface doesn't exist. Please choose another one."
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid   "The requested network bridge \"%s\" already exists. Please choose another name."
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid   "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr  ""
@@ -7165,27 +7174,27 @@ msgstr  ""
 msgid   "The server doesn't have a web UI installed"
 msgstr  ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684 cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid   "The type to create (file, symlink, or directory)"
 msgstr  ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid   "This client hasn't been configured to use a remote server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote server.\n"
         "\n"
@@ -7196,241 +7205,241 @@ msgstr  ""
 msgid   "This command isn't supported on Windows"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid   "This server currently has the following storage pools:"
 msgstr  ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid   "This server is already clustered"
 msgstr  ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid   "This server is not available on the network"
 msgstr  ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid   "Threads:"
 msgstr  ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid   "Timestamps:"
 msgstr  ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid   "To attach a network to an instance, use: incus network attach"
 msgstr  ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid   "To create a new network, use: incus network create"
 msgstr  ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387 cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703 cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389 cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536 cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538 cmd/incus/info.go:544
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid   "Transmit policy"
 msgstr  ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid   "Try `incus info --show-log %s%s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid   "Type"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid   "Type of certificate"
 msgstr  ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434 cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988 cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436 cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008 cmd/incus/storage_volume.go:1455
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid   "URL"
 msgstr  ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid   "USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid   "USB device:"
 msgstr  ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174 cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76 cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139 cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723 cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77 cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142 cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736 cmd/incus/storage_volume.go:1723
 msgid   "USED BY"
 msgstr  ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid   "UUID"
 msgstr  ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid   "Unable to connect to any of the cluster members specified in join token"
 msgstr  ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid   "Unavailable remote server"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131 cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462 cmd/incus/config_trust.go:648 cmd/incus/image.go:1148 cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157 cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94 cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470 cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150 cmd/incus/network_zone.go:157 cmd/incus/operation.go:177 cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783 cmd/incus/snapshot.go:356 cmd/incus/storage.go:739 cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947 cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685 cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156 cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469 cmd/incus/config_trust.go:659 cmd/incus/image.go:1167 cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178 cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95 cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471 cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153 cmd/incus/network_zone.go:160 cmd/incus/operation.go:182 cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784 cmd/incus/snapshot.go:363 cmd/incus/storage.go:752 cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967 cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761 cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid   "Unknown key: %s"
 msgstr  ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid   "Unset a cluster group's configuration keys"
 msgstr  ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid   "Unset image properties"
 msgstr  ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
@@ -7438,82 +7447,82 @@ msgstr  ""
 msgid   "Unset network address set configuration keys"
 msgstr  ""
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid   "Unset network forward keys"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid   "Unset network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid   "Unset network peer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid   "Unset network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid   "Unset storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid   "Unset storage volume configuration keys\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid   "Unset the key as a cluster group property"
 msgstr  ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid   "Unset the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
@@ -7521,76 +7530,76 @@ msgstr  ""
 msgid   "Unset the key as a network address set property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid   "Unset the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid   "Unset the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid   "Unset the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid   "Unset the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid   "Unset the key as a storage bucket property"
 msgstr  ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid   "Up delay"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
@@ -7599,115 +7608,115 @@ msgstr  ""
 msgid   "Updated interval to %v"
 msgstr  ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid   "Upper devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535 cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537 cmd/incus/info.go:543
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid   "User aborted configuration"
 msgstr  ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234 cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239 cmd/incus/snapshot.go:263
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid   "VFs: %d"
 msgstr  ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid   "VLAN ID"
 msgstr  ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid   "VLAN filtering"
 msgstr  ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid   "VLAN:"
 msgstr  ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid   "Vendor ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid   "Vendor: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374 cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:412
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid   "Vendor: %v (%v)"
 msgstr  ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid   "Version: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid   "Version: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid   "Volume Only"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid   "Volume description"
 msgstr  ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid   "WWN: %s"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid   "Wait for the daemon to be ready to process requests"
 msgstr  ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid   "Wait for the daemon to be ready to process requests\n"
         "\n"
         "  This command will block until the daemon is reachable over its REST API and\n"
@@ -7715,11 +7724,11 @@ msgid   "Wait for the daemon to be ready to process requests\n"
         "  containers."
 msgstr  ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid   "We detected that you are running inside an unprivileged container.\n"
         "This means that unless you manually configured your host otherwise,\n"
         "you will not have enough uids and gids to allocate to your containers.\n"
@@ -7735,216 +7744,216 @@ msgstr  ""
 msgid   "Web server running at: %s"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid   "What IP address or DNS name should be used to reach this server?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid   "What IPv4 address should be used?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid   "What IPv6 address should be used?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid   "What member name should be used to identify this server in the cluster?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid   "What should the new bridge be called?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid   "Where should this storage pool store its data?"
 msgstr  ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid   "Whether or not to only backup the instance (without snapshots)"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid   "Whether or not to restore the instance's running state from snapshot (if available)"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid   "Wipe the instance root disk and re-initialize with a new image (or empty volume)."
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid   "Would you like a YAML \"init\" preseed to be printed?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid   "Would you like stale cached images to be updated automatically?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid   "Would you like the server to be available over the network?"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid   "Would you like those to be recovered?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid   "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid   "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid   "Would you like to continue with scanning for lost volumes?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid   "Would you like to create a new btrfs subvolume under %s?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid   "Would you like to create a new local network bridge?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid   "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid   "Would you like to have your containers share their parent's allocation?"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid   "Would you like to recover another storage pool?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid   "Would you like to use an existing bridge or host interface?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid   "Would you like to use an existing empty block device (e.g. a disk or partition)?"
 msgstr  ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid   "Would you like to use clustering?"
 msgstr  ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207 cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212 cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631 cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658 cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid   "YES"
 msgstr  ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid   "You are currently missing the following:"
 msgstr  ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid   "You can't pass -t and -T at the same time"
 msgstr  ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid   "Zone description"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074 cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31 cmd/incus/network.go:1083 cmd/incus/network_acl.go:91 cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:111 cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669 cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70 cmd/incus/webui.go:17
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099 cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33 cmd/incus/network.go:1104 cmd/incus/network_acl.go:94 cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414 cmd/incus/network_zone.go:91 cmd/incus/operation.go:116 cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid   "[<remote>:] <cert>"
 msgstr  ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253 cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260 cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid   "[<remote>:]<ACL> <key>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid   "[<remote>:]<ACL> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626 cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640 cmd/incus/network_zone.go:768
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
@@ -7972,135 +7981,135 @@ msgstr  ""
 msgid   "[<remote>:]<address-set> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid   "[<remote>:]<alias>"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid   "[<remote>:]<alias> <fingerprint>"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751 cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764 cmd/incus/config_trust.go:886
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277 cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278 cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid   "[<remote>:]<group> <key>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid   "[<remote>:]<group> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid   "[<remote>:]<image> <remote>:"
 msgstr  ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid   "[<remote>:]<image> [<remote>:]<instance>"
 msgstr  ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752 cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185 cmd/incus/config_template.go:286 cmd/incus/console.go:36 cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767 cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190 cmd/incus/config_template.go:295 cmd/incus/console.go:38 cmd/incus/snapshot.go:299
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid   "[<remote>:]<instance> <device> <key>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid   "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid   "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid   "[<remote>:]<instance> <instance>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid   "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr  ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid   "[<remote>:]<instance> <snapshot name>"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid   "[<remote>:]<instance> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131 cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136 cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid   "[<remote>:]<instance> <template>"
 msgstr  ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid   "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid   "[<remote>:]<instance> [<snapshot name>]"
 msgstr  ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81 cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79 cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid   "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr  ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid   "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr  ""
 
@@ -8108,427 +8117,427 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--format]"
 msgstr  ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr  ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690 cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451 cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707 cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482 cmd/incus/cluster.go:1512
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619 cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620 cmd/incus/cluster_group.go:824
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid   "[<remote>:]<name>"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228 cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:730
 msgid   "[<remote>:]<network integration>"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid   "[<remote>:]<network integration> <key>"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid   "[<remote>:]<network integration> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid   "[<remote>:]<network integration> <new-name>"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid   "[<remote>:]<network integration> <type>"
 msgstr  ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926 cmd/incus/network.go:1287 cmd/incus/network.go:1601 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97 cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945 cmd/incus/network.go:1310 cmd/incus/network.go:1630 cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100 cmd/incus/network_peer.go:87
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678 cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254 cmd/incus/network_load_balancer.go:647 cmd/incus/network_load_balancer.go:811 cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693 cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259 cmd/incus/network_load_balancer.go:662 cmd/incus/network_load_balancer.go:828 cmd/incus/network_load_balancer.go:1319
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631 cmd/incus/network_load_balancer.go:439 cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644 cmd/incus/network_load_balancer.go:448 cmd/incus/network_load_balancer.go:630
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid   "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid   "[<remote>:]<network> <peer name>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid   "[<remote>:]<network> <peer_name>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid   "[<remote>:]<network> <peer_name> <[target project/]<target network or integration> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid   "[<remote>:]<network> <peer_name> <key>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489 cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500 cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid   "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275 cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid   "[<remote>:]<pool> <bucket>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812 cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153 cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829 cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177 cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid   "[<remote>:]<pool> <bucket> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid   "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid   "[<remote>:]<pool> <bucket> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid   "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid   "[<remote>:]<pool> <driver> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid   "[<remote>:]<pool> <key>"
 msgstr  ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid   "[<remote>:]<pool> <old name> <new name>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid   "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid   "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322 cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343 cmd/incus/storage_volume.go:2188
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754 cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504 cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769 cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517 cmd/incus/profile.go:1142
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid   "[<remote>:]<profile> <device> <key>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid   "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305 cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312 cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330 cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361 cmd/incus/network_zone.go:1492
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid   "application"
 msgstr  ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid   "current"
 msgstr  ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid   "description"
 msgstr  ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid   "disabled"
 msgstr  ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid   "driver"
 msgstr  ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid   "enabled"
 msgstr  ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid   "ephemeral"
 msgstr  ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid   "error: %v"
 msgstr  ""
@@ -8548,12 +8557,12 @@ msgid   "incus alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid   "incus cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid   "incus cluster group assign foo default,bar\n"
         "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -8561,14 +8570,14 @@ msgid   "incus cluster group assign foo default,bar\n"
         "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid   "incus cluster group create g1\n"
         "\n"
         "incus cluster group create g1 < config.yaml\n"
         "	Create a cluster group with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid   "incus config device add [<remote>:]instance1 <device-name> disk source=/share/c1 path=/opt\n"
         "    Will mount the host's /share/c1 onto /opt in the instance.\n"
         "\n"
@@ -8576,12 +8585,12 @@ msgid   "incus config device add [<remote>:]instance1 <device-name> disk source=
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid   "incus config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid   "incus config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -8589,14 +8598,14 @@ msgid   "incus config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid   "incus config template create u1 t1\n"
         "\n"
         "incus config template create u1 t1 < config.tpl\n"
         "    Create template t1 for instance u1 from config.tpl"
 msgstr  ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid   "incus create images:ubuntu/22.04 u1\n"
         "\n"
         "incus create images:ubuntu/22.04 u1 < config.yaml\n"
@@ -8611,7 +8620,7 @@ msgid   "incus debug dump-memory vm1 memory-dump.elf --format=elf\n"
         "    Creates an ELF format memory dump of the vm1 instance."
 msgstr  ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid   "incus exec c1 bash\n"
         "	Run the \"bash\" command in instance \"c1\"\n"
         "\n"
@@ -8619,34 +8628,34 @@ msgid   "incus exec c1 bash\n"
         "	Run the \"ls -lh /\" command in instance \"c1\""
 msgstr  ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid   "incus export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid   "incus file create foo/bar\n"
         "	   To create a file /bar in the foo instance.\n"
         "incus file create --type=symlink foo/bar baz\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid   "incus file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid   "incus file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid   "incus file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid   "incus image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -8654,12 +8663,12 @@ msgid   "incus image edit <image>\n"
         "    Load the image properties from a YAML file"
 msgstr  ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid   "incus import backup0.tar.gz\n"
         "    Create a new instance using backup0.tar.gz as the source."
 msgstr  ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid   "incus info [<remote>:]<instance> [--show-log]\n"
         "    For instance information.\n"
         "\n"
@@ -8667,7 +8676,7 @@ msgid   "incus info [<remote>:]<instance> [--show-log]\n"
         "    For server information."
 msgstr  ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid   "incus launch images:ubuntu/22.04 u1\n"
         "\n"
         "incus launch images:ubuntu/22.04 u1 < config.yaml\n"
@@ -8683,7 +8692,7 @@ msgid   "incus launch images:ubuntu/22.04 u1\n"
         "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr  ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid   "incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"
@@ -8693,7 +8702,7 @@ msgid   "incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:et
         "  List instances with their running state and user comment."
 msgstr  ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid   "incus monitor --type=logging\n"
         "    Only show log messages.\n"
         "\n"
@@ -8704,7 +8713,7 @@ msgid   "incus monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid   "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"
@@ -8715,7 +8724,7 @@ msgid   "incus move [<remote>:]<source instance> [<remote>:][<destination instan
         "    Rename a snapshot."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid   "incus network acl create a1\n"
         "\n"
         "incus network acl create a1 < config.yaml\n"
@@ -8729,7 +8738,7 @@ msgid   "incus network address-set create as1\n"
         "    Create network address set with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid   "incus network create foo\n"
         "    Create a new network called foo\n"
         "\n"
@@ -8740,33 +8749,33 @@ msgid   "incus network create foo\n"
         "    Create a new OVN network called bar using baz as its uplink network"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid   "incus network forward create n1 127.0.0.1\n"
         "\n"
         "incus network forward create n1 127.0.0.1 < config.yaml\n"
         "    Create a new network forward for network n1 from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid   "incus network integration create o1 ovn\n"
         "\n"
         "incus network integration create o1 ovn < config.yaml\n"
         "    Create network integration o1 of type ovn with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid   "incus network integration edit <network integration> < network-integration.yaml\n"
         "    Update a network integration using the content of network-integration.yaml"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid   "incus network load-balancer create n1 127.0.0.1\n"
         "\n"
         "incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
         "    Create network load-balancer for network n1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid   "incus network peer create default peer1 web/default\n"
         "    Create a new peering between network \"default\" in the current project and network \"default\" in the \"web\" project\n"
         "\n"
@@ -8778,26 +8787,26 @@ msgid   "incus network peer create default peer1 web/default\n"
         "	in the file config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid   "incus network zone create z1\n"
         "\n"
         "incus network zone create z1 < config.yaml\n"
         "    Create network zone z1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid   "incus network zone record create z1 r1\n"
         "\n"
         "incus network zone record create z1 r1 < config.yaml\n"
         "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid   "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid   "incus profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -8808,7 +8817,7 @@ msgid   "incus profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid   "incus profile create p1\n"
         "    Create a profile named p1\n"
         "\n"
@@ -8816,7 +8825,7 @@ msgid   "incus profile create p1\n"
         "    Create a profile named p1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid   "incus profile device add [<remote>:]profile1 <device-name> disk source=/share/c1 path=/opt\n"
         "    Will mount the host's /share/c1 onto /opt in the instance.\n"
         "\n"
@@ -8824,12 +8833,12 @@ msgid   "incus profile device add [<remote>:]profile1 <device-name> disk source=
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid   "incus profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid   "incus project create p1\n"
         "    Create a project named p1\n"
         "\n"
@@ -8837,17 +8846,17 @@ msgid   "incus project create p1\n"
         "    Create a project named p1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid   "incus project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid   "incus query -X DELETE --wait /1.0/instances/c1\n"
         "    Delete local instance \"c1\"."
 msgstr  ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid   "incus snapshot create u1 snap0\n"
         "	Create a snapshot of \"u1\" called \"snap0\".\n"
         "\n"
@@ -8855,12 +8864,12 @@ msgid   "incus snapshot create u1 snap0\n"
         "	Create a snapshot of \"u1\" called \"snap0\" with the configuration from \"config.yaml\"."
 msgstr  ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid   "incus snapshot restore u1 snap0\n"
         "    Restore instance u1 to snapshot snap0"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid   "incus storage bucket create p1 b01\n"
         "	Create a new storage bucket named b01 in storage pool p1\n"
         "\n"
@@ -8868,27 +8877,27 @@ msgid   "incus storage bucket create p1 b01\n"
         "	Create a new storage bucket named b01 in storage pool p1 using the content of config.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid   "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
         "    Update a storage bucket using the content of bucket.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid   "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
         "    Update a storage bucket key using the content of key.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid   "incus storage bucket export default b1\n"
         "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid   "incus storage bucket import default backup0.tar.gz\n"
         "		Create a new storage bucket using backup0.tar.gz as the source."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid   "incus storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1.\n"
         "\n"
@@ -8896,17 +8905,17 @@ msgid   "incus storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1 using the content of config.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid   "incus storage bucket key show default data foo\n"
         "    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid   "incus storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid   "incus storage create s1 dir\n"
         "\n"
         "incus storage create s1 dir < config.yaml\n"
@@ -8914,12 +8923,12 @@ msgid   "incus storage create s1 dir\n"
         "	"
 msgstr  ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid   "incus storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid   "incus storage volume create default foo\n"
         "    Create custom storage volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8927,7 +8936,7 @@ msgid   "incus storage volume create default foo\n"
         "    Create custom storage volume \"foo\" in pool \"default\" with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid   "incus storage volume edit default container/c1\n"
         "    Edit container storage volume \"c1\" in pool \"default\"\n"
         "\n"
@@ -8935,7 +8944,7 @@ msgid   "incus storage volume edit default container/c1\n"
         "    Edit custom storage volume \"foo\" in pool \"default\" using the content of volume.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid   "incus storage volume get default data size\n"
         "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
         "\n"
@@ -8943,7 +8952,7 @@ msgid   "incus storage volume get default data size\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume using backup0.tar.gz as the source\n"
         "\n"
@@ -8951,7 +8960,7 @@ msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume storing some-installer.iso for use as a CD-ROM image"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid   "incus storage volume info default foo\n"
         "    Returns state information for a custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8959,7 +8968,7 @@ msgid   "incus storage volume info default foo\n"
         "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid   "incus storage volume set default data size=1GiB\n"
         "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
         "\n"
@@ -8967,7 +8976,7 @@ msgid   "incus storage volume set default data size=1GiB\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid   "incus storage volume show default foo\n"
         "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8978,7 +8987,7 @@ msgid   "incus storage volume show default foo\n"
         "    Will show the properties of the container volume \"c1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid   "incus storage volume snapshot create default foo snap0\n"
         "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
         "\n"
@@ -8986,7 +8995,7 @@ msgid   "incus storage volume snapshot create default foo snap0\n"
         "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid   "incus storage volume unset default foo size\n"
         "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8994,64 +9003,64 @@ msgid   "incus storage volume unset default foo size\n"
         "    Removes the snapshot expiration period of virtual machine volume \"v1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid   "info"
 msgstr  ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid   "n"
 msgstr  ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid   "name"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976 cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996 cmd/incus/image.go:1209
 msgid   "no"
 msgstr  ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid   "please use `incus profile`"
 msgstr  ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid   "space used"
 msgstr  ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid   "total space"
 msgstr  ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid   "unreachable"
 msgstr  ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid   "used by"
 msgstr  ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid   "y"
 msgstr  ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500 cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978 cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509 cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998 cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid   "yes"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -58,7 +58,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -119,7 +119,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -135,7 +135,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -149,7 +149,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -203,7 +203,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
@@ -242,7 +242,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -315,7 +315,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -354,7 +354,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network integration.\n"
@@ -370,7 +370,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -419,7 +419,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -451,7 +451,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -480,7 +480,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -509,7 +509,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -544,7 +544,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -580,7 +580,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -616,98 +616,98 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, fuzzy, c-format
 msgid "%q is not a block device"
 msgstr "%s non è una directory"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, fuzzy, c-format
 msgid "%q is not an IP address"
 msgstr "%s non è una directory"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partizione %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Porta %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -715,24 +715,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr "Alias:"
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -765,45 +765,45 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 #, fuzzy
 msgid "<remote>: <path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 #, fuzzy
 msgid "A cluster member name must be provided"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -811,62 +811,62 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "Azione (default a GET)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -875,24 +875,24 @@ msgstr "Il nome del container è: %s"
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -900,11 +900,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -916,16 +916,16 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -934,7 +934,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -942,57 +942,57 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "La periferica esiste già: %s"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1007,106 +1007,106 @@ msgstr "il remote %s esiste già"
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Alias:"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, fuzzy, c-format
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 #, fuzzy
 msgid "Attach new custom storage volumes to instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 #, fuzzy
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1114,152 +1114,152 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -1268,73 +1268,73 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 #, fuzzy
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, fuzzy, c-format
 msgid "Can't read from environment file: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
@@ -1343,255 +1343,255 @@ msgstr "Impossible leggere da stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Colonne"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1602,55 +1602,55 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 #, fuzzy
 msgid "Config key/value to apply to the new network integration"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1658,43 +1658,43 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1702,11 +1702,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1722,146 +1722,146 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, fuzzy, c-format
 msgid "Create a new %s pool?"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 #, fuzzy
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, fuzzy, c-format
 msgid "Create instance backup: %w"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 #, fuzzy
 msgid "Create instance snapshot"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1869,35 +1869,35 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1906,89 +1906,89 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1996,29 +1996,29 @@ msgstr "DESCRIZIONE"
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -2033,11 +2033,11 @@ msgstr "Comandi:"
 msgid "Debug commands for instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2045,55 +2045,55 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 #, fuzzy
 msgid "Delete instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 #, fuzzy
 msgid "Delete instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2102,376 +2102,376 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "La periferica esiste già: %s"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
@@ -2480,7 +2480,7 @@ msgstr "Creazione del container in corso"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Creazione del container in corso"
@@ -2507,112 +2507,112 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2621,65 +2621,65 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2688,32 +2688,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2737,47 +2737,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, fuzzy, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2787,57 +2787,57 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2866,11 +2866,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2885,22 +2885,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2909,37 +2909,37 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Creazione del container in corso"
@@ -2951,241 +2951,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, fuzzy, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, fuzzy, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, fuzzy, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, fuzzy, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, fuzzy, c-format
 msgid "Failed import request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, fuzzy, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, fuzzy, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, fuzzy, c-format
 msgid "Failed to close export file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, fuzzy, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, fuzzy, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, fuzzy, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, fuzzy, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Accetta certificato"
@@ -3195,104 +3195,104 @@ msgstr "Accetta certificato"
 msgid "Failed to dump instance memory: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, fuzzy, c-format
 msgid "Failed to join cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, fuzzy, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, fuzzy, c-format
 msgid "Failed to parse servers: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, fuzzy, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, fuzzy, c-format
 msgid "Failed to rename export file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, fuzzy, c-format
 msgid "Failed to render the config: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, fuzzy, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, fuzzy, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, fuzzy, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, fuzzy, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, fuzzy, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3308,98 +3308,98 @@ msgstr "Accetta certificato"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, fuzzy, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, fuzzy, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, fuzzy, c-format
 msgid "Failed validation request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3423,7 +3423,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3433,36 +3433,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3475,7 +3475,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3484,217 +3484,217 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3706,68 +3706,68 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3775,313 +3775,313 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "Il nome del container è: %s"
@@ -4091,7 +4091,7 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
@@ -4105,60 +4105,60 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -4173,104 +4173,104 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid sorting type provided"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Architettura: %s"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4304,12 +4304,12 @@ msgstr "Creazione del container in corso"
 msgid "List aliases"
 msgstr "Alias:"
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4331,12 +4331,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4358,12 +4358,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4385,11 +4385,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4411,16 +4411,16 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias:"
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4429,11 +4429,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4457,12 +4457,12 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4485,11 +4485,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4513,16 +4513,16 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4545,11 +4545,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4570,11 +4570,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4599,11 +4599,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4629,11 +4629,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4657,11 +4657,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4689,21 +4689,21 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 #, fuzzy
 msgid "List instance devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4726,12 +4726,12 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 #, fuzzy
 msgid "List instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4804,8 +4804,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4815,16 +4815,16 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4847,12 +4847,12 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4875,25 +4875,25 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4909,11 +4909,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4934,11 +4934,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4960,12 +4960,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4988,12 +4988,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5007,14 +5007,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5030,11 +5042,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5060,11 +5072,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5088,12 +5100,12 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias:"
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5116,89 +5128,89 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 #, fuzzy
 msgid "Lower device"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 #, fuzzy
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5206,57 +5218,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Il nome del container è: %s"
@@ -5265,25 +5277,25 @@ msgstr "Il nome del container è: %s"
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5303,35 +5315,35 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 #, fuzzy
 msgid "Manage instance metadata files"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -5340,268 +5352,268 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
@@ -5614,175 +5626,175 @@ msgstr "Il nome del container è: %s"
 msgid "Missing network address set name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 #, fuzzy
 msgid "Monitor a local or remote server"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5798,217 +5810,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -6032,169 +6044,169 @@ msgstr ""
 msgid "Network address set description"
 msgstr ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6205,19 +6217,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6225,31 +6237,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6263,175 +6275,175 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "PCI device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, fuzzy, c-format
 msgid "Path %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 #, fuzzy
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 #, fuzzy
 msgid "Please provide join token:"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6447,263 +6459,263 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6716,24 +6728,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6743,13 +6755,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
@@ -6764,41 +6776,41 @@ msgstr "il remote %s è statico e non può essere modificato"
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -6811,48 +6823,48 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6860,53 +6872,53 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6915,20 +6927,20 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6936,292 +6948,292 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 #, fuzzy
 msgid "Restart instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "CREATO IL"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7230,7 +7242,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7239,15 +7251,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7256,11 +7268,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7274,11 +7286,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7287,11 +7299,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7300,12 +7312,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7315,12 +7327,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7329,11 +7341,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7342,12 +7354,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7356,16 +7368,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7374,11 +7386,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7387,12 +7399,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7401,11 +7413,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7414,11 +7426,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7436,40 +7448,40 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7478,142 +7490,142 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
@@ -7623,72 +7635,72 @@ msgstr "Il nome del container è: %s"
 msgid "Show network address set configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7700,21 +7712,21 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7723,97 +7735,97 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -7822,13 +7834,13 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7837,76 +7849,76 @@ msgstr ""
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Il nome del container è: %s"
@@ -7915,96 +7927,96 @@ msgstr "Il nome del container è: %s"
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -8012,15 +8024,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8028,37 +8040,37 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -8069,20 +8081,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, fuzzy, c-format
 msgid "The %s storage pool already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8096,7 +8108,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8105,62 +8117,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8169,108 +8181,108 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8285,18 +8297,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8306,28 +8318,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8341,274 +8353,274 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "USB device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 #, fuzzy
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8617,74 +8629,74 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8693,16 +8705,16 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8711,84 +8723,84 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8797,121 +8809,121 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 #, fuzzy
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8921,11 +8933,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8942,259 +8954,259 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 #, fuzzy
 msgid "Where should this storage pool store its data?"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -9230,174 +9242,174 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "Creazione del container in corso"
@@ -9407,554 +9419,554 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9977,13 +9989,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9992,7 +10004,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10000,7 +10012,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10011,13 +10023,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -10026,7 +10038,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -10034,15 +10046,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10052,7 +10064,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -10061,13 +10073,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10075,26 +10087,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -10103,13 +10115,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10118,7 +10130,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -10129,19 +10141,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10152,7 +10164,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -10164,7 +10176,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -10178,7 +10190,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -10194,7 +10206,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -10206,7 +10218,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -10214,24 +10226,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -10240,7 +10252,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -10256,7 +10268,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -10264,7 +10276,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10272,13 +10284,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10290,7 +10302,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10299,7 +10311,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10310,13 +10322,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10325,19 +10337,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -10347,13 +10359,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10363,31 +10375,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10397,21 +10409,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -10420,13 +10432,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10436,7 +10448,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10446,7 +10458,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10456,7 +10468,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10466,7 +10478,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10476,7 +10488,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10486,7 +10498,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10500,7 +10512,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10510,7 +10522,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10520,68 +10532,68 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 #, fuzzy
 msgid "n"
 msgstr "no"
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr "no"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-12-14 14:00+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.9-rc\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  筐体:"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  ファームウェア:"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  マザーボード:"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -52,7 +52,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -82,7 +82,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -107,7 +107,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -119,7 +119,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -127,7 +127,7 @@ msgstr ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -166,7 +166,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "### An example would be:\n"
 "###  description: My custom image"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -304,7 +304,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network integration.\n"
@@ -361,7 +361,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -416,7 +416,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -446,7 +446,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -470,7 +470,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -494,7 +494,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -530,7 +530,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -568,7 +568,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -602,7 +602,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -610,92 +610,92 @@ msgstr ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d（id: %d, オンライン: %v, NUMA ノード: %v）"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr "%q はブロックデバイスではありません"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr "%q は IP アドレスではありません"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 "%s %q（プール %q 上, プロジェクト %q 内, スナップショット %d 個を含む）"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s（他%d個）"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d個使用可能)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（バックエンド=%q, ソース=%q）"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(none)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- レベル %d（タイプ: %s）: %s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- パーティション %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- ポート %d（%s）"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "インスタンスの強制シャットダウンの際は --console は使えません"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr "--console と --all は同時に指定できません"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
@@ -703,25 +703,25 @@ msgstr "--instance-only はコピー元がスナップショットの場合は�
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port を使うには --network-address を指定しなければなりません"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 #, fuzzy
 msgid "--target can only be used with clusters"
 msgstr "--target はインスタンスでは使えません"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -733,7 +733,7 @@ msgstr "<alias>"
 msgid "<alias> <target>"
 msgstr "<alias> <target>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr "<local|global> <query>"
 
@@ -753,43 +753,43 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr "<remote>: <path>"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr "<target>"
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr "=> クエリ %d:"
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "クライアント証明書がサーバに格納されました:"
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr "クラスターメンバー名が必要です"
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr "クラスターメンバー名が必要です"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
@@ -798,61 +798,61 @@ msgstr "ADDRESS"
 msgid "ADDRESSES"
 msgstr "ADDRESS"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr "APP"
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr "アクセスキー（空白の場合自動生成）"
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr "警告を確認します"
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスターメンバーをクラスターグループに追加します"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
@@ -861,23 +861,23 @@ msgstr "ネットワークゾーンレコードのエントリを追加します
 msgid "Add addresses to a network address set"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr "メンバーをグループに追加します"
 
@@ -885,11 +885,11 @@ msgstr "メンバーをグループに追加します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -908,15 +908,15 @@ msgstr ""
 "  incus remote add some-name https://LOGIN:PASSWORD@example.com/some/path --"
 "protocol=simplestreams\n"
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr "新たに信頼済みのクライアントを追加します"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr "新たに信頼済みのクライアント証明書を追加します"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -930,7 +930,7 @@ msgstr ""
 "- client (デフォルト)\n"
 "- metrics\n"
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -942,56 +942,56 @@ msgstr ""
 "クライアントが自身をトラストストアに追加するために使うトラストトークンが発行"
 "されます。\n"
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr "追加のストレージプール設定プロパティー（KEY=VALUE, 完了時は空文字列）:"
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr "バインドするアドレス (デフォルト: none)"
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr "バインドするアドレス (ポートを含まない)"
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
@@ -1006,105 +1006,105 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr "エイリアス: %s"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr "エイリアスは既に存在します: %s"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr "クラスターに join すると、すべてのデータが削除されます。続けますか?"
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr "既存のクラスターに join しますか?"
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr "インスタンスにネットワークインターフェースを追加します"
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 #, fuzzy
 msgid "Attach new custom storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 #, fuzzy
 msgid "Attach new custom storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr "インスタンスのコンソールに接続します"
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1116,156 +1116,156 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr "自動（非インタラクティブ）モード"
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "平均: %.2f %.2f %.2f"
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 #, fuzzy
 msgid "Backend description"
 msgstr "説明"
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr "バックエンドの稼働状況:"
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップを行います"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr "バックアップ:"
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr "ボンディング:"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 #, fuzzy
 msgid "Bucket description"
 msgstr "説明"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr "COUNT"
 
@@ -1274,74 +1274,74 @@ msgstr "COUNT"
 msgid "CPU TIME(s)"
 msgstr "CPU (%s):"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 #, fuzzy
 msgid "CPUs:"
 msgstr "GPUs:"
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "CREATED"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr "アドレス %q をバインドできません: %w"
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, fuzzy, c-format
 msgid "Can't read from environment file: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
@@ -1350,53 +1350,53 @@ msgstr "標準入力から読み込めません: %w"
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr "--project と --all-project は同時に指定できません"
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr "--auto と --preseed は同時に使えません"
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr "--dump とその他のオプションを同時に使えません"
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr "--minimal と --auto を同時に使えません"
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr "--minimal と --preseed を同時に使えません"
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr "イメージに --empty は使えません"
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1404,55 +1404,55 @@ msgstr ""
 "デバイス %q の設定を上書きできません: プロファイルのデバイス内にデバイスが見"
 "つかりません"
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "スナップショットをコピーするときに --volume-only は指定できません"
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 #, fuzzy
 msgid "Certificate description"
 msgstr "証明書のフィンガープリント: %s"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
@@ -1460,153 +1460,153 @@ msgstr ""
 "証明書のフィンガープリントが join するためのトークンとクラスターメンバーの間"
 "で一致しません %q"
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr "Chassis"
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr "デーモンが準備できていることを確認しています (試行 %d)"
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr "選択してください %s"
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスターグループ名 %s を %s に変更しました"
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "クラスターグループ %s を作成しました"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "クラスターメンバー %s がグループ %s に追加されました"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "クラスターメンバー %s はグループ %s にすでに存在します"
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr "クラスターメンバ名"
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr "incus のコマンドラインクライアント"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1624,55 +1624,55 @@ msgstr ""
 "カスタムコマンドをエイリアスを使って定義でき、それらを制御するには \"incus "
 "alias\" を使います。"
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `none`)"
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 #, fuzzy
 msgid "Config key/value to apply to the new network integration"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr "設定オプションに --auto が必要です"
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr "デーモンの設定"
 
@@ -1681,43 +1681,43 @@ msgstr "デーモンの設定"
 msgid "Configure the refresh delay in seconds"
 msgstr "更新間隔を秒単位で入力:"
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "デーモンに接続しています (試行 %d)"
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr "サーバ間でイメージをコピーします"
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1729,11 +1729,11 @@ msgstr ""
 "自動更新フラグは、このイメージを最新に保つようにサーバに指示します。\n"
 "ソースはエイリアスで、かつパブリックである必要があります。"
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr "サーバ内、またはサーバ間でインスタンスをコピーします"
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1761,141 +1761,141 @@ msgstr ""
 "すべてのサーバーバージョンとの互換性のため、pull 転送モードがデフォルトで"
 "す。\n"
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr "コア %d"
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr "コア:"
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr "statfs %s できません: %w"
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr "新たに %s プールを作成しますか?"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr "仮想マシンを作成します"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr "インスタンス内にファイル、もしくはディレクトリーを作成します"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr "インスタンスのバックアップを作成します: %w"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr "インスタンスのスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1907,32 +1907,32 @@ msgstr ""
 "--stateful を指定すると、インスタンスの実行状態（プロセスのメモリ状態、TCPコ"
 "ネクション、など…を含む）を保存しようとします。"
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr "新たにインスタンスのファイルテンプレートを作成します"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
@@ -1941,86 +1941,86 @@ msgstr "新たにネットワーク ACL を作成します"
 msgid "Create new network address sets"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr "新たにネットワークフォワードを作成します"
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr "新たにネットワークロードバランサーを作成します"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr "%s: %%s を作成中"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2028,30 +2028,30 @@ msgstr "DESCRIPTION"
 msgid "DISK"
 msgstr "ディスク"
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr "DRM:"
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 "%d 秒のタイムアウトが経過しましたが、デーモンがまだ実行中ではありません (%v)"
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr "%d 秒のタイムアウトが経過しましたが、デーモンがまだ実行中です"
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "状態: %s"
@@ -2066,11 +2066,11 @@ msgstr "コマンド:"
 msgid "Debug commands for instances"
 msgstr "インスタンス内でコマンドを実行します"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -2079,52 +2079,52 @@ msgstr "圧縮アルゴリズムを指定します: backup or none"
 msgid "Delay:"
 msgstr "Down delay"
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr "クラスターグループを削除します"
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "ストレージボリュームを削除します"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr "イメージを削除します"
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr "インスタンスのファイルテンプレートを削除します"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr "インスタンスのスナップショットを削除します"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr "インスタンスを削除します"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
@@ -2133,286 +2133,286 @@ msgstr "ネットワーク ACL を削除します"
 msgid "Delete network address sets"
 msgstr "ネットワークゾーンを削除します"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr "ストレージバケットを削除します"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr "ストレージボリュームのスナップショットを削除します"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr "警告を削除します"
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "説明"
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "デバイス: %s"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr "デバイス %s が %s に追加されました"
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "デバイス %s が %s で上書きされました"
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
@@ -2420,7 +2420,7 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは変更できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
@@ -2428,78 +2428,78 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは削除できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr "擬似端末の割り当てを無効にします"
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr "すべてのプロジェクトのイメージを表示します"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのイメージを表示します"
@@ -2508,7 +2508,7 @@ msgstr "すべてのプロジェクトのイメージを表示します"
 msgid "Display resource usage info per instance"
 msgstr "インスタンスごとのリソース消費状況を表示する"
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2560,49 +2560,49 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr "新しいローカルストレージプールを設定しますか?"
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr "新しいリモートストレージプールの設定をしますか?"
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr "新しいストレージプールのの設定をしますか?"
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr "Thin provisioning なしで続けますか?"
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr "Down delay"
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "ドライバ: %v (%v)"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr "YAML 形式で設定を stdout に出力します"
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
@@ -2610,64 +2610,64 @@ msgstr ""
 "インクリメンタルコピーの際、最新のターゲットスナップショットより前のソースス"
 "ナップショットを除外する"
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 "更新時、最新のターゲットスナップショットより前のソーススナップショットを除外"
 "する"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "既存: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr "クラスターグループを編集します"
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr "インスタンスのファイルテンプレートを編集します"
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr "インスタンスのメタデータファイルを編集します"
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
@@ -2676,61 +2676,61 @@ msgstr "ネットワーク ACL をYAMLで編集します"
 msgid "Edit network address set configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2744,33 +2744,33 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr "クラスタリングで動作していないサーバ上でクラスタリングを有効にします"
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2803,47 +2803,47 @@ msgstr "ソートタイプを入力する（'a' はアルファベット、'c' C
 msgid "Enter new delay in seconds:"
 msgstr "更新間隔を秒単位で入力:"
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "既存のクラスターメンバー %q への接続でエラーが発生しました: %v"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr "デコーダーの作成でエラーが発生しました: %v"
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr "デコーディングデータのエラー: %v"
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr "エイリアスの取得に失敗しました: %w"
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "プロパティの設定でエラーが発生しました: %v"
@@ -2853,57 +2853,57 @@ msgstr "プロパティの設定でエラーが発生しました: %v"
 msgid "Error setting term size %s"
 msgstr "ターミナルサイズの設定でエラーが発生しました: %s"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr "プロパティの削除でエラーが発生しました: %v"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "エイリアスの展開の実行中にエラー発生しました: %s\n"
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr "エラー: %v\n"
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr "Listenするイベントタイプ"
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 "ローカルまたはグローバルのデータベースに対して SQL クエリーを実行します"
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 #, fuzzy
 msgid ""
 "Execute a SQL query against the local or global database\n"
@@ -2960,11 +2960,11 @@ msgstr ""
 "  このコマンドは、グローバルデータベースを対象にしており、ローカルモードおよ"
 "びクラスターモードの両方で動作します。"
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr "インスタンス内でコマンドを実行します"
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2990,22 +2990,22 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr "失効日時"
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
@@ -3014,11 +3014,11 @@ msgstr "失効日時: 失効しない"
 msgid "Export a virtual machine's memory state"
 msgstr "仮想マシンイメージをコピーします"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
@@ -3028,23 +3028,23 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr "ストレージバケットをエクスポートします"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr "ストレージバケットを tarball 形式でエクスポートします。"
 
@@ -3055,242 +3055,242 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップをエクスポートします"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "デーモンへの接続に失敗しました（試行回数 %d）: %v"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "証明書追加トークンのトークン変換操作に失敗しました: %w"
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "join トークンのトークン変換操作に失敗しました: %w"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "インスタンス %q （プロジェクト %q 内）の削除に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー後のソースボリュームの削除に失敗しました: %w"
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "既存のストレージプールの取得に失敗しました: %w"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr "インポート要求が失敗しました: %w"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "ネットワーク %q の取得に失敗しました: %w"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "ストレージプール %q の取得に失敗しました: %w"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "バリデーションレスポンスの読み取りに失敗しました: %w"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "サーバー証明書のクラスターへの追加に失敗しました: %w"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr "デーモンが利用可能かどうかのチェックに失敗しました (試行 %d): %v"
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr "エクスポートするファイルのクローズに失敗しました: %w"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "クラスターの設定に失敗しました: %w"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスターメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "サーバー情報の取得のための接続に失敗しました: %w"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "ローカルデーモンへの接続に失敗しました: %w"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "ターゲットのクラスターノード %q への接続に失敗しました: %w"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "移動元のインスタンスをコピーしたあとの削除に失敗しました: %w"
@@ -3300,104 +3300,104 @@ msgstr "移動元のインスタンスをコピーしたあとの削除に失敗
 msgid "Failed to dump instance memory: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr "クラスターへの join に失敗しました: %w"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr "設定のロードに失敗しました: %s"
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "ダンプレスポンスの読み取りに失敗しました: %w"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr "サーバーの読み取りに失敗しました: %w"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, fuzzy, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, fuzzy, c-format
 msgid "Failed to rename export file: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, fuzzy, c-format
 msgid "Failed to render the config: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, fuzzy, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, fuzzy, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, fuzzy, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, fuzzy, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, fuzzy, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3413,97 +3413,97 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, fuzzy, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, fuzzy, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, fuzzy, c-format
 msgid "Failed validation request: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "名前: %v"
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr "強制的にファイルまたはディレクトリーを作成します"
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr "プロジェクトとプロジェクトに含まれるすべてを強制的に削除します。"
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "Force deleting files, directories, and subdirectories"
 msgstr "強制的にファイルまたはディレクトリーを作成します"
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr "インスタンスを強制停止します"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, fuzzy, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3542,7 +3542,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3553,36 +3553,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr "フォーマット (json|pretty|yaml)"
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr "フォーマット (man|md|rest|yaml)"
 
@@ -3596,7 +3596,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr "Forward delay"
 
@@ -3605,216 +3605,216 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "クロック数: %vMhz"
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "新たに信頼済みのクライアント証明書を追加します"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 #, fuzzy
 msgid "Get the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr "key をネットワーク ACL プロパティとして取得します"
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr "key をネットワークプロパティとして取得します"
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr "key をプロファイルプロパティとして取得します"
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr "key をプロジェクトプロパティとして取得します"
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr "key をインスタンスプロパティとして取得します"
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr "ネットワーク ACL の設定値を取得します"
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr "ストレージバケットの設定値を取得します"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 #, fuzzy
 msgid ""
 "Get values for storage volume configuration keys\n"
@@ -3829,67 +3829,67 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "名前"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr "ID"
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr "ID: %d"
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -3897,148 +3897,148 @@ msgstr "IMAGES"
 msgid "INSTANCE NAME"
 msgstr "インスタンス名"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr "IOMMU グループ: %v"
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr "IPV4"
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr "IPV6"
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 #, fuzzy
 msgid "IPv4 uplink address"
 msgstr "IP アドレス"
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 #, fuzzy
 msgid "IPv6 uplink address"
 msgstr "IP アドレス"
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr "インスタンスが実行中の場合、停止してからリビルドしてください"
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 #, fuzzy
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行する必要があります"
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 #, fuzzy
 msgid "Image alias description"
 msgstr "説明"
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -4049,177 +4049,177 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 "インポートするタイプは \"backup\" もしくは \"iso\" である必要があります"
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "インポートするタイプ。backup もしくは iso (デフォルト \\\"backup\\\")"
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "ISO イメージをインポートするには、ボリューム名を設定する必要があります"
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr "ファイルからの環境変数を含める"
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 #, fuzzy
 msgid "Include less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 #, fuzzy
 msgid "Incus - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr "Infiniband:"
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "説明"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "不正なスナップショット名"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr "不正な引数 %q"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "不正な引数 %q"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "パス %q に不正なバックアップ名のセグメントがあります: %w"
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "メンバ %s の join トークン:"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 #, fuzzy
 msgid "Invalid database type"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "不正なインスタンス名: %s"
@@ -4229,7 +4229,7 @@ msgstr "不正なインスタンス名: %s"
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %s"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
@@ -4243,62 +4243,62 @@ msgstr "入力が無効です。正の値を入力してください"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "メンバ %s の join トークン:"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "不適切な キー=値 の設定: %s"
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -4312,105 +4312,105 @@ msgstr "不正な送り先 %s"
 msgid "Invalid sorting type provided"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr "既存のクラスターに加わるには root 権限が必要です"
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr "サーバのバージョン: %s"
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 #, fuzzy
 msgid "Key description"
 msgstr "説明"
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr "LOCATION"
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, c-format
 msgid "Link detected: %v"
 msgstr "リンクを検出: %v"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 #, fuzzy
 msgid ""
 "List DHCP leases\n"
@@ -4468,11 +4468,11 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 #, fuzzy
 msgid ""
 "List all active certificate add tokens\n"
@@ -4519,11 +4519,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 #, fuzzy
 msgid ""
 "List all active cluster member join tokens\n"
@@ -4570,11 +4570,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr "クラスターグループをすべて一覧表示します"
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 #, fuzzy
 msgid ""
 "List all the cluster groups\n"
@@ -4621,11 +4621,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr "クラスターのメンバをすべて一覧表示します"
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 #, fuzzy
 msgid ""
 "List all the cluster members\n"
@@ -4672,15 +4672,15 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr "警告を一覧表示します"
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
@@ -4689,11 +4689,11 @@ msgstr "利用可能なネットワーク ACL を一覧表示します"
 msgid "List available network address sets"
 msgstr "利用可能なネットワークピアを一覧表示します"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr "利用可能なネットワークフォワードを一覧表示します"
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 #, fuzzy
 msgid ""
 "List available network forwards\n"
@@ -4742,11 +4742,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr "利用可能なネットワークロードバランサーを一覧表示します"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 #, fuzzy
 msgid ""
 "List available network load balancers\n"
@@ -4794,11 +4794,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr "利用可能なネットワークピアを一覧表示します"
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 #, fuzzy
 msgid ""
 "List available network peers\n"
@@ -4847,15 +4847,15 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 #, fuzzy
 msgid ""
 "List available network zone\n"
@@ -4903,11 +4903,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 #, fuzzy
 msgid ""
 "List available networks\n"
@@ -4953,11 +4953,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -5002,11 +5002,11 @@ msgstr ""
 "  u - 使用中の数\n"
 "  s - 状態"
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 #, fuzzy
 msgid ""
 "List background operations\n"
@@ -5057,11 +5057,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr "イメージのエイリアスを一覧表示します"
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5105,11 +5105,11 @@ msgstr ""
 "  t - タイプ\n"
 "  d - 説明"
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 #, fuzzy
 msgid ""
 "List images\n"
@@ -5162,20 +5162,20 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr "インスタンスのデバイスを一覧表示します"
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr "インスタンスのファイルテンプレートを一覧表示します"
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "インスタンスのスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 #, fuzzy
 msgid ""
 "List instance snapshots\n"
@@ -5223,11 +5223,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -5300,8 +5300,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -5340,8 +5340,8 @@ msgstr ""
 "  - \"type=container status=running\" 実行中のコンテナインスタンスをすべて表"
 "示します\n"
 "\n"
-"設定項目もしくは値とマッチする正規表現 "
-"(例:volatile.eth0.hwaddr=00:16:3e:.*)。\n"
+"設定項目もしくは値とマッチする正規表現 (例:volatile.eth0.hwaddr=00:16:3e:."
+"*)。\n"
 "\n"
 "複数のフィルタを指定した場合は、指定したフィルタが順に追加され、\n"
 "すべてのフィルタを満たすインスタンスが選択されます。\n"
@@ -5388,17 +5388,17 @@ msgstr ""
 "  MAXWIDTH: カラムの最大幅 (結果がこれより長い場合は切り詰められます)\n"
 "  デフォルトは -1 (制限なし)。0 はカラムのヘッダサイズに制限します。"
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 #, fuzzy
 msgid ""
 "List network allocations in use\n"
@@ -5446,12 +5446,12 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "ネットワークの設定を削除します"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 #, fuzzy
 msgid ""
 "List network integrations\n"
@@ -5499,25 +5499,25 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 #, fuzzy
 msgid ""
 "List profiles\n"
@@ -5558,11 +5558,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 #, fuzzy
 msgid ""
 "List projects\n"
@@ -5608,11 +5608,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr "ストレージバケットの鍵を一覧表示します"
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 #, fuzzy
 msgid ""
 "List storage bucket keys\n"
@@ -5659,11 +5659,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 #, fuzzy
 msgid ""
 "List storage buckets\n"
@@ -5711,12 +5711,12 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 #, fuzzy
 msgid ""
 "List storage volume snapshots\n"
@@ -5755,14 +5755,27 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
+#, fuzzy
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5792,11 +5805,11 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5843,11 +5856,11 @@ msgstr ""
 "  s - 静的\n"
 "  g - グローバル"
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 #, fuzzy
 msgid ""
 "List trusted clients\n"
@@ -5890,11 +5903,11 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr "警告を一覧表示します"
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5935,89 +5948,89 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 #, fuzzy
 msgid "Load balancer description"
 msgstr "説明"
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr "負荷:"
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr "ログ:"
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr "論理ルーター"
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 #, fuzzy
 msgid "Logical switch"
 msgstr "論理ルーター"
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr "ユーザー名 %q とパスワード %q でログイン"
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr "ユーザー名、パスワードを使用せずにログイン"
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr "クラスターの検査と回復のための低レベルの管理ツール"
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr "低レベルのクラスター管理コマンド"
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr "Lower device"
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr "MAC アドレス"
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
@@ -6026,57 +6039,57 @@ msgstr "MEMBERS"
 msgid "MEMORY"
 msgstr "MEMORY USAGE"
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr "MEMORY USAGE"
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr "MII 監視頻度"
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr "MTU"
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr "イメージを public にする"
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr "イメージを public にする"
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr "ネットワークを管理し、インスタンスをネットワークに接続します"
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr "クラスターグループを管理します"
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr "クラスターのメンバを管理します"
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr "クラスターロールを管理します"
 
@@ -6084,23 +6097,23 @@ msgstr "クラスターロールを管理します"
 msgid "Manage command aliases"
 msgstr "コマンドのエイリアスを管理します"
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr "イメージのエイリアスを管理します"
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr "イメージを管理します"
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 #, fuzzy
 msgid ""
 "Manage images\n"
@@ -6134,34 +6147,34 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "クラスタのメンバを管理します"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr "インスタンスやサーバの設定を管理します"
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr "インスタンスのファイルテンプレートを管理します"
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr "インスタンスのメタデータファイルを管理します"
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "インスタンスのスナップショットを作成します"
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr "ネットワーク ACL ルールを管理します"
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
@@ -6170,255 +6183,255 @@ msgstr "ネットワーク ACL を管理します"
 msgid "Manage network address sets"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr "ネットワークフォワードを管理します"
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr "ネットワークロードバランサーを管理します"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr "ストレージバケットの鍵を管理します"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr "ストレージバケットの鍵を管理します。"
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr "ストレージバケットを管理します"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr "ストレージバケットを管理します。"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr "ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr "警告を管理します"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr "クライアント証明書の生成を手動でトリガーする"
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr "VF の最大数: %d"
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr "メンバー %q はすでにロール %q を持っています"
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr "最小限の設定を行う (非インタラクティブ)"
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr "ログメッセージの最小レベル（pretty フォーマット使用時のみ利用可能）"
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr "最小サイズは 1GiB です"
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr "バケット名を指定する必要があります"
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
@@ -6430,140 +6443,140 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 msgid "Missing network address set name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "プロファイル名を指定する必要があります"
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "作成するネットワーク名を指定する必要があります"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr "モード"
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr "モデル: %s"
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr "モデル: %v"
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 #, fuzzy
 msgid "Monitor a local or remote server"
 msgstr "ローカルもしくはリモートの LXD サーバをモニタリングします"
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 #, fuzzy
 msgid ""
 "Monitor a local or remote server\n"
@@ -6574,32 +6587,32 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 #, fuzzy
 msgid ""
 "Move instances within or in between servers\n"
@@ -6627,224 +6640,224 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr "NAME"
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr "NAT"
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "新規: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr "NICs:"
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr "NO"
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr "NVIDIA 情報:"
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr "名前"
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr "CEPHfs ボリューム名:"
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 #, fuzzy
 msgid "Name of the OSD storage pool"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, fuzzy, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr "既存の CEPH クラスター名"
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr "既存の CEPHfs クラスター名"
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr "既存の OSD ストレージプール名"
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr "既存のブリッジ名、もしくはホストインターフェース名"
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 #, fuzzy
 msgid "Name of the new storage pool"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 #, fuzzy
 msgid "Name of the shared LVM volume group:"
 msgstr "CEPHfs ボリューム名:"
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "ストレージバケットを削除します"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr "使用するストレージバックエンド名 (%s)"
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 #, fuzzy
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク ACL %s を削除しました"
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
@@ -6869,71 +6882,71 @@ msgstr "ネットワーク名 %s を %s に変更しました"
 msgid "Network address set description"
 msgstr "説明"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr "説明"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, fuzzy, c-format
 msgid "Network integration %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, fuzzy, c-format
 msgid "Network integration %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr "ネットワークピア %s を作成しました"
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr "ネットワークピア %s を削除しました"
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr "ネットワークピア %s は想定外のステータスです %q"
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -6941,104 +6954,104 @@ msgstr ""
 "ネットワークピア %s はピアリング状態です (ピアネットワーク上で相互ピアリング"
 "を完了させてください)"
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr "利用可能なストレージバックエンド %s がありません"
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 "メンバー %s に対するクラスターへの join トークンがリモート %s にありません"
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr "ロードバランサーのヘルス情報がありません"
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr "利用可能なストレージバックエンドがありません"
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr "テキストエディターが見つかりません。環境変数 EDITOR を設定してください"
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 "未知のストレージプールやボリュームが見つかりません。実行することがありませ"
 "ん。"
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -7051,20 +7064,20 @@ msgstr ""
 "--storage-pool, --storage-create-device, --storage-create-loop のいずれ"
 "も、'dir' バックエンドでは使えません"
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr "配置するグループの数"
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr "OS"
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 #, fuzzy
 msgid "OS Version"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr "OVN:"
 
@@ -7072,32 +7085,32 @@ msgstr "OVN:"
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 #, fuzzy
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -7113,178 +7126,178 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Operating System:"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "PCI device:"
 msgstr "device"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 #, fuzzy
 msgid "PCI devices:"
 msgstr "上位デバイス"
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr "PEER"
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr "PORTS"
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 #, fuzzy
 msgid "PROJECTS"
 msgstr "PROJECT"
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr "送信パケット"
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "%s のパスワード: "
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, fuzzy, c-format
 msgid "Path %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr "既存のブロックデバイスのパス:"
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 #, fuzzy
 msgid "Peer description"
 msgstr "説明"
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr "不足しているエントリーを作成してから ENTER を押してください:"
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 #, fuzzy
 msgid "Please provide join token:"
 msgstr "クライアント名を入力してください: "
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr "プール名を空白にすることはできません"
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 #, fuzzy
 msgid "Port description"
 msgstr "説明"
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr "バインドするポート"
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr "バインドするポート (デフォルト: %d)"
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr "ポートタイプ: %s"
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr "ポート:"
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr "Pre-seed モード。標準入力から YAML で設定を入力します"
 
@@ -7300,265 +7313,265 @@ msgstr "ソート方法を変更するには 's' + ENTER を押してくださ�
 msgid "Press CTRL-C to exit"
 msgstr "終了するには CTRL-C を押してください"
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
 "す"
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 #, fuzzy
 msgid "Profile description"
 msgstr "説明"
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 #, fuzzy
 msgid "Project description"
 msgstr "説明"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "クライアント %s の証明書追加トークン: %s"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr "プロキシータイムアウト (接続がない場合終了)"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr "インスタンスをイメージとして出力します"
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr "RESTRICTED"
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr "ROLE"
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr "ROLES"
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "空のインスタンスを作成"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 #, fuzzy
 msgid "Record description"
 msgstr "説明"
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr "既存または未知のストレージプールから失われたインスタンスを復旧させます"
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -7579,24 +7592,24 @@ msgstr ""
 "リュームを特定します。\n"
 "  そして、データベースレコードの再作成を提案します。"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -7606,13 +7619,13 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
@@ -7627,26 +7640,26 @@ msgstr "リモート %s は global ですので削除できません"
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 #, fuzzy
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr "リムーバブルディスク: %v"
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -7655,15 +7668,15 @@ msgstr ""
 "%s とそれに含まれるすべて（インスタンス、イメージ、ボリューム、ネットワー"
 "ク、…）を削除します (yes/no): "
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスターグループからメンバを削除します"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr "クラスターからメンバを削除します"
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
@@ -7676,44 +7689,44 @@ msgstr "ネットワークゾーンレコードからエントリを削除しま
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -7721,52 +7734,52 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr "クラスターメンバからロールを削除します"
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, fuzzy, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr "クラスターグループの名前を変更します"
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr "クラスターメンバの名前を変更します"
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "インスタンスまたはインスタンスのスナップショットの名前を変更します"
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "インスタンスを再起動します"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
@@ -7775,20 +7788,20 @@ msgstr "ネットワーク ACL 名を変更します"
 msgid "Rename network address sets"
 msgstr "ネットワーク名を変更します"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "ネットワーク名を変更します"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -7796,47 +7809,47 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr "リソース:"
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr "インスタンスを再起動します"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 #, fuzzy
 msgid ""
 "Restore instance from snapshots\n"
@@ -7847,246 +7860,246 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "インスタンスを再起動します"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr "影響を受ける行: %d"
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 #, fuzzy
 msgid "Rule description"
 msgstr "説明"
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr "ローカルの API プロキシーを実行します"
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr "リモート接続用のローカルの API プロキシーを実行します"
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr "特定のプロジェクトを再実行します"
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr "SIZE"
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "UUID: %v"
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr "SSH SFTP は %v でリッスンしています"
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "CREATED AT"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr "STATE"
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 #, fuzzy
 msgid "STATEFUL"
 msgstr "STATE"
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr "STATIC"
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr "STATUS"
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr "STP"
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr "未知のボリュームをスキャンしています..."
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr "秘密鍵（空白の場合自動生成）"
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 #, fuzzy
 msgid "Send a raw query to the server"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 #, fuzzy
 msgid "Server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 #, fuzzy
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr "デバイスの設定項目を設定します"
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 #, fuzzy
 msgid ""
 "Set device configuration keys\n"
@@ -8100,7 +8113,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 #, fuzzy
 msgid ""
 "Set device configuration keys\n"
@@ -8114,15 +8127,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 #, fuzzy
 msgid ""
 "Set instance or server configuration keys\n"
@@ -8136,11 +8149,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr "ネットワーク ACL の設定項目を設定します"
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 #, fuzzy
 msgid ""
 "Set network ACL configuration keys\n"
@@ -8159,11 +8172,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 #, fuzzy
 msgid ""
 "Set network configuration keys\n"
@@ -8177,11 +8190,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 #, fuzzy
 msgid ""
 "Set network forward keys\n"
@@ -8195,12 +8208,12 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 #, fuzzy
 msgid ""
 "Set network integration configuration keys\n"
@@ -8215,11 +8228,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 #, fuzzy
 msgid ""
 "Set network load balancer keys\n"
@@ -8233,11 +8246,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 #, fuzzy
 msgid ""
 "Set network peer keys\n"
@@ -8251,11 +8264,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 #, fuzzy
 msgid ""
 "Set network zone configuration keys\n"
@@ -8269,15 +8282,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 #, fuzzy
 msgid ""
 "Set profile configuration keys\n"
@@ -8291,11 +8304,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 #, fuzzy
 msgid ""
 "Set project configuration keys\n"
@@ -8309,11 +8322,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr "ストレージバケットの設定項目を設定します"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 #, fuzzy
 msgid ""
 "Set storage bucket configuration keys\n"
@@ -8327,11 +8340,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage bucket set [<remote>:]<pool> <volume> <key> <value>"
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 #, fuzzy
 msgid ""
 "Set storage pool configuration keys\n"
@@ -8345,11 +8358,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -8372,44 +8385,44 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 #, fuzzy
 msgid "Set the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティとして設定します"
 
@@ -8418,146 +8431,146 @@ msgstr "ネットワーク ACL プロパティとして設定します"
 msgid "Set the key as a network address set property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr "ネットワークプロパティとして設定します"
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr "プロファイルプロパティとして設定します"
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr "プロジェクトプロパティとして設定します"
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr "インスタンスプロパティとして設定します"
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr "DEVICE を使ってストレージベースのデバイスをセットアップします"
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr "サイズ GiB で loop ベースのストレージをセットアップします"
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr "クラスターグループの設定を表示します"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr "クラスターメンバの詳細を表示します"
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr "バックグラウンド操作の詳細を表示します"
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr "すべてのプロジェクトのイベントを表示します"
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr "ネットワーク ACL の設定を表示します"
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
@@ -8566,65 +8579,65 @@ msgstr "ネットワーク ACL ログを表示します"
 msgid "Show network address set configuration"
 msgstr "ネットワークピアの設定を表示します"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr "ネットワークフォワードの設定を表示します"
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "ネットワークの設定を表示します"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr "ネットワークロードバランサーの設定を表示します"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr "ネットワークピアの設定を表示します"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr "ストレージバケットの設定を表示する"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr "ストレージバケットの鍵の設定を表示する"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 #, fuzzy
 msgid ""
 "Show storage volume configurations\n"
@@ -8639,21 +8652,21 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -8667,98 +8680,98 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 #, fuzzy
 msgid "Show the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr "使用量と空き容量を byte で表示します"
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr "新しい loop デバイスのサイズ (GiB)"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 #, fuzzy
 msgid "Snapshot description"
 msgstr "説明"
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
@@ -8767,7 +8780,7 @@ msgstr "一部のインスタンスで %s が失敗しました"
 msgid "Sorting Method:"
 msgstr "ソート方法:"
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
@@ -8775,7 +8788,7 @@ msgstr ""
 "ストレージプールのソース (適用できるブロックデバイス、ボリュームグループ、"
 "データセット、パス...)"
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr "取得元:"
 
@@ -8783,75 +8796,75 @@ msgstr "取得元:"
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr "状態"
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr "インスタンスを停止します"
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr "実行中の場合、インスタンスを停止します"
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr "インスタンスの停止に失敗しました！"
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "インスタンスの停止に失敗しました: %s"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr "使用するストレージバックエンド (btrfs, dir, lvm, zfs, デフォルト: dir)"
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "ストレージバケット %s を作成しました"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "ストレージバケット %s を削除しました"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "ストレージバケットの鍵 %s を作成しました"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "ストレージバケットの鍵 %s を削除しました"
@@ -8860,97 +8873,97 @@ msgstr "ストレージバケットの鍵 %s を削除しました"
 msgid "Storage has already been configured"
 msgstr "ストレージはすでに設定されています"
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, fuzzy, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, fuzzy, c-format
 msgid "Storage pool %q of type %q"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 #, fuzzy
 msgid "Storage pool to use or create"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr "サポートするモード: %s"
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -8958,15 +8971,15 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr "システム:"
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr "TAKEN AT"
 
@@ -8974,37 +8987,37 @@ msgstr "TAKEN AT"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr "取得日時"
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 "すべてのインスタンスをシャットダウンして終了するようにデーモンに指示します"
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -9023,20 +9036,20 @@ msgstr ""
 "  インスタンスのシャットダウンには長い時間がかかる可能性があるため、かなり時"
 "間がかかることがあります"
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, fuzzy, c-format
 msgid "The %s storage pool already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr "システム上に LVM のシン・プロビジョニング用のツールが見つかりません"
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -9060,7 +9073,7 @@ msgstr ""
 "再度 \"init\" を実行する前に、\"thin_check\" コマンドが実行できることを確認し"
 "てください。"
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -9075,7 +9088,7 @@ msgstr ""
 "\n"
 "\"incusd cluster\" から呼び出すことができます。"
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 #, fuzzy
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
@@ -9083,28 +9096,28 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr "次の未知のストレージプールが見つかりました:"
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr "次の未知のボリュームが見つかりました:"
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr "インスタンスは実行中です。先に停止させるか、--force を指定してください"
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -9112,32 +9125,32 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr "インスタンスのスナップショットに設定する設定キーはありません。"
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "設定 %q はクラスターメンバー %q には存在しません"
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスターメンバー %q には存在しません"
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -9147,96 +9160,96 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr "更新間隔の最小値は 10 秒です"
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -9244,12 +9257,12 @@ msgstr ""
 "プロパティ %q が、ストレージプールボリュームのスナップショット %s/%s に存在し"
 "ません: %v"
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr "リカバリープロセスは次のストレージプールをスキャンします:"
 
@@ -9266,13 +9279,13 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr "入力したバックエンド '%s' は、この初期化ではサポートされていません"
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 "入力したインターフェースが存在しません。他のインターフェースを選択してくださ"
 "い。"
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
@@ -9281,7 +9294,7 @@ msgstr ""
 "入力したネットワークブリッジ \"%s\" がすでに存在しています。他の名前を入力し"
 "てください。"
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -9293,30 +9306,30 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr "サーバーに Web UI がインストールされていません"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr "作成するタイプ（file, symlink, directory）"
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 #, fuzzy
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
@@ -9341,50 +9354,50 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr "入力したバックエンド '%s' は、この初期化ではサポートされていません"
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr "このサーバーは、次のストレージプールを持っています:"
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 #, fuzzy
 msgid "This server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr "スレッド:"
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 #, fuzzy
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
@@ -9394,83 +9407,83 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスターに属していなければ"
 "なりません"
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, fuzzy, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr "タイプ"
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -9478,147 +9491,147 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr "ピアのタイプ（localまたはremote）"
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr "USAGE"
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "USB device:"
 msgstr "device"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 #, fuzzy
 msgid "USB devices:"
 msgstr "上位デバイス"
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr "USED BY"
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr "UUID"
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "クラスタメンバへの接続に失敗しました"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
@@ -9627,68 +9640,68 @@ msgstr "ネットワーク ACL の設定を削除します"
 msgid "Unset network address set configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr "ストレージバケットの設定を削除します"
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -9702,16 +9715,16 @@ msgstr ""
 "サポートされているタイプの値は \"custom\", \"container\", \"virtual-"
 "machine\" です。"
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "クラスタープロパティの設定を削除します"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr "クラスタープロパティの設定を削除します"
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティの設定を削除します"
 
@@ -9720,89 +9733,89 @@ msgstr "ネットワーク ACL プロパティの設定を削除します"
 msgid "Unset the key as a network address set property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr "プロファイルプロパティの設定を削除します"
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr "プロジェクトプロパティの設定を削除します"
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr "Up delay"
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 #, fuzzy
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
@@ -9812,123 +9825,123 @@ msgstr "コピー元の全てのプロファイルがターゲットに存在し
 msgid "Updated interval to %v"
 msgstr "間隔を %v に更新します"
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr "VFs: %d"
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr "VLAN ID"
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr "VLAN フィルタリング"
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr "ベンダ: %v (%v)"
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr "Volume Only"
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 #, fuzzy
 msgid "Volume description"
 msgstr "説明"
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr "WWN: %s"
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr "デーモンがプロセスのリクエストを処理する準備ができるのを待ちます"
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -9944,11 +9957,11 @@ msgstr ""
 "で\n"
 "  ブロックします。"
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 #, fuzzy
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
@@ -9972,38 +9985,38 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr "Web サーバーの実行 URL: %s"
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 "このサーバーにアクセスするためには、どの IP アドレス、または DNS 名を使用する"
 "必要がありますか?"
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr "どの IPv4 アドレスを使いますか?"
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr "どの IPv6 アドレスを使いますか?"
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr "クラスター内のこのサーバーを識別するのに使うメンバー名は何ですか?"
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr "新しいブリッジは何という名前にしますか?"
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 #, fuzzy
 msgid "Where should this storage pool store its data?"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "スナップショットを含めずにインスタンスのみをバックアップするかどうか"
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
@@ -10011,11 +10024,11 @@ msgstr ""
 "スナップショットからインスタンスの稼動状態をリストアするかどうか (取得可能な"
 "場合)"
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 #, fuzzy
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
@@ -10025,198 +10038,198 @@ msgstr ""
 "ジや --empty が指定されていない場合は、インスタンスの再初期化には元のイメージ"
 "を使います。"
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr "YAML 形式の初期設定値を表示しますか?"
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr "キャッシュされた古いイメージを自動的に更新しますか?"
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr "それらを回復しますか?"
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr "ブリッジ上で IPv4 トラフィックを NAT しますか?"
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr "ブリッジ上で IPv6 トラフィックを NAT しますか?"
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr "失われたボリュームのスキャンを続行しますか?"
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr "%s に新しい btrfs のサブボリュームを作成しますか?"
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr "新しいローカルネットワークブリッジを作成しますか?"
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr "rpool/incus に新しい zfs データセットを作成しますか?"
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr "コンテナの親の割当をコンテナに共有させますか?"
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr "他のストレージプールを回復しますか?"
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr "既存のブリッジかホストのインターフェースを使用しますか?"
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 "既存の空のブロックデバイス（ディスクやパーティションなど）を使用しますか?"
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr "クラスタリングを使用しますか?"
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr "YES"
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr "現在、次のものが不足しています:"
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr "-t と -T は同時に指定できません"
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid "Zone description"
 msgstr "説明"
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "[<remote>:] [<cert>]"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <direction> <key>=<value>..."
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <key>"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <key>=<value>..."
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <new-name>"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "[<remote>:]<ACL> [key=value...]"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
@@ -10251,151 +10264,151 @@ msgstr "[<remote>:]<project> <new-name>"
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <fingerprint>"
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "[<remote>:]<group>"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr "[<remote>:]<image> <remote>:"
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "[<remote>:]<instance> <device> <key>"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr "[<remote>:]<instance> <name>..."
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr "[<remote>:]<instance> [<snapshot name>]"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "[<remote>:]<instance> <snapshot>"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr "[<remote>:]<instance> <template>"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "[<remote>:]<instance> [<snapshot name>]"
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 
@@ -10404,131 +10417,131 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr "[<remote>:] <name>"
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr "[<remote>:]<operation>"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -10536,17 +10549,17 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -10554,7 +10567,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -10562,27 +10575,27 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr "[<remote>:]<network> <peer name>"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "[<remote>:]<network> <peer_name>"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -10591,300 +10604,300 @@ msgstr ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "[<remote>:]<network> <peer_name> <key>"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <key>"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <key>=<value>..."
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [key=value...]"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr "[<remote>:]<pool> <driver> [key=value...]"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr "[<remote>:]<pool> <key>"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "[<remote>:]<profile> <device> <key>"
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 #, fuzzy
 msgid "application"
 msgstr "operation"
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr "現在値"
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr "説明"
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr "無効"
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr "ドライバ"
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr "有効"
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 #, fuzzy
 msgid "ephemeral"
 msgstr "タイプ: %s (ephemeral)"
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
@@ -10916,7 +10929,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 #, fuzzy
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
@@ -10925,7 +10938,7 @@ msgstr ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    member.yaml の内容でクラスターメンバーを更新します"
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 #, fuzzy
 msgid ""
 "incus cluster group assign foo default,bar\n"
@@ -10940,7 +10953,7 @@ msgstr ""
 "lxc cluster group assign foo default\n"
 "    \"foo\" を \"default\" クラスタグループのみ使用するように再設定します。"
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 #, fuzzy
 msgid ""
 "incus cluster group create g1\n"
@@ -10953,7 +10966,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 #, fuzzy
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
@@ -10973,7 +10986,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンス内の /opt にマウントし"
 "ます。"
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 #, fuzzy
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
@@ -10982,7 +10995,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 #, fuzzy
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
@@ -11000,7 +11013,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 #, fuzzy
 msgid ""
 "incus config template create u1 t1\n"
@@ -11013,7 +11026,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 #, fuzzy
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
@@ -11021,8 +11034,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 "lxc init ubuntu:22.04 u1\n"
@@ -11036,7 +11049,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -11050,7 +11063,7 @@ msgstr ""
 "incus exec c1 -- ls -lh /\n"
 "\t\"ls -lh /\" コマンドをインスタンス \"c1\" で実行します"
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 #, fuzzy
 msgid ""
 "incus export u1 backup0.tar.gz\n"
@@ -11059,7 +11072,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -11072,7 +11085,7 @@ msgstr ""
 "\t   インスタンス foo 内に、ターゲットが baz であるシンボリックリンク /bar を"
 "作成します。"
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 #, fuzzy
 msgid ""
 "incus file mount foo/root fooroot\n"
@@ -11082,7 +11095,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 #, fuzzy
 msgid ""
 "incus file pull foo/etc/hosts .\n"
@@ -11093,7 +11106,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 #, fuzzy
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
@@ -11103,7 +11116,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 #, fuzzy
 msgid ""
 "incus image edit <image>\n"
@@ -11118,7 +11131,7 @@ msgstr ""
 "lxc image edit <image> < image.yaml\n"
 "    YAML ファイルからイメージプロパティをロードします"
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 #, fuzzy
 msgid ""
 "incus import backup0.tar.gz\n"
@@ -11127,7 +11140,7 @@ msgstr ""
 "lxc import backup0.tar.gz\n"
 "    backup0.tar.gz を使って新しいインスタンスを作成します。"
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 #, fuzzy
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
@@ -11142,7 +11155,7 @@ msgstr ""
 "lxc info [<remote>:] [--resources]\n"
 "    LXD サーバの情報を表示します。"
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 #, fuzzy
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
@@ -11154,12 +11167,12 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 "lxc launch ubuntu:22.04 u1\n"
@@ -11170,11 +11183,11 @@ msgstr ""
 "lxc launch ubuntu:22.04 v1 --vm\n"
 "    仮想マシンを作成し、起動します"
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 #, fuzzy
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -11184,8 +11197,8 @@ msgid ""
 "incus list -c ns,user.comment:comment\n"
 "  List instances with their running state and user comment."
 msgstr ""
-"lxc list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  \"NAME\"、\"BASE IMAGE\"、\"STATE\"、\"IPV4\"、\"IPV6\"、\"MAC\" カラムを"
 "使ってインスタンスを一覧表示します。\n"
 "  \"BASE IMAGE\" と \"MAC\" と \"IMAGE OS\" はインスタンスの設定から生成した"
@@ -11195,7 +11208,7 @@ msgstr ""
 "lxc list -c ns,user.comment:comment\n"
 "  実行状態とユーザコメントとともにインスタンスを一覧表示します。"
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 #, fuzzy
 msgid ""
 "incus monitor --type=logging\n"
@@ -11216,7 +11229,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 #, fuzzy
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
@@ -11242,7 +11255,7 @@ msgstr ""
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 #, fuzzy
 msgid ""
 "incus network acl create a1\n"
@@ -11268,7 +11281,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 #, fuzzy
 msgid ""
 "incus network create foo\n"
@@ -11287,7 +11300,7 @@ msgstr ""
 "    上流ネットワークに baz を使用する、bar という名前の新しい OVN ネットワー"
 "クを作成します"
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 #, fuzzy
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
@@ -11300,32 +11313,32 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 #, fuzzy
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 #, fuzzy
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 #, fuzzy
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
@@ -11339,7 +11352,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -11367,7 +11380,7 @@ msgstr ""
 "\"default\" と \"web\" プロジェクト内の \"default\" ネットワークの間に、新た"
 "にピアリングを作成します"
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 #, fuzzy
 msgid ""
 "incus network zone create z1\n"
@@ -11380,7 +11393,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 #, fuzzy
 msgid ""
 "incus network zone record create z1 r1\n"
@@ -11393,7 +11406,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 #, fuzzy
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
@@ -11402,7 +11415,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 #, fuzzy
 msgid ""
 "incus profile assign foo default,bar\n"
@@ -11424,7 +11437,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 #, fuzzy
 msgid ""
 "incus profile create p1\n"
@@ -11438,7 +11451,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 #, fuzzy
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
@@ -11458,7 +11471,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 #, fuzzy
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
@@ -11467,7 +11480,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 #, fuzzy
 msgid ""
 "incus project create p1\n"
@@ -11481,7 +11494,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 #, fuzzy
 msgid ""
 "incus project edit <project> < project.yaml\n"
@@ -11490,7 +11503,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 #, fuzzy
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
@@ -11499,7 +11512,7 @@ msgstr ""
 "lxc query -X DELETE --wait /1.0/instances/c1\n"
 "    ローカルのインスタンス \"c1\" を削除します。"
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 #, fuzzy
 msgid ""
 "incus snapshot create u1 snap0\n"
@@ -11514,7 +11527,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 #, fuzzy
 msgid ""
 "incus snapshot restore u1 snap0\n"
@@ -11523,7 +11536,7 @@ msgstr ""
 "lxc snapshot u1 snap0\n"
 "    \"u1\" のスナップショットを \"snap0\" という名前で作成します。"
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 #, fuzzy
 msgid ""
 "incus storage bucket create p1 b01\n"
@@ -11536,7 +11549,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 #, fuzzy
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
@@ -11545,7 +11558,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    bucket.yaml の内容でストレージバケットを更新します。"
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 #, fuzzy
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
@@ -11554,7 +11567,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    key.yaml の内容でストレージバケットの鍵を更新します。"
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 #, fuzzy
 msgid ""
 "incus storage bucket export default b1\n"
@@ -11563,7 +11576,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 #, fuzzy
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
@@ -11572,7 +11585,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 #, fuzzy
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
@@ -11585,7 +11598,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 #, fuzzy
 msgid ""
 "incus storage bucket key show default data foo\n"
@@ -11596,7 +11609,7 @@ msgstr ""
 "    \"default\" プール内の \"data\" という名前のバケットに対する \"foo\" とい"
 "う名前のバケットの鍵のプロパティを表示します。"
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 #, fuzzy
 msgid ""
 "incus storage bucket show default data\n"
@@ -11606,7 +11619,7 @@ msgstr ""
 "lxc storage bucket show default data\n"
 "    \"default\" プール内の \"data\" というバケットのプロパティを表示します。"
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 #, fuzzy
 msgid ""
 "incus storage create s1 dir\n"
@@ -11618,7 +11631,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 #, fuzzy
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -11627,7 +11640,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 #, fuzzy
 msgid ""
 "incus storage volume create default foo\n"
@@ -11642,7 +11655,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 #, fuzzy
 msgid ""
 "incus storage volume edit default container/c1\n"
@@ -11655,7 +11668,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 #, fuzzy
 msgid ""
 "incus storage volume get default data size\n"
@@ -11668,7 +11681,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11685,7 +11698,7 @@ msgstr ""
 "    CD-ROM イメージとして使用するために some-installer.iso を保存する新しいカ"
 "スタムボリュームを作成します"
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 #, fuzzy
 msgid ""
 "incus storage volume info default foo\n"
@@ -11698,7 +11711,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 #, fuzzy
 msgid ""
 "incus storage volume set default data size=1GiB\n"
@@ -11711,7 +11724,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 #, fuzzy
 msgid ""
 "incus storage volume show default foo\n"
@@ -11733,7 +11746,7 @@ msgstr ""
 "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
 "示します。"
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 #, fuzzy
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
@@ -11748,7 +11761,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 #, fuzzy
 msgid ""
 "incus storage volume unset default foo size\n"
@@ -11761,70 +11774,70 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr "ストレージ情報"
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr "名前"
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr "no"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 #, fuzzy
 msgid "please use `incus profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr "使用量"
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
 "てください"
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr "総容量"
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr "サーバに接続できません"
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr "y"
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "yes"
 
@@ -11940,8 +11953,8 @@ msgstr "yes"
 #~ "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 "
 #~ "GiB.\n"
 #~ "\n"
-#~ "incus storage volume set default virtual-machine/data "
-#~ "snapshots.expiry=7d\n"
+#~ "incus storage volume set default virtual-machine/data snapshots."
+#~ "expiry=7d\n"
 #~ "    Sets the snapshot expiration period for a virtual machine \"data\" in "
 #~ "pool \"default\" to seven days."
 #~ msgstr ""
@@ -11958,8 +11971,8 @@ msgstr "yes"
 #~ "incus storage volume create p1 v1\n"
 #~ "\n"
 #~ "incus storage volume create p1 v1 < config.yaml\n"
-#~ "\tCreate storage volume v1 for pool p1 with configuration from "
-#~ "config.yaml."
+#~ "\tCreate storage volume v1 for pool p1 with configuration from config."
+#~ "yaml."
 #~ msgstr ""
 #~ "lxc init ubuntu:22.04 u1\n"
 #~ "\n"
@@ -11968,8 +11981,8 @@ msgstr "yes"
 
 #, fuzzy
 #~ msgid ""
-#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < "
-#~ "volume.yaml\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
 #~ "    Update a storage volume using the content of pool.yaml."
 #~ msgstr ""
 #~ "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -12036,8 +12049,8 @@ msgstr "yes"
 #~ "Provide the type of the storage volume if it is not custom.\n"
 #~ "Supported types are custom, image, container and virtual-machine.\n"
 #~ "\n"
-#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < "
-#~ "volume.yaml\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
 #~ "    Update a storage volume using the content of pool.yaml."
 #~ msgstr ""
 #~ "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
@@ -13090,8 +13103,8 @@ msgstr "yes"
 #~ "lxc image edit [<remote>:]<image>\n"
 #~ "    Edit image, either by launching external editor or reading STDIN.\n"
 #~ "    Example: lxc image edit <image> # launch editor\n"
-#~ "             cat image.yaml | lxc image edit <image> # read from "
-#~ "image.yaml\n"
+#~ "             cat image.yaml | lxc image edit <image> # read from image."
+#~ "yaml\n"
 #~ "\n"
 #~ "lxc image alias create [<remote>:]<alias> <fingerprint>\n"
 #~ "    Create a new alias for an existing image.\n"
@@ -14278,8 +14291,8 @@ msgstr "yes"
 #~ "  f - Base Image Fingerprint (short)\n"
 #~ "  F - Base Image Fingerprint (long)\n"
 #~ "\n"
-#~ "Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-#~ "\":\n"
+#~ "Custom columns are defined with \"[config:|devices:]key[:name][:"
+#~ "maxWidth]\":\n"
 #~ "  KEY: The (extended) config or devices key to display. If [config:|"
 #~ "devices:] is omitted then it defaults to config key.\n"
 #~ "  NAME: Name to display in the column header.\n"
@@ -14319,8 +14332,8 @@ msgstr "yes"
 #~ "  - \"type=container status=running\" 実行中のコンテナインスタンスをすべて"
 #~ "表示します\n"
 #~ "\n"
-#~ "設定項目もしくは値とマッチする正規表現 "
-#~ "(例:volatile.eth0.hwaddr=00:16:3e:.*)。\n"
+#~ "設定項目もしくは値とマッチする正規表現 (例:volatile.eth0.hwaddr=00:16:3e:."
+#~ "*)。\n"
 #~ "\n"
 #~ "複数のフィルタを指定した場合は、指定したフィルタが順に追加され、\n"
 #~ "すべてのフィルタを満たすインスタンスが選択されます。\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  Fastvare:"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  Hovedkort:"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -44,7 +44,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -75,7 +75,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -83,13 +83,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -110,7 +110,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -120,7 +120,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -144,7 +144,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgstr ""
 "###\n"
 "### Bemerk at navnet vises, men kan ikke endres"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -216,7 +216,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -228,7 +228,7 @@ msgstr ""
 "###\n"
 "### Bemerk at navnet vises, men kan ikke endres"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -262,7 +262,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -279,7 +279,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -293,7 +293,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -307,7 +307,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -327,7 +327,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -348,7 +348,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -369,97 +369,97 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -467,24 +467,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -516,41 +516,41 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr ""
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -558,61 +558,61 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr ""
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -620,23 +620,23 @@ msgstr ""
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -644,11 +644,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -660,15 +660,15 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -677,7 +677,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -685,56 +685,56 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -749,102 +749,102 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -852,152 +852,152 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr ""
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -1005,72 +1005,72 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr ""
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr ""
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1079,253 +1079,253 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid "Cluster group description"
 msgstr ""
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1336,54 +1336,54 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1391,42 +1391,42 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1434,11 +1434,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1454,141 +1454,141 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1596,31 +1596,31 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1628,86 +1628,86 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1715,29 +1715,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1750,11 +1750,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1762,51 +1762,51 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr ""
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1814,361 +1814,361 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr ""
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr ""
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2202,110 +2202,110 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2313,60 +2313,60 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2375,32 +2375,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2424,47 +2424,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2474,56 +2474,56 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2552,11 +2552,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2571,22 +2571,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2594,34 +2594,34 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr ""
 
@@ -2632,241 +2632,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2876,104 +2876,104 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -2989,96 +2989,96 @@ msgstr ""
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3102,7 +3102,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3112,36 +3112,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3154,7 +3154,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3163,200 +3163,200 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3368,67 +3368,67 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "navn"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3436,304 +3436,304 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -3743,7 +3743,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3757,58 +3757,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3820,103 +3820,103 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3948,11 +3948,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3974,11 +3974,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4000,11 +4000,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4026,11 +4026,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4052,15 +4052,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4068,11 +4068,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4096,11 +4096,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4123,11 +4123,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4151,15 +4151,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4182,11 +4182,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4207,11 +4207,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4236,11 +4236,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4266,11 +4266,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4294,11 +4294,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4326,19 +4326,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4361,11 +4361,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4438,8 +4438,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4449,15 +4449,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4480,11 +4480,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4507,23 +4507,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4539,11 +4539,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4564,11 +4564,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4590,11 +4590,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4617,11 +4617,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4635,14 +4635,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -4658,11 +4670,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -4688,11 +4700,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4716,11 +4728,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -4743,87 +4755,87 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4831,57 +4843,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -4889,23 +4901,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -4925,32 +4937,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -4958,249 +4970,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5211,164 +5223,164 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5384,217 +5396,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5618,169 +5630,169 @@ msgstr ""
 msgid "Network address set description"
 msgstr ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5791,19 +5803,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -5811,31 +5823,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5848,171 +5860,171 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6028,258 +6040,258 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6292,24 +6304,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6319,13 +6331,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6340,40 +6352,40 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6385,44 +6397,44 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6430,49 +6442,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6480,19 +6492,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6500,281 +6512,281 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6783,7 +6795,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6792,15 +6804,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6809,11 +6821,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6826,11 +6838,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6839,11 +6851,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6852,11 +6864,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -6866,11 +6878,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6879,11 +6891,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6892,11 +6904,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6905,15 +6917,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6922,11 +6934,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6935,11 +6947,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6948,11 +6960,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6961,11 +6973,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6983,39 +6995,39 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7023,135 +7035,135 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7159,64 +7171,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr ""
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7228,19 +7240,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7249,94 +7261,94 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7345,13 +7357,13 @@ msgstr ""
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7359,75 +7371,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7436,94 +7448,94 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7531,15 +7543,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7547,36 +7559,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7587,20 +7599,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -7614,7 +7626,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -7623,62 +7635,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7687,107 +7699,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -7802,18 +7814,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -7823,28 +7835,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7858,265 +7870,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8124,67 +8136,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8193,15 +8205,15 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8209,78 +8221,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8289,119 +8301,119 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8411,11 +8423,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8432,235 +8444,235 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8689,142 +8701,142 @@ msgstr ""
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -8832,458 +8844,458 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9306,13 +9318,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9321,7 +9333,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9329,7 +9341,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9340,13 +9352,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9355,7 +9367,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9363,15 +9375,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9381,7 +9393,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9390,13 +9402,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9404,26 +9416,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9432,13 +9444,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9447,7 +9459,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9458,19 +9470,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9481,7 +9493,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9493,7 +9505,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9507,7 +9519,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9523,7 +9535,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9535,7 +9547,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9543,24 +9555,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9569,7 +9581,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9585,7 +9597,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9593,7 +9605,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9601,13 +9613,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9619,7 +9631,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9628,7 +9640,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9639,13 +9651,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9654,19 +9666,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9676,13 +9688,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9692,31 +9704,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9726,21 +9738,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -9749,13 +9761,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9765,7 +9777,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9775,7 +9787,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9785,7 +9797,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9795,7 +9807,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9805,7 +9817,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9815,7 +9827,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9829,7 +9841,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9839,7 +9851,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9849,66 +9861,66 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr "informasjon"
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr "navn"
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr "nei"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr "vennligst bruk `incus profile`"
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr "brukt plass"
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr "sshfs har stoppet"
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr "total plass"
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr "utilgjengelig"
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr "brukt av"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr "j"
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "ja"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
-"Last-Translator: Dklfajsjfi49wefklsf32 "
-"<nlincus@users.noreply.hosted.weblate.org>\n"
+"Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
+"org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/incus/cli/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  Chassis:"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  Firmware:"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  Moederboord:"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -54,7 +54,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -121,7 +121,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde fingerprint niet kan worden aangepast"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -129,7 +129,7 @@ msgstr ""
 "### Dit is een YAML weergave van clustergroep.\n"
 "## Elke regel beginnende met een '# zal worden genegeerd."
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -168,7 +168,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgstr ""
 "### Een voorbeeld hiervan is:\n"
 "###  description: Mijn eigen image"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -228,7 +228,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -309,7 +309,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -354,7 +354,7 @@ msgstr ""
 "### Merk op dat het luisteradres (listen_address) en locatie (location) niet "
 "aangepast kunnen worden."
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -366,7 +366,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de naam wordt getoond, maar aangepast kan worden"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,7 +433,7 @@ msgstr ""
 "### Merk op dat het luisteradres (listen_address) en locatie (location) niet "
 "kunnen worden aangepast."
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -464,7 +464,7 @@ msgstr ""
 "(target_project), bestemming netwerk (target_network) en de status velden "
 "(status fielsds) niet kunnen worden aangepast."
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -490,7 +490,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,7 +515,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###\n"
 "### Merk op dat alleen de configuratie kan worden aangepast."
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -590,7 +590,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde naam (name) niet kan worden aangepast"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -629,7 +629,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde naam (name) niet kan worden aangepast"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -637,96 +637,96 @@ msgstr ""
 "### Dit is een YAML weergave van een clusterlid (cluster member).\n"
 "### Elke regel beginnende met '#' zal worden genegeerd."
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr "%q is geen block device"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr "%q is geen IP adres"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q van pool %q in project %q (bevat %d snapshots)"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d beschikbaar)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, source=%q)"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s is geen directory"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' is geen ondersteund bestandstype"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(geen)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (type: %s): %s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 "--console kan niet gebruikt worden tijden een geforceerde instantiatie "
 "(instance) shutdown"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr "--console kan niet gebruikt worden samen met --all"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr ""
 "--console werkt alleen als het een enkele instantiatie (instance) betreft"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 "--empty kan niet gebruikt worden in combinatie met een virtuele disk (image) "
 "naam (name)"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded kan niet gebruikt worden voor een server"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 "--instance-only kan niet worden doorgegeven, als de bron een snapshot is"
@@ -735,24 +735,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port kan niet gebruikt worden zonder --network-address"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles kan niet gebruikt worden met --refresh"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr "--project kan niet gebruikt worden met de query command"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kan alleen worden gebruikt bij geïnstantieerden (instances)"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr "--target kan alleen gebruikt worden met clusters"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr "--target kan niet gebruikt worden met: instances"
 
@@ -764,7 +764,7 @@ msgstr "<alias>"
 msgid "<alias> <target>"
 msgstr "<alias> <target>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr "<local|global> <Query>"
 
@@ -784,41 +784,41 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr "Een client certificaat is al aanwezig"
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr "Een client naam moet worden meegegeven"
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr "Een clusterlid (cluster member) naam (name) moet worden meegegeven"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr "ADRES"
 
@@ -827,62 +827,62 @@ msgstr "ADRES"
 msgid "ADDRESSES"
 msgstr "ADRES"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIASSEN"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr "AUTHENTICATIE TYPE"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Accepteer certificaat"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr "Toegangssleutel (automatisch gegenereerd wanneer leeg gegeven)"
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr "Toegangssleutel: %s"
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr "Toegang tot de geëxpandeerde configuratie"
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr "Bevestig de waarschuwing"
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Actie %q is niet ondersteund door dit programma"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "Actie (standaard is: GET)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 "Voeg een clusterlid (cluster member) toe aan de clustergroep (cluster group)"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr "Voeg een netwerk (network) zone record toe"
 
@@ -891,23 +891,23 @@ msgstr "Voeg een netwerk (network) zone record toe"
 msgid "Add addresses to a network address set"
 msgstr "Voeg een items toe aan een netwerk (network) zone record"
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr "Voeg een items toe aan een netwerk (network) zone record"
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr "Voeg een lid (member) toe aan een group (group)"
 
@@ -915,11 +915,11 @@ msgstr "Voeg een lid (member) toe aan een group (group)"
 msgid "Add new aliases"
 msgstr "Voeg nieuwe aliassen toe"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "Voeg nieuwe remote servers toe"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -939,15 +939,15 @@ msgstr ""
 "  incus remote add gekozen-naam https://GEBRUIKERSNAAM:PASWOORD@example.com/"
 "een/zeker/pad --protocol=simplestreams\n"
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr "Voeg een vertrouwde cliënt (client) toe"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -956,7 +956,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -964,60 +964,60 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr "Voeg poorten (ports) toe aan een doorstuurregel (forward)"
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr "Voeg poorten (ports) toe aan een werkverdeler (load balancer)"
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr "Voeg profielen (profiles) toe aan instantiaties (instances)"
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr "Voeg rollen (roles) toe aan een clusterlid (cluster member)"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 "Voeg regels (rules) toe aan een toegangscontrole lijst (Access Control List "
 "(ACL))"
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 "Aanvullende opslag (storage) poel (pool) configuratie (configuration) "
 "eigenschappen (SLEUTEL=WAARDE, laat leeg wanneer klaar):"
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr "Adres (Address) om aan te verbinden (bind) (standaard: geen)"
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr "Adres: %v"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Beheer (Admin) toegangssleutel: %s"
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Beheer (Admin) geheime toegangssleutel (secret key): %s"
@@ -1032,111 +1032,111 @@ msgstr "Alias %s bestaat al"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s bestaat niet"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "Alias naam (name) mist"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr "Alias: %s"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr "Aliassen bestaan al: %s"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Aliassen:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 "Alle huidige gegevens gaan verloren bij het lid worden (joining) van een "
 "cluster, doorgaan?"
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr "Alle projecten"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr "Alle server adressen zijn onbeschikbaar"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "Architectuur: %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr "Wilt u lid worden (joining) van een bestaand cluster?"
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr "Weet je zeker dat je %s wilt clusteren met %q ? (yes/no) "
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 "Beide konden niet worden gevonden, de directe SPICE plug (raw SPICE socket) "
 "kan hier gevonden worden:"
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 "Gevraagd naar een virtueel machine (VM), maar het bestand (image) is van het "
 "type: container"
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr "Wijs collecties van groepen toe aan clusterleden (cluster members)"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 "Wijs collecties van profielen (set of profiles) toe aan instantiaties "
 "(instances)"
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr "Toekennen van netwerk interfaces aan instantiaties (instances)"
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr ""
 "Toekennen van nieuwe aangepaste opslag volumes aan instantiaties (instances)"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Toekennen nieuwe aangepaste opslag volumes aan profielen (profiles)"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr "Toekennen van nieuwe netwerk interfaces aan instantiaties (instances)"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1144,152 +1144,152 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr "BASIS IMAGEBESTAND"
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "Backup aan het maken van instantiatie (instance): %s"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Back-uppen van opslag emmer (storage bucket): %s"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr "Backups:"
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Ongeldig sleutel=waarde paar: %q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ongeldig sleutel=waarde paar: %s"
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "Ongeldig eigenschap: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr "Samenvoeging (Bond):"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr "Beide --all en instantiatie naam (instance name) zijn gegeven"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr "Merk (Brand): %v"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr "Brug (Bridge):"
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr "Bus Adres: %v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "ONDERBREEKBAAR"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "GEWONE NAAM"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr "INHOUDSTYPE"
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr "SOM"
 
@@ -1297,74 +1297,74 @@ msgstr "SOM"
 msgid "CPU TIME(s)"
 msgstr "CPU TIJD(s)"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr "CPUs:"
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "GECREËERD"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "GECREËERD OM"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr "Caches:"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr "Kan niet binden (bind) aan adres (address) %q: %w"
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "Niet mogelijk om geforceerd (override) de configuratie of de profielen in "
 "een lokaal (local) herbenaming (rename) uit te voeren"
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1373,253 +1373,253 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid "Cluster group description"
 msgstr ""
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr "Clustering aan"
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Kolommen"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr "Lijncommando client voor Incus"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1638,54 +1638,54 @@ msgstr ""
 "Aangepaste opdrachten kunnen worden gedefinieerd door aliassen, gebruik "
 "\"incus alias\" om die te controleren."
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Compressie algoritme om te gebruiken (`none` is geen compressie)"
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Compressie algoritme om te gebruiken (none is zonder compressie)"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuratie sleutel/waarde toe te passen op de nieuwe instantiatie"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1693,42 +1693,42 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr "Kopieer aangepaste opslag volumes"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1736,11 +1736,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1756,141 +1756,141 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1898,31 +1898,31 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr "Creëer netwerk integraties"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1931,86 +1931,86 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr "Creëer netwerk integraties"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2018,29 +2018,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr "Datum: %s"
@@ -2053,11 +2053,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2065,51 +2065,51 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr "Verwijder aangepaste opslag volumes (storage volume)"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr ""
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2118,361 +2118,361 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr "Verwijder netwerk integratie"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr "Verwijder netwerk integratie"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr "Ontkoppel aangepaste opslag volumes van een instantiatie (instance)"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr "Ontkoppel aangepaste opslag volumes van profielen (profiles)"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr "Device: %d:"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr "Device Adres: %v"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr ""
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr "Toon netwerk zones van alle projecten"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr "Toon profielen van alle projecten"
 
@@ -2480,7 +2480,7 @@ msgstr "Toon profielen van alle projecten"
 msgid "Display resource usage info per instance"
 msgstr "Toon resource gebruik per instantiatie"
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr "Toon opslag pool emmers (buckets) van alle projecten"
 
@@ -2506,110 +2506,110 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr "Wilt u een nieuwe lokale opslag pool configureren?"
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr "Toon geen voortgang indicator/informatie"
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr "Stuurprogramma: %v"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "Stuurprogramma: %v (%v)"
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr "Dump YAML configuratie naar standaard uitvoer (stdout)"
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2618,60 +2618,60 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr "Definieer de netwerk integratie configuratie sleutels (keys)"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2680,32 +2680,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2729,47 +2729,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2779,56 +2779,56 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2857,11 +2857,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2876,22 +2876,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2899,34 +2899,34 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr ""
 
@@ -2937,241 +2937,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Exporteren van de backup van opslag (storage) emmer (bucket): %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -3181,104 +3181,104 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3294,96 +3294,96 @@ msgstr ""
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3407,7 +3407,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3417,36 +3417,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3459,7 +3459,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3468,200 +3468,200 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr "Genereer het client certificaat"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr "Opvragen sleutel (key) als cluster groep eigenschap (property)"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr "Opvragen sleutel (key) als netwerk integratie eigenschap (property)"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr "Opvragen waarden van cluster groep configuratie sleutels (keys)"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3673,66 +3673,66 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3740,304 +3740,304 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr "Importeer aangepaste opslag volumes (storage volume)."
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -4047,7 +4047,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -4061,58 +4061,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -4124,103 +4124,103 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4253,11 +4253,11 @@ msgstr "Toon lijst van netwerken in alle projecten"
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4279,11 +4279,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4305,11 +4305,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4331,11 +4331,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4357,15 +4357,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4373,11 +4373,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4401,11 +4401,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4428,11 +4428,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4456,15 +4456,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4487,11 +4487,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4512,11 +4512,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4541,11 +4541,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4571,11 +4571,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4599,11 +4599,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4631,19 +4631,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4666,11 +4666,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4743,8 +4743,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4754,15 +4754,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4785,11 +4785,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr "Toon lijst van netwerk integraties"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4812,23 +4812,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr "Toon lijst van netwerken in alle projecten"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4844,11 +4844,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4869,11 +4869,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4895,11 +4895,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4922,11 +4922,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4940,14 +4940,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -4963,11 +4975,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -4993,11 +5005,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5021,11 +5033,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5048,87 +5060,87 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5136,57 +5148,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -5194,23 +5206,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5230,32 +5242,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -5264,249 +5276,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr "Beheer netwerk integraties"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr "Beheer netwerk integraties"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5518,164 +5530,164 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr "Netwerk integratie naam mist"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr "Netwerk integratie naam mist"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5691,217 +5703,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5925,169 +5937,169 @@ msgstr ""
 msgid "Network address set description"
 msgstr ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6098,19 +6110,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr "OS Versie"
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6118,31 +6130,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6155,171 +6167,171 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6335,258 +6347,258 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr "Product Id: %v"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr "Product: %v"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6599,24 +6611,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6626,13 +6638,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6647,40 +6659,40 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6692,44 +6704,44 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6737,49 +6749,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr "Hernoem aangepaste opslag volumes"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6788,19 +6800,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr "Hernoem netwerk integraties"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr "Hernoem netwerk integraties"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6808,281 +6820,281 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr "GESTART OM"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr "Serie Nummer: %v"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr "Serienummer: %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr "Serienummer: %v"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr "Definieer een cluster groep configuratie sleutels (keys)"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7091,7 +7103,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7100,15 +7112,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7117,11 +7129,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7135,11 +7147,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Definieer de netwerk integratie configuratie sleutels (keys)"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7148,11 +7160,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7161,11 +7173,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr "Definieer de netwerk integratie configuratie sleutels (keys)"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7175,11 +7187,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7188,11 +7200,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7201,11 +7213,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7214,15 +7226,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7231,11 +7243,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7244,11 +7256,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7257,11 +7269,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7270,11 +7282,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7292,40 +7304,40 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 "Definieer de sleutel (key) voor markering als een cluster groep eigenschap"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7335,136 +7347,136 @@ msgid "Set the key as a network address set property"
 msgstr ""
 "Definieer de sleutel (key) als een netwerk integratie eigenschap (property)"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 "Definieer de sleutel (key) als een netwerk integratie eigenschap (property)"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7473,64 +7485,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr "Definieer de netwerk integratie configuratie sleutels (keys)"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr "Toon de netwerk integratie opties"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7542,19 +7554,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7563,94 +7575,94 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7659,13 +7671,13 @@ msgstr ""
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7673,75 +7685,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr "Gestart: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7750,94 +7762,94 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7845,15 +7857,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7861,36 +7873,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7901,20 +7913,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -7928,7 +7940,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -7937,62 +7949,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8001,107 +8013,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8116,18 +8128,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8137,28 +8149,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8172,265 +8184,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr "Verwijder de cluster groep eigenschappen (keys)"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8439,67 +8451,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr "Definieer de netwerk integratie configuratie sleutels (keys)"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8508,16 +8520,16 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 "Verwijder de sleutel (key) voor markering als een cluster groep eigenschap"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8526,78 +8538,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Opvragen sleutel (key) als netwerk integratie eigenschap (property)"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8606,119 +8618,119 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr "Maker ID: %v"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr "Maker: %s"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr "Versie: %s"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr "Versie: %v"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8728,11 +8740,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8749,235 +8761,235 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -9006,142 +9018,142 @@ msgstr ""
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -9149,458 +9161,458 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9623,13 +9635,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9638,7 +9650,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9646,7 +9658,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9657,13 +9669,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9672,7 +9684,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9680,15 +9692,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9698,7 +9710,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9707,13 +9719,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9721,26 +9733,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9749,13 +9761,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9764,7 +9776,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9775,19 +9787,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9798,7 +9810,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9810,7 +9822,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9824,7 +9836,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9840,7 +9852,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9852,7 +9864,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9860,24 +9872,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9886,7 +9898,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9902,7 +9914,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9910,7 +9922,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9918,13 +9930,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9936,7 +9948,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9945,7 +9957,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9956,13 +9968,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9971,19 +9983,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9993,13 +10005,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10009,31 +10021,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10043,21 +10055,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -10066,13 +10078,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10082,7 +10094,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10092,7 +10104,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10102,7 +10114,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10112,7 +10124,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10122,7 +10134,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10132,7 +10144,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10146,7 +10158,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10156,7 +10168,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10173,67 +10185,67 @@ msgstr ""
 "    Verwijdert de snapshot houdbaarheidsperiode van de virtuele machine "
 "volume \"v1\" in pool \"default\""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr "informatie"
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr "n"
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr "naam"
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr "nee"
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (j/n/[vingerafdruk])?"
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr "gebruik `incus profile`"
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr "ruimte gebruikt"
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr "sshfs is gestopt"
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs koppelen van %q op %q"
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr "sshfs niet gevonden. Probeer SSH SFTP methode via de --listen optie"
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr "totale ruimte"
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr "onbereikbaar"
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr "gebruikt door"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr "j"
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "ja"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,19 +16,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -41,7 +41,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -58,7 +58,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -80,13 +80,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -117,7 +117,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -141,7 +141,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "###  user.foo: bar\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -216,7 +216,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -267,7 +267,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -295,7 +295,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,7 +315,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -336,7 +336,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -357,97 +357,97 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -455,24 +455,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -504,41 +504,41 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr ""
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -546,61 +546,61 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr ""
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -632,11 +632,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -648,15 +648,15 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -665,7 +665,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -673,56 +673,56 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -737,102 +737,102 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -840,152 +840,152 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr ""
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -993,72 +993,72 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr ""
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr ""
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1067,253 +1067,253 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid "Cluster group description"
 msgstr ""
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1324,54 +1324,54 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1379,42 +1379,42 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1422,11 +1422,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1442,141 +1442,141 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1584,31 +1584,31 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1616,86 +1616,86 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1703,29 +1703,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1738,11 +1738,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1750,51 +1750,51 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr ""
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1802,361 +1802,361 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr ""
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr ""
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2190,110 +2190,110 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2301,60 +2301,60 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2363,32 +2363,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2412,47 +2412,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2462,56 +2462,56 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2540,11 +2540,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2559,22 +2559,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2582,34 +2582,34 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr ""
 
@@ -2620,241 +2620,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2864,104 +2864,104 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -2977,96 +2977,96 @@ msgstr ""
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3090,7 +3090,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3100,36 +3100,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3142,7 +3142,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3151,200 +3151,200 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3356,66 +3356,66 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3423,304 +3423,304 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -3730,7 +3730,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3744,58 +3744,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3807,103 +3807,103 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3935,11 +3935,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3961,11 +3961,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -3987,11 +3987,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4013,11 +4013,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4039,15 +4039,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4055,11 +4055,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4083,11 +4083,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4110,11 +4110,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4138,15 +4138,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4169,11 +4169,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4194,11 +4194,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4223,11 +4223,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4253,11 +4253,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4281,11 +4281,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4313,19 +4313,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4348,11 +4348,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4425,8 +4425,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4436,15 +4436,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4467,11 +4467,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4494,23 +4494,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4526,11 +4526,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4551,11 +4551,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4577,11 +4577,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4604,11 +4604,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4622,14 +4622,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -4645,11 +4657,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -4675,11 +4687,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4703,11 +4715,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -4730,87 +4742,87 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4818,57 +4830,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -4876,23 +4888,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -4912,32 +4924,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -4945,249 +4957,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5198,164 +5210,164 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5371,217 +5383,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5605,169 +5617,169 @@ msgstr ""
 msgid "Network address set description"
 msgstr ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5778,19 +5790,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -5798,31 +5810,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5835,171 +5847,171 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6015,258 +6027,258 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6279,24 +6291,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6306,13 +6318,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6327,40 +6339,40 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6372,44 +6384,44 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6417,49 +6429,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6467,19 +6479,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6487,281 +6499,281 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6770,7 +6782,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6779,15 +6791,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6796,11 +6808,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6813,11 +6825,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6826,11 +6838,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6839,11 +6851,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -6853,11 +6865,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6866,11 +6878,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6879,11 +6891,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6892,15 +6904,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6909,11 +6921,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6922,11 +6934,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6935,11 +6947,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6948,11 +6960,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6970,39 +6982,39 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7010,135 +7022,135 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7146,64 +7158,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr ""
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7215,19 +7227,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7236,94 +7248,94 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7332,13 +7344,13 @@ msgstr ""
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7346,75 +7358,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7423,94 +7435,94 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7518,15 +7530,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7534,36 +7546,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7574,20 +7586,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -7601,7 +7613,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -7610,62 +7622,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7674,107 +7686,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -7789,18 +7801,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -7810,28 +7822,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7845,265 +7857,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8111,67 +8123,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8180,15 +8192,15 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8196,78 +8208,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8276,119 +8288,119 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8398,11 +8410,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8419,235 +8431,235 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8676,142 +8688,142 @@ msgstr ""
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -8819,458 +8831,458 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9293,13 +9305,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9308,7 +9320,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9316,7 +9328,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9327,13 +9339,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9342,7 +9354,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9350,15 +9362,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9368,7 +9380,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9377,13 +9389,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9391,26 +9403,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9419,13 +9431,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9434,7 +9446,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9445,19 +9457,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9468,7 +9480,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9480,7 +9492,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9494,7 +9506,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9510,7 +9522,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9522,7 +9534,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9530,24 +9542,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9556,7 +9568,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9572,7 +9584,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9580,7 +9592,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9588,13 +9600,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9606,7 +9618,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9615,7 +9627,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9626,13 +9638,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9641,19 +9653,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9663,13 +9675,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9679,31 +9691,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9713,21 +9725,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -9736,13 +9748,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9752,7 +9764,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9762,7 +9774,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9772,7 +9784,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9782,7 +9794,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9792,7 +9804,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9802,7 +9814,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9816,7 +9828,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9826,7 +9838,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9836,66 +9848,66 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -54,7 +54,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -85,7 +85,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -111,7 +111,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -123,7 +123,7 @@ msgstr ""
 "###\n"
 "### Observe que a impressão digital é exibida, mas não pode ser alterada"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -131,7 +131,7 @@ msgstr ""
 "### Esta é uma representação de yaml do grupo de cluster.\n"
 "### Qualquer linha começando com um '#' será ignorada."
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -170,7 +170,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -186,7 +186,7 @@ msgstr ""
 "### Um exemplo seria:\n"
 "###  description: Minha imagem personalizada"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -230,7 +230,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -302,7 +302,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -343,7 +343,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network integration.\n"
@@ -356,7 +356,7 @@ msgstr ""
 "###\n"
 "### Observe que a impressão digital é exibida, mas não pode ser alterada"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -407,7 +407,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -439,7 +439,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -465,7 +465,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -491,7 +491,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -528,7 +528,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -567,7 +567,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -603,7 +603,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -611,96 +611,96 @@ msgstr ""
 "### Essa é uma representação yaml do membro do cluster.\n"
 "### Qualquer linha iniciando em '# será ignorada"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, fuzzy, c-format
 msgid "%q is not a block device"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, fuzzy, c-format
 msgid "%q is not an IP address"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, fuzzy, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Nível %d (tipo: %s): %s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partição %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
@@ -710,28 +710,28 @@ msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 msgid "--network-port can't be used without --network-address"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 #, fuzzy
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 #, fuzzy
 msgid "--target can only be used with clusters"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -764,45 +764,45 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 #, fuzzy
 msgid "<remote>: <path>"
 msgstr "Criar perfis"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Certificado do cliente armazenado no servidor: "
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 #, fuzzy
 msgid "A cluster member name must be provided"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -810,63 +810,63 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "Ação (padrão para o GET)"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -875,24 +875,24 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -900,11 +900,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -916,17 +916,17 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 #, fuzzy
 msgid "Add new trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -935,7 +935,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -943,59 +943,59 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, fuzzy, c-format
 msgid "Address: %v"
 msgstr "O dispositivo já existe: %s"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
@@ -1010,111 +1010,111 @@ msgstr "Alias %s já existe"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Aliases:"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, fuzzy, c-format
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 #, fuzzy
 msgid "Attach network interfaces to instances"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 #, fuzzy
 msgid "Attach new custom storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 #, fuzzy
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1122,155 +1122,155 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 #, fuzzy
 msgid "Backend description"
 msgstr "Descrição"
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, fuzzy, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 #, fuzzy
 msgid "Bucket description"
 msgstr "Descrição"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "CANCELÁVEL"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -1279,74 +1279,74 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 #, fuzzy
 msgid "CPUs:"
 msgstr "CPUs:"
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 #, fuzzy
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, fuzzy, c-format
 msgid "Can't read from environment file: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
@@ -1355,258 +1355,258 @@ msgstr "Não é possível ler stdin: %s"
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 #, fuzzy
 msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, fuzzy, c-format
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 #, fuzzy
 msgid "Certificate description"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr "Clustering ativado"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, fuzzy, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Colunas"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 #, fuzzy
 msgid "Command line client for Incus"
 msgstr "Cliente de linha de comando para LXD"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 #, fuzzy
 msgid ""
 "Command line client for Incus\n"
@@ -1623,59 +1623,59 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 #, fuzzy
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 #, fuzzy
 msgid "Config key/value to apply to the new network integration"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1683,43 +1683,43 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Criar novas redes"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1727,12 +1727,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 #, fuzzy
 msgid "Copy instances within or in between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1748,145 +1748,145 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, fuzzy, c-format
 msgid "Create a new %s pool?"
 msgstr "Criar novas redes"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, fuzzy, c-format
 msgid "Create instance backup: %w"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 #, fuzzy
 msgid "Create instance snapshot"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 #, fuzzy
 msgid ""
 "Create instance snapshots\n"
@@ -1899,34 +1899,34 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 #, fuzzy
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
@@ -1936,92 +1936,92 @@ msgstr "Criar novas redes"
 msgid "Create new network address sets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2029,29 +2029,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "DRIVER"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Criado: %s"
@@ -2065,11 +2065,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -2078,57 +2078,57 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 #, fuzzy
 msgid "Delete instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 #, fuzzy
 msgid "Delete instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
@@ -2138,379 +2138,379 @@ msgstr "Criar novas redes"
 msgid "Delete network address sets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Em cache: %s"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "Dispositivo %s sobreposto em %s"
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "O dispositivo já existe: %s"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr "O dispositivo já existe: %s"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Alias %s não existe"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr "Desabilitar alocação de pseudo-terminal"
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
@@ -2519,7 +2519,7 @@ msgstr "Criar projetos"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Criar projetos"
@@ -2546,116 +2546,116 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 #, fuzzy
 msgid "Edit instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2665,68 +2665,68 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network address set configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2735,33 +2735,33 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 #, fuzzy
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2785,47 +2785,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, fuzzy, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2835,57 +2835,57 @@ msgstr "Editar propriedades da imagem"
 msgid "Error setting term size %s"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr "Tipo de evento a escutar"
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2914,11 +2914,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2933,22 +2933,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2957,35 +2957,35 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Clustering ativado"
@@ -2997,241 +2997,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Criar novas redes"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, fuzzy, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, fuzzy, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, fuzzy, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, fuzzy, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, fuzzy, c-format
 msgid "Failed import request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, fuzzy, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, fuzzy, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, fuzzy, c-format
 msgid "Failed to close export file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, fuzzy, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, fuzzy, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, fuzzy, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, fuzzy, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Aceitar certificado"
@@ -3241,104 +3241,104 @@ msgstr "Aceitar certificado"
 msgid "Failed to dump instance memory: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, fuzzy, c-format
 msgid "Failed to join cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, fuzzy, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, fuzzy, c-format
 msgid "Failed to parse servers: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, fuzzy, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, fuzzy, c-format
 msgid "Failed to rename export file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, fuzzy, c-format
 msgid "Failed to render the config: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, fuzzy, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, fuzzy, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, fuzzy, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, fuzzy, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, fuzzy, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3354,97 +3354,97 @@ msgstr "Aceitar certificado"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, fuzzy, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, fuzzy, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, fuzzy, c-format
 msgid "Failed validation request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3468,7 +3468,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3478,36 +3478,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3520,7 +3520,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3529,226 +3529,226 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Criar novas redes"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 #, fuzzy
 msgid "Get values for network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3760,66 +3760,66 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr "ID"
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3827,313 +3827,313 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr "IPV4"
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr "IPV6"
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Criar novas redes"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 #, fuzzy
 msgid "Incus - Command line client"
 msgstr "Cliente de linha de comando para LXD"
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "Descrição"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "Versão do cliente: %s\n"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "Editar arquivos no container"
@@ -4143,7 +4143,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid format %q"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
@@ -4157,59 +4157,59 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "Versão do cliente: %s\n"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -4224,105 +4224,105 @@ msgstr "Editar arquivos no container"
 msgid "Invalid sorting type provided"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, fuzzy, c-format
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 #, fuzzy
 msgid "Key description"
 msgstr "Descrição"
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Arquitetura: %v"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4355,12 +4355,12 @@ msgstr "Criar projetos"
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4382,12 +4382,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4409,12 +4409,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4436,11 +4436,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4462,15 +4462,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4479,11 +4479,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4507,12 +4507,12 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4535,11 +4535,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4563,16 +4563,16 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4595,11 +4595,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4620,11 +4620,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4649,11 +4649,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4679,11 +4679,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4707,11 +4707,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4739,21 +4739,21 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 #, fuzzy
 msgid "List instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4776,11 +4776,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4853,8 +4853,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4864,17 +4864,17 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4897,12 +4897,12 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4925,25 +4925,25 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4959,11 +4959,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4984,11 +4984,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -5010,11 +5010,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5037,12 +5037,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5056,14 +5056,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5079,11 +5091,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5109,11 +5121,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5137,11 +5149,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5164,89 +5176,89 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 #, fuzzy
 msgid "Lower device"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 #, fuzzy
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, fuzzy, c-format
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5254,57 +5266,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Nome de membro do cluster"
@@ -5313,25 +5325,25 @@ msgstr "Nome de membro do cluster"
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5351,37 +5363,37 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 #, fuzzy
 msgid "Manage instance and server configuration options"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 #, fuzzy
 msgid "Manage instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 #, fuzzy
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
@@ -5391,271 +5403,271 @@ msgstr "Criar novas redes"
 msgid "Manage network address sets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 #, fuzzy
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 #, fuzzy
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
@@ -5668,175 +5680,175 @@ msgstr "Nome de membro do cluster"
 msgid "Missing network address set name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 #, fuzzy
 msgid "Monitor a local or remote server"
 msgstr "Adicionar novos servidores remoto"
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5852,218 +5864,218 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "Apagar projetos"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -6088,171 +6100,171 @@ msgstr ""
 msgid "Network address set description"
 msgstr "Descrição"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr "Descrição"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, fuzzy, c-format
 msgid "Network integration %s created"
 msgstr "Clustering ativado"
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6263,20 +6275,20 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 #, fuzzy
 msgid "OS Version"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6284,31 +6296,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6322,176 +6334,176 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Criando %s"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "PCI device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, fuzzy, c-format
 msgid "Path %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 #, fuzzy
 msgid "Peer description"
 msgstr "Descrição"
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 #, fuzzy
 msgid "Please provide join token:"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 #, fuzzy
 msgid "Port description"
 msgstr "Descrição"
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6507,269 +6519,269 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 #, fuzzy
 msgid "Profile description"
 msgstr "Descrição"
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 #, fuzzy
 msgid "Project description"
 msgstr "Descrição"
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 #, fuzzy
 msgid "Record description"
 msgstr "Descrição"
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6782,24 +6794,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6809,13 +6821,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6830,42 +6842,42 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -6879,49 +6891,49 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -6930,55 +6942,55 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, fuzzy, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 #, fuzzy
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
@@ -6988,20 +7000,20 @@ msgstr "Criar novas redes"
 msgid "Rename network address sets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -7009,49 +7021,49 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 #, fuzzy
 msgid "Restart instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 #, fuzzy
 msgid ""
 "Restore instance from snapshots\n"
@@ -7063,245 +7075,245 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 #, fuzzy
 msgid "Rule description"
 msgstr "Descrição"
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "CRIADO EM"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7310,7 +7322,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7319,17 +7331,17 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7338,12 +7350,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7357,11 +7369,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7370,12 +7382,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7384,12 +7396,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7399,12 +7411,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7413,12 +7425,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7427,12 +7439,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7441,16 +7453,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7459,12 +7471,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7473,12 +7485,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7487,11 +7499,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7500,11 +7512,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7522,40 +7534,40 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7564,151 +7576,151 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 #, fuzzy
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 #, fuzzy
 msgid "Show network ACL configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7718,73 +7730,73 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network address set configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7796,22 +7808,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7820,99 +7832,99 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 #, fuzzy
 msgid "Snapshot description"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -7921,13 +7933,13 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7935,75 +7947,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr "Clustering ativado"
@@ -8012,98 +8024,98 @@ msgstr "Clustering ativado"
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr "Clustering ativado"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 #, fuzzy
 msgid "Storage pool to use or create"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -8111,15 +8123,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8127,37 +8139,37 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -8168,20 +8180,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, fuzzy, c-format
 msgid "The %s storage pool already exists"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8195,7 +8207,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8204,62 +8216,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8268,107 +8280,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8383,18 +8395,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8404,28 +8416,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8439,277 +8451,277 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Senha de administrador para %s: "
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "USB device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 #, fuzzy
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -8719,78 +8731,78 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network address set configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8799,16 +8811,16 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8817,87 +8829,87 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8906,122 +8918,122 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 #, fuzzy
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, fuzzy, c-format
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 #, fuzzy
 msgid "Volume description"
 msgstr "Descrição"
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -9031,11 +9043,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -9052,251 +9064,251 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 #, fuzzy
 msgid "Where should this storage pool store its data?"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid "Zone description"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -9332,156 +9344,156 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -9490,513 +9502,513 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -10019,13 +10031,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -10034,7 +10046,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10042,7 +10054,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10053,13 +10065,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -10068,7 +10080,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -10076,15 +10088,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10094,7 +10106,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -10103,13 +10115,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10117,26 +10129,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -10145,13 +10157,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10160,7 +10172,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -10171,19 +10183,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10194,7 +10206,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -10206,7 +10218,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -10220,7 +10232,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -10236,7 +10248,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -10248,7 +10260,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -10256,24 +10268,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -10282,7 +10294,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -10298,7 +10310,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -10306,7 +10318,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10314,13 +10326,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10332,7 +10344,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10341,7 +10353,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10352,13 +10364,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10367,19 +10379,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -10389,13 +10401,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10405,31 +10417,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10439,21 +10451,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -10462,13 +10474,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10478,7 +10490,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10488,7 +10500,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10498,7 +10510,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10508,7 +10520,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10518,7 +10530,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10528,7 +10540,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10542,7 +10554,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10552,7 +10564,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10562,67 +10574,67 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,19 +20,19 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -59,7 +59,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -118,7 +118,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -133,7 +133,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -146,7 +146,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -185,7 +185,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -202,7 +202,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
@@ -244,7 +244,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -318,7 +318,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -359,7 +359,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network integration.\n"
@@ -374,7 +374,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -425,7 +425,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -460,7 +460,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -488,7 +488,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -516,7 +516,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -553,7 +553,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -592,7 +592,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -631,97 +631,97 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, fuzzy, c-format
 msgid "%q is not a block device"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(пусто)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -729,24 +729,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr "Псевдонимы:"
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -779,7 +779,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 #, fuzzy
 msgid "<remote>: <path>"
 msgstr ""
@@ -787,7 +787,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -795,35 +795,35 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 #, fuzzy
 msgid "A client certificate is already present"
 msgstr "Сертификат клиента хранится на сервере: "
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 #, fuzzy
 msgid "A cluster member name must be provided"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -831,63 +831,63 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -896,24 +896,24 @@ msgstr "Копирование образа: %s"
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 #, fuzzy
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -922,11 +922,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -938,16 +938,16 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 #, fuzzy
 msgid "Add new trusted client certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -956,7 +956,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -964,57 +964,57 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -1029,107 +1029,107 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 #, fuzzy
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 #, fuzzy
 msgid "Attach new custom storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 #, fuzzy
 msgid "Attach new custom storage volumes to profiles"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1137,153 +1137,153 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, fuzzy, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -1292,74 +1292,74 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 #, fuzzy
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, fuzzy, c-format
 msgid "Can't read from environment file: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
@@ -1368,255 +1368,255 @@ msgstr "Невозможно прочитать из стандартного в
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, fuzzy, c-format
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, fuzzy, c-format
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 #, fuzzy
 msgid "Cluster group description"
 msgstr " Использование сети:"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, fuzzy, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "Столбцы"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1627,54 +1627,54 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1682,43 +1682,43 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1726,11 +1726,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1746,146 +1746,146 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, fuzzy, c-format
 msgid "Create a new %s pool?"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, fuzzy, c-format
 msgid "Create instance backup: %w"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 #, fuzzy
 msgid "Create instance snapshot"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1893,37 +1893,37 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 #, fuzzy
 msgid "Create network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 #, fuzzy
 msgid "Create new instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1932,94 +1932,94 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 #, fuzzy
 msgid "Create new network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 #, fuzzy
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2027,29 +2027,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Авто-обновление: %s"
@@ -2063,11 +2063,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2075,57 +2075,57 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 #, fuzzy
 msgid "Delete instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 #, fuzzy
 msgid "Delete instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 #, fuzzy
 msgid "Delete instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2134,377 +2134,377 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 #, fuzzy
 msgid "Delete network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 #, fuzzy
 msgid "Display clusters from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 #, fuzzy
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
@@ -2513,7 +2513,7 @@ msgstr "Копирование образа: %s"
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 #, fuzzy
 msgid "Display storage pool buckets from all projects"
 msgstr "Копирование образа: %s"
@@ -2540,112 +2540,112 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, fuzzy, c-format
 msgid "Driver: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 #, fuzzy
 msgid "Edit instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 #, fuzzy
 msgid "Edit instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2654,66 +2654,66 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 #, fuzzy
 msgid "Edit network integration configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2722,32 +2722,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2771,47 +2771,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, fuzzy, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2821,39 +2821,39 @@ msgstr "Копирование образа: %s"
 msgid "Error setting term size %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2861,20 +2861,20 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2903,11 +2903,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2922,22 +2922,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2946,39 +2946,39 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2990,242 +2990,242 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, fuzzy, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, fuzzy, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, fuzzy, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, fuzzy, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, fuzzy, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, fuzzy, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, fuzzy, c-format
 msgid "Failed import request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, fuzzy, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, fuzzy, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, fuzzy, c-format
 msgid "Failed to close export file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, fuzzy, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, fuzzy, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, fuzzy, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, fuzzy, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Принять сертификат"
@@ -3235,104 +3235,104 @@ msgstr "Принять сертификат"
 msgid "Failed to dump instance memory: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, fuzzy, c-format
 msgid "Failed to join cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, fuzzy, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, fuzzy, c-format
 msgid "Failed to parse servers: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, fuzzy, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, fuzzy, c-format
 msgid "Failed to rename export file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, fuzzy, c-format
 msgid "Failed to render the config: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, fuzzy, c-format
 msgid "Failed to request dump: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, fuzzy, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, fuzzy, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, fuzzy, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, fuzzy, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, fuzzy, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3348,97 +3348,97 @@ msgstr "Принять сертификат"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, fuzzy, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, fuzzy, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, fuzzy, c-format
 msgid "Failed validation request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, fuzzy, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3462,7 +3462,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3472,36 +3472,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3514,7 +3514,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3523,222 +3523,222 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 #, fuzzy
 msgid "Generate the client certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 #, fuzzy
 msgid "Get current load balancer status"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 #, fuzzy
 msgid "Get current load-balacner status"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 #, fuzzy
 msgid "Get the key as a cluster group property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 #, fuzzy
 msgid "Get the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 #, fuzzy
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 #, fuzzy
 msgid "Get values for cluster group configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 #, fuzzy
 msgid "Get values for network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3750,68 +3750,68 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "Hostname"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3819,316 +3819,316 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 #, fuzzy
 msgid "Instance description"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 #, fuzzy
 msgid "Invalid IP address or DNS name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, fuzzy, c-format
 msgid "Invalid argument %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 #, fuzzy
 msgid "Invalid arguments"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, fuzzy, c-format
 msgid "Invalid boolean value: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, fuzzy, c-format
 msgid "Invalid cluster join token: %w"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, fuzzy, c-format
 msgid "Invalid expiration date: %w"
 msgstr "Имя контейнера: %s"
@@ -4138,7 +4138,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid format %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
@@ -4152,59 +4152,59 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, fuzzy, c-format
 msgid "Invalid join token: %w"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -4219,104 +4219,104 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid sorting type provided"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:249
+#: cmd/incus/info.go:251
 #, fuzzy, c-format
 msgid "Link detected: %v"
 msgstr "Архитектура: %s"
 
-#: cmd/incus/info.go:251
+#: cmd/incus/info.go:253
 #, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4350,12 +4350,12 @@ msgstr "Копирование образа: %s"
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 #, fuzzy
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4377,12 +4377,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4404,12 +4404,12 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4431,11 +4431,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4457,16 +4457,16 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 #, fuzzy
 msgid "List all warnings"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4475,11 +4475,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4503,12 +4503,12 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 #, fuzzy
 msgid "List available network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4531,11 +4531,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4559,16 +4559,16 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4591,11 +4591,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4616,11 +4616,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4645,11 +4645,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4675,11 +4675,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4703,11 +4703,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4735,22 +4735,22 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 #, fuzzy
 msgid "List instance devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 #, fuzzy
 msgid "List instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 #, fuzzy
 msgid "List instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4773,12 +4773,12 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 #, fuzzy
 msgid "List instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4851,8 +4851,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4862,16 +4862,16 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 #, fuzzy
 msgid "List network ACLs across all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4894,12 +4894,12 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 #, fuzzy
 msgid "List network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4922,25 +4922,25 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 #, fuzzy
 msgid "List networks in all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4956,11 +4956,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4981,12 +4981,12 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -5008,12 +5008,12 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -5036,12 +5036,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5055,15 +5055,27 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5079,11 +5091,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5109,11 +5121,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5137,12 +5149,12 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 #, fuzzy
 msgid "List warnings"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5165,89 +5177,89 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 #, fuzzy
 msgid "Lower device"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 #, fuzzy
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5255,58 +5267,58 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Копирование образа: %s"
@@ -5315,24 +5327,24 @@ msgstr "Копирование образа: %s"
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 #, fuzzy
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5352,37 +5364,37 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 #, fuzzy
 msgid "Manage incus daemon"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 #, fuzzy
 msgid "Manage instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 #, fuzzy
 msgid "Manage instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 #, fuzzy
 msgid "Manage instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -5391,275 +5403,275 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 #, fuzzy
 msgid "Manage network forwards"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 #, fuzzy
 msgid "Manage network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 #, fuzzy
 msgid "Manage network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 #, fuzzy
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 #, fuzzy
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 #, fuzzy
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
@@ -5672,175 +5684,175 @@ msgstr "Имя контейнера: %s"
 msgid "Missing network address set name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 #, fuzzy
 msgid "Missing network integration name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 #, fuzzy
 msgid "Missing required arguments"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5856,222 +5868,222 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 #, fuzzy
 msgid "Name of the OSD storage pool"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 #, fuzzy
 msgid "Name of the new storage pool"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 #, fuzzy
 msgid "Name of the shared LVM volume group:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, fuzzy, c-format
 msgid "Name of the storage backend (%s):"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 #, fuzzy
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 #, fuzzy
 msgid "Network ACL description"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
@@ -6096,174 +6108,174 @@ msgstr " Использование сети:"
 msgid "Network address set description"
 msgstr " Использование сети:"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 #, fuzzy
 msgid "Network description"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 #, fuzzy
 msgid "Network forward description"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, fuzzy, c-format
 msgid "Network integration %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, fuzzy, c-format
 msgid "Network integration %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, fuzzy, c-format
 msgid "Network integration %s renamed to %s"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6274,19 +6286,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6294,31 +6306,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6332,174 +6344,174 @@ msgstr ""
 msgid "Open the web interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 #, fuzzy
 msgid "PCI device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 #, fuzzy
 msgid "PCI devices:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 #, fuzzy
 msgid "Please provide join token:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, fuzzy, c-format
 msgid "Port type: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6515,260 +6527,260 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, fuzzy, c-format
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, fuzzy, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6781,26 +6793,26 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -6810,13 +6822,13 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6831,41 +6843,41 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -6878,48 +6890,48 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6927,53 +6939,53 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, fuzzy, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 #, fuzzy
 msgid "Rename instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 #, fuzzy
 msgid "Rename instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6982,20 +6994,20 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 #, fuzzy
 msgid "Rename network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -7003,293 +7015,293 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 #, fuzzy
 msgid "Restart instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 #, fuzzy
 msgid "Restore instance snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 #, fuzzy
 msgid "Resume instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 #, fuzzy
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Доступные команды:"
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 #, fuzzy
 msgid "STARTED AT"
 msgstr "СОЗДАН"
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 #, fuzzy
 msgid "Set a cluster group's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7298,7 +7310,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7307,15 +7319,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7324,11 +7336,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7342,11 +7354,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7355,12 +7367,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7369,12 +7381,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 #, fuzzy
 msgid "Set network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7384,12 +7396,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7398,12 +7410,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7412,12 +7424,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7426,16 +7438,16 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7444,11 +7456,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7457,12 +7469,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7471,11 +7483,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7484,11 +7496,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7506,40 +7518,40 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 #, fuzzy
 msgid "Set the key as a cluster group property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7548,148 +7560,148 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 #, fuzzy
 msgid "Set the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 #, fuzzy
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 #, fuzzy
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 #, fuzzy
 msgid "Show instance snapshot configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 #, fuzzy
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
@@ -7699,73 +7711,73 @@ msgstr "Копирование образа: %s"
 msgid "Show network address set configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 #, fuzzy
 msgid "Show network integration options"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 #, fuzzy
 msgid "Show network load balancer configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 #, fuzzy
 msgid "Show network peer configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7777,22 +7789,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7801,99 +7813,99 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 #, fuzzy
 msgid "Show the instance's recent log entries"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 #, fuzzy
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -7902,13 +7914,13 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7916,78 +7928,78 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 #, fuzzy
 msgid "Stop instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, fuzzy, c-format
 msgid "Storage bucket %q created"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, fuzzy, c-format
 msgid "Storage bucket %q deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, fuzzy, c-format
 msgid "Storage bucket key %q added"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, fuzzy, c-format
 msgid "Storage bucket key %q removed"
 msgstr " Использование сети:"
@@ -7996,98 +8008,98 @@ msgstr " Использование сети:"
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 #, fuzzy
 msgid "Storage pool description"
 msgstr " Использование сети:"
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 #, fuzzy
 msgid "Storage pool to use or create"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 #, fuzzy
 msgid "Successfully updated cluster certificates"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -8095,15 +8107,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8111,36 +8123,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -8151,20 +8163,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, fuzzy, c-format
 msgid "The %s storage pool already exists"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8178,7 +8190,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8187,62 +8199,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8251,107 +8263,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, fuzzy, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, fuzzy, c-format
 msgid "The property with tag %q does not exist"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8366,18 +8378,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8387,28 +8399,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8422,272 +8434,272 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 #, fuzzy
 msgid "This server is not available on the network"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 #, fuzzy
 msgid "Type of certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 #, fuzzy
 msgid "USB device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 #, fuzzy
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 #, fuzzy
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 #, fuzzy
 msgid "Unset a cluster group's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8696,77 +8708,77 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 #, fuzzy
 msgid "Unset network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8775,16 +8787,16 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 #, fuzzy
 msgid "Unset the key as a cluster group property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8793,89 +8805,89 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 #, fuzzy
 msgid "Unset the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 #, fuzzy
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8884,121 +8896,121 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 #, fuzzy
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 #, fuzzy
 msgid "User aborted configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -9008,11 +9020,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -9029,151 +9041,151 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 #, fuzzy
 msgid "Where should this storage pool store its data?"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 #, fuzzy
 msgid "Would you like the server to be available over the network?"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9181,7 +9193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -9189,14 +9201,14 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9205,7 +9217,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 #, fuzzy
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
@@ -9213,7 +9225,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -9221,7 +9233,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 #, fuzzy
 msgid "[<remote>:] <cert>"
 msgstr ""
@@ -9229,7 +9241,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -9237,7 +9249,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -9245,7 +9257,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -9253,8 +9265,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -9262,7 +9274,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -9270,7 +9282,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -9278,7 +9290,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -9286,7 +9298,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9294,7 +9306,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 #, fuzzy
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
@@ -9302,7 +9314,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 #, fuzzy
 msgid "[<remote>:]<API path>"
 msgstr ""
@@ -9310,8 +9322,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -9319,7 +9331,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -9327,7 +9339,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9335,7 +9347,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9392,7 +9404,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9400,7 +9412,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 #, fuzzy
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
@@ -9408,7 +9420,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9416,8 +9428,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 #, fuzzy
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
@@ -9425,8 +9437,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -9434,7 +9446,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 #, fuzzy
 msgid "[<remote>:]<group> <key>"
 msgstr ""
@@ -9442,7 +9454,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 #, fuzzy
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
@@ -9450,7 +9462,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -9458,7 +9470,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -9466,7 +9478,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -9474,7 +9486,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -9482,7 +9494,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -9490,7 +9502,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
@@ -9498,7 +9510,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9506,7 +9518,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -9514,7 +9526,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9522,10 +9534,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -9533,7 +9545,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -9541,7 +9553,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -9549,7 +9561,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
@@ -9557,7 +9569,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -9565,7 +9577,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 #, fuzzy
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
@@ -9573,7 +9585,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -9581,7 +9593,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 #, fuzzy
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
@@ -9589,7 +9601,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9597,7 +9609,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -9605,7 +9617,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
@@ -9613,7 +9625,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 #, fuzzy
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
@@ -9621,8 +9633,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 #, fuzzy
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
@@ -9630,7 +9642,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
@@ -9638,7 +9650,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 #, fuzzy
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
@@ -9646,8 +9658,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -9655,7 +9667,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 #, fuzzy
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
@@ -9671,7 +9683,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -9679,7 +9691,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9687,7 +9699,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -9695,7 +9707,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9703,7 +9715,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9712,7 +9724,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -9720,7 +9732,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -9728,9 +9740,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -9738,8 +9750,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -9747,7 +9759,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -9755,7 +9767,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -9763,7 +9775,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -9771,7 +9783,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -9779,7 +9791,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 #, fuzzy
 msgid "[<remote>:]<name>"
 msgstr ""
@@ -9787,8 +9799,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 #, fuzzy
 msgid "[<remote>:]<network integration>"
 msgstr ""
@@ -9796,7 +9808,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
@@ -9804,7 +9816,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 #, fuzzy
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
@@ -9812,7 +9824,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 #, fuzzy
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
@@ -9820,7 +9832,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 #, fuzzy
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
@@ -9828,10 +9840,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -9839,7 +9851,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -9847,7 +9859,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
@@ -9855,7 +9867,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -9863,7 +9875,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -9871,11 +9883,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -9883,7 +9895,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -9891,7 +9903,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -9901,9 +9913,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -9911,7 +9923,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -9919,7 +9931,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -9929,13 +9941,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9943,7 +9955,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
@@ -9951,7 +9963,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -9959,7 +9971,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 #, fuzzy
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
@@ -9967,7 +9979,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -9975,7 +9987,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
@@ -9985,7 +9997,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -9993,7 +10005,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -10001,7 +10013,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -10009,7 +10021,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -10017,7 +10029,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -10025,7 +10037,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -10033,8 +10045,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10042,7 +10054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -10050,7 +10062,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10058,8 +10070,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -10067,9 +10079,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -10077,7 +10089,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -10085,7 +10097,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -10093,7 +10105,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -10101,7 +10113,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 #, fuzzy
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
@@ -10109,7 +10121,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 #, fuzzy
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
@@ -10117,7 +10129,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 #, fuzzy
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
@@ -10125,7 +10137,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10133,7 +10145,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10141,7 +10153,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10149,7 +10161,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -10157,7 +10169,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10165,7 +10177,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10173,7 +10185,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10181,7 +10193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10189,7 +10201,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10197,7 +10209,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10205,7 +10217,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10213,8 +10225,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10222,7 +10234,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10230,7 +10242,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10238,7 +10250,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10246,7 +10258,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10254,7 +10266,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10262,9 +10274,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10272,7 +10284,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -10280,7 +10292,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -10288,7 +10300,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
@@ -10296,7 +10308,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10304,7 +10316,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10312,7 +10324,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -10320,7 +10332,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10328,7 +10340,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -10336,8 +10348,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10345,7 +10357,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10353,7 +10365,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10361,7 +10373,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10369,7 +10381,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -10377,7 +10389,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -10385,7 +10397,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -10393,8 +10405,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -10402,7 +10414,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -10410,7 +10422,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -10418,7 +10430,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -10426,7 +10438,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -10434,7 +10446,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -10442,7 +10454,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 #, fuzzy
 msgid "[<remote>:][<instance>]"
 msgstr ""
@@ -10450,7 +10462,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -10458,7 +10470,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -10466,7 +10478,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -10474,7 +10486,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -10482,35 +10494,35 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -10533,13 +10545,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -10548,7 +10560,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -10556,7 +10568,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10567,13 +10579,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -10582,7 +10594,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -10590,15 +10602,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10608,7 +10620,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -10617,13 +10629,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10631,26 +10643,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -10659,13 +10671,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -10674,7 +10686,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -10685,19 +10697,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10708,7 +10720,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -10720,7 +10732,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -10734,7 +10746,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -10750,7 +10762,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -10762,7 +10774,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -10770,24 +10782,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -10796,7 +10808,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -10812,7 +10824,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -10820,7 +10832,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -10828,13 +10840,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10846,7 +10858,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10855,7 +10867,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10866,13 +10878,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10881,19 +10893,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -10903,13 +10915,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10919,31 +10931,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10953,21 +10965,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -10976,13 +10988,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10992,7 +11004,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -11002,7 +11014,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11012,7 +11024,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11022,7 +11034,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11032,7 +11044,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11042,7 +11054,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11056,7 +11068,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -11066,7 +11078,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -11076,67 +11088,67 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr "да"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,19 +16,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -41,7 +41,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -58,7 +58,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -72,7 +72,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -80,13 +80,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -117,7 +117,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -141,7 +141,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -184,7 +184,7 @@ msgid ""
 "###  user.foo: bar\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -208,7 +208,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -216,7 +216,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -267,7 +267,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -281,7 +281,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -295,7 +295,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -315,7 +315,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -336,7 +336,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -357,97 +357,97 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr ""
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr ""
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -455,24 +455,24 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "<alias> <target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr ""
 
@@ -504,41 +504,41 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr ""
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -546,61 +546,61 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr ""
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -608,23 +608,23 @@ msgstr ""
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -632,11 +632,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -648,15 +648,15 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -665,7 +665,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -673,56 +673,56 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -737,102 +737,102 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -840,152 +840,152 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr ""
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -993,72 +993,72 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr ""
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr ""
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1067,253 +1067,253 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid "Cluster group description"
 msgstr ""
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1324,54 +1324,54 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1379,42 +1379,42 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1422,11 +1422,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1442,141 +1442,141 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1584,31 +1584,31 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1616,86 +1616,86 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1703,29 +1703,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1738,11 +1738,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1750,51 +1750,51 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr ""
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1802,361 +1802,361 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr ""
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr ""
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2190,110 +2190,110 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2301,60 +2301,60 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2363,32 +2363,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2412,47 +2412,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2462,56 +2462,56 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2540,11 +2540,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2559,22 +2559,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2582,34 +2582,34 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr ""
 
@@ -2620,241 +2620,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2864,104 +2864,104 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -2977,96 +2977,96 @@ msgstr ""
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3090,7 +3090,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3100,36 +3100,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3142,7 +3142,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3151,200 +3151,200 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3356,66 +3356,66 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3423,304 +3423,304 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -3730,7 +3730,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3744,58 +3744,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3807,103 +3807,103 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3935,11 +3935,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3961,11 +3961,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -3987,11 +3987,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4013,11 +4013,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4039,15 +4039,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4055,11 +4055,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4083,11 +4083,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4110,11 +4110,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4138,15 +4138,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4169,11 +4169,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4194,11 +4194,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4223,11 +4223,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4253,11 +4253,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4281,11 +4281,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4313,19 +4313,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4348,11 +4348,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4425,8 +4425,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4436,15 +4436,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4467,11 +4467,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4494,23 +4494,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4526,11 +4526,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4551,11 +4551,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4577,11 +4577,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4604,11 +4604,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4622,14 +4622,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -4645,11 +4657,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -4675,11 +4687,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4703,11 +4715,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -4730,87 +4742,87 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4818,57 +4830,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -4876,23 +4888,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -4912,32 +4924,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -4945,249 +4957,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5198,164 +5210,164 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5371,217 +5383,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5605,169 +5617,169 @@ msgstr ""
 msgid "Network address set description"
 msgstr ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5778,19 +5790,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -5798,31 +5810,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5835,171 +5847,171 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6015,258 +6027,258 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6279,24 +6291,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6306,13 +6318,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6327,40 +6339,40 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6372,44 +6384,44 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6417,49 +6429,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6467,19 +6479,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6487,281 +6499,281 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6770,7 +6782,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6779,15 +6791,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6796,11 +6808,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6813,11 +6825,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6826,11 +6838,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6839,11 +6851,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -6853,11 +6865,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6866,11 +6878,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6879,11 +6891,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6892,15 +6904,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6909,11 +6921,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6922,11 +6934,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6935,11 +6947,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6948,11 +6960,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6970,39 +6982,39 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7010,135 +7022,135 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7146,64 +7158,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr ""
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7215,19 +7227,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7236,94 +7248,94 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7332,13 +7344,13 @@ msgstr ""
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7346,75 +7358,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7423,94 +7435,94 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7518,15 +7530,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7534,36 +7546,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7574,20 +7586,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -7601,7 +7613,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -7610,62 +7622,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7674,107 +7686,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -7789,18 +7801,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -7810,28 +7822,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7845,265 +7857,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8111,67 +8123,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8180,15 +8192,15 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8196,78 +8208,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8276,119 +8288,119 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8398,11 +8410,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8419,235 +8431,235 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8676,142 +8688,142 @@ msgstr ""
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -8819,458 +8831,458 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9293,13 +9305,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9308,7 +9320,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9316,7 +9328,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9327,13 +9339,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9342,7 +9354,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9350,15 +9362,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9368,7 +9380,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9377,13 +9389,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9391,26 +9403,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9419,13 +9431,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9434,7 +9446,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9445,19 +9457,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9468,7 +9480,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9480,7 +9492,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9494,7 +9506,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9510,7 +9522,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9522,7 +9534,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9530,24 +9542,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9556,7 +9568,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9572,7 +9584,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9580,7 +9592,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9588,13 +9600,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9606,7 +9618,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9615,7 +9627,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9626,13 +9638,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9641,19 +9653,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9663,13 +9675,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9679,31 +9691,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9713,21 +9725,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -9736,13 +9748,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9752,7 +9764,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9762,7 +9774,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9772,7 +9784,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9782,7 +9794,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9792,7 +9804,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9802,7 +9814,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9816,7 +9828,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9826,7 +9838,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9836,66 +9848,66 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2025-03-01 08:01+0000\n"
 "Last-Translator: Loge X <wazolm5643@163.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.10.3-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  逻辑机箱（Chassis）:"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  固件:"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  主板:"
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -53,7 +53,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -83,7 +83,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -107,7 +107,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -119,7 +119,7 @@ msgstr ""
 "###\n"
 "### 注意，展示的指纹不能修改"
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -127,7 +127,7 @@ msgstr ""
 "### 这是集群组的 YAML 表示形式。\n"
 "### 任何以“#”开头的行都会被忽略。"
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -166,7 +166,7 @@ msgstr ""
 "###\n"
 "### 注意，显示的名称（name）不能修改"
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgstr ""
 "### 例如：\n"
 "###  description: My custom image"
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -226,7 +226,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -304,7 +304,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgstr ""
 "###\n"
 "### 注意，监听地址（listen_address）和位置（location）不能修改。"
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -359,7 +359,7 @@ msgstr ""
 "###\n"
 "### 注意，展示的名称不能修改"
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -422,7 +422,7 @@ msgstr ""
 "###\n"
 "### 注意，监听地址（listen_address）和位置（location）不能修改。"
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -452,7 +452,7 @@ msgstr ""
 "### 注意，名称（name）、目标项目（target_project）、目标网络"
 "（target_network）、状态（status）字段不能更改。"
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -476,7 +476,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -500,7 +500,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -536,7 +536,7 @@ msgstr ""
 "###\n"
 "### 请注意，只能更改配置项。"
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -573,7 +573,7 @@ msgstr ""
 "###\n"
 "### 请注意，显示的名称（name）无法更改"
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -611,7 +611,7 @@ msgstr ""
 "###\n"
 "### 请注意，显示的名称（name）无法更改"
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -619,91 +619,91 @@ msgstr ""
 "### 这是集群成员的 YAML 表示形式。\n"
 "### 任何以“#”开头的行都会被忽略。"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d （id：%d，在线：%v，NUMA 节点：%v）"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr "%q 不是块设备"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr "%q 不是 IP 地址"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "项目 %q 中 %q 池的 %s %q（包括 %d 个快照）"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s（还有%d个）"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s（%s）（%d个可用）"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（后端=%q，来源=%q）"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是目录"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "“%s”不是受支持的文件类型"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "（无）"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- 第 %d 级（类型：%s）：%s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- 分区 %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- 端口 %d（%s）"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "强制关闭实例时无法使用 --console"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr "--console 不能与 --all 一起使用"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr "--console 只适用于单个实例"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty 不能与图像名称组合"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded 不能与服务器一起使用"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "当来源是快照时，无法传递 --instance-only"
 
@@ -711,24 +711,24 @@ msgstr "当来源是快照时，无法传递 --instance-only"
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port 必须和 --network-address 一起使用"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles 不能与 --refresh 一起使用"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr "--project 不能与 query 命令一起使用"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr "--refresh 只能与实例一起使用"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr "--target 只能与集群一起使用"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr "--target 不能与实例一起使用"
 
@@ -740,7 +740,7 @@ msgstr "<别名>"
 msgid "<alias> <target>"
 msgstr "<别名> <目标>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr "<本地|全局> <查询>"
 
@@ -760,41 +760,41 @@ msgstr "<远程> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<远程> <新名称>"
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr "<远程>: <路径>"
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<源路径>... [<远程>:]<示例>/<路径>"
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr "<tarball>|<目录>|<URL> [<rootfs tarball>] [<远程>:] [键=值…]"
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr "<目标>"
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr "=> 查询 %d："
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr "客户端证书已存在"
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr "必须提供客户端名称"
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr "必须提供集群成员名称"
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr "地址"
 
@@ -803,61 +803,61 @@ msgstr "地址"
 msgid "ADDRESSES"
 msgstr "地址"
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr "别名"
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr "别名"
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr "应用"
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr "架构"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr "认证类型"
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr "接受证书"
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr "访问密钥（为空时自动生成）"
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr "访问密钥：%s"
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr "访问扩展配置"
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr "确认警告"
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "此工具不支持操作 %q"
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr "操作（默认为 GET）"
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr "将集群成员添加到集群组"
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr "添加网络区域记录条目"
 
@@ -866,23 +866,23 @@ msgstr "添加网络区域记录条目"
 msgid "Add addresses to a network address set"
 msgstr "向网络区域记录添加条目"
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr "将后端添加到负载均衡器"
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr "将后端添加到负载均衡器"
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr "向网络区域记录添加条目"
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr "添加实例设备"
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr "将成员添加到组"
 
@@ -890,11 +890,11 @@ msgstr "将成员添加到组"
 msgid "Add new aliases"
 msgstr "添加新别名"
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr "添加新的远程服务器"
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -913,15 +913,15 @@ msgstr ""
 "  incus remote add some-name https://LOGIN:PASSWORD@example.com/some/path --"
 "protocol=simplestreams\n"
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr "添加新的受信任客户端"
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr "添加新的受信任客户端证书"
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -935,7 +935,7 @@ msgstr ""
 "- 客户端（默认）\n"
 "- 监控证书\n"
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -946,56 +946,56 @@ msgstr ""
 "\n"
 "这会发布一个信任令牌，供客户端将自己添加到信任存储中。\n"
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr "将端口添加到转发"
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr "向负载平衡器添加端口"
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr "向实例添加配置文件"
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr "向集群成员添加角色"
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr "向 ACL 添加规则"
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr "附加存储池配置属性（键=值，完成后为空）："
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr "要绑定的地址（默认值：无）"
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr "要绑定的地址（不包括端口）"
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr "地址：%s"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr "地址：%v"
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理员访问密钥：%s"
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理员私密密钥：%s"
@@ -1010,102 +1010,102 @@ msgstr "别名 %s 已存在"
 msgid "Alias %s doesn't exist"
 msgstr "别名 %s 不存在"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr "缺少别名"
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr "别名：%s"
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr "别名已存在：%s"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr "别名："
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr "加入集群会丢失所有现有数据，是否继续？"
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr "所有项目"
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr "所有服务器地址都不可用"
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr "备选证书名称"
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr "架构：%s"
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr "架构：%v"
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr "您是否正在加入现有集群？"
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr "您确定要 %s 集群成员 %q 吗？（是/否）[默认值=否]： "
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "由于两者都找不到，原始 SPICE 套接字可在以下位置找到："
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr "请求 VM，但映像的类型为容器"
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr "为集群成员分配组集"
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr "为实例分配配置文件集"
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr "将网络接口附加到实例"
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr "将网络接口附加到配置文件"
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr "将新的自定义存储卷附加到实例"
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr "将新的自定义存储卷附加到配置文件"
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr "将新的网络接口附加到实例"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr "附加到实例控制台"
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1116,152 +1116,152 @@ msgstr ""
 "\n"
 "此命令允许您与实例的引导控制台进行交互，并从中检索过去的日志条目。"
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "服务器不支持身份验证类型“%s”"
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr "自动协商：%v"
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr "自动更新仅在拉模式下可用"
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr "自动更新：%s"
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr "自动（非交互）模式"
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr "可用项目："
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr "平均值：%.2f %.2f %.2f"
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr "基础镜像"
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr "后端描述"
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr "后端健康："
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "正在备份实例：%s"
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr "备份存储桶：%s"
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "备份存储卷：%s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr "备份导出成功！"
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr "备份："
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "设备覆盖语法错误，应为“<设备>,<键>=<值>”：%s"
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "错误的键值对：%s"
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "错误的键=值对：%q"
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "错误的键=值对：%s"
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr "错误特性：%s"
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr "网络绑定："
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr "给出了--all和实例名称"
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr "品牌：%v"
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr "网络桥接："
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr "桶描述"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr "总线地址：%v"
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr "已接收字节"
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr "已发送字节"
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr "可取消"
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr "常用名"
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr "内容类型"
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr "数量"
 
@@ -1269,72 +1269,72 @@ msgstr "数量"
 msgid "CPU TIME(s)"
 msgstr "CPU 时间（秒）"
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr "CPU 占用"
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr "CPU 占用（秒）"
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr "CPU 占用："
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr "CPU："
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr "CPU："
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr "创建"
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr "创建于"
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr "CUDA 版本：%v"
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr "已缓存：%s"
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr "缓存："
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr "无法绑定地址 %q：%w"
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr "无法在本地重命名中覆盖配置或配置文件"
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr "无法为目标镜像提供名称"
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr "没有 --recursive 无法拉取目录"
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr "无法读取环境文件：%w"
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "无法从标准输入读取：%w"
@@ -1343,253 +1343,253 @@ msgstr "无法从标准输入读取：%w"
 msgid "Can't remove the default remote"
 msgstr "无法移除默认远程服务器"
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr "不能用 --columns 指定 --fast"
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr "不能用 --all-projects 指定 --project"
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr "无法指定其他远程服务器进行重命名"
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr "未集群时无法指定列 L"
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "无法在递归模式下提供 uid/gid/mode"
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "无法取消设置键“%s”，当前尚未设置"
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr "不能同时使用 --auto 和 --preseed"
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr "--dump 不能与其他标志一起使用"
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr "不能同时使用 --minimal 和 --auto"
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr "不能同时使用 --minimal 和 --preseed"
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr "镜像服务器不能与 --empty 一起使用"
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr "无法覆盖设备 %q 的配置：在配置文件设备中找不到设备"
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr "当目标服务器未集群时，无法设置 --destination-target"
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr "源服务器未集群时无法设置 --target"
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "复制快照时无法设置 --volume-only"
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "无法设置键：%s"
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr "显卡 %d："
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr "已删除 %s 的证书添加令牌"
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr "证书描述"
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr "证书令牌和服务器 %q 之间的证书指纹不匹配"
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr "连接令牌与集群成员 %q 之间的证书指纹不匹配"
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "证书指纹：%s"
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr "逻辑机箱（Chassis）"
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr "正在检查守护进程是否已就绪（第 %d 次尝试）"
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr "选择 %s："
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr "客户端 %s 证书添加令牌："
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr "服务器现已信任客户端证书："
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr "客户端版本：%s\n"
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr "已创建集群组 %s"
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "已删除集群组 %s"
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "当前集群组 %s 未应用于 %s"
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "集群组 %s 已重命名为 %s"
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid "Cluster group description"
 msgstr "集群组描述"
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s 的集群连接令牌：%s 已删除"
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "集群成员 %s 已添加到集群组 %s 中"
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr "集群成员 %s 已添加到组 %s 中"
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr "集群成员 %s 已在组 %s 中"
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "已从组 %s 中移除集群成员 %s"
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr "集群成员名称"
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr "已启用集群"
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr "列"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr "Incus 的命令行客户端"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1606,54 +1606,54 @@ msgstr ""
 "\n"
 "可以用别名自定义命令，可使用“incus alias”进行控制。"
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "要使用的压缩算法（“none”表示不压缩）"
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "要使用的压缩算法（留空表示不压缩）"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr "要应用于新实例的配置键/值"
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr "要应用于新网络集成的配置键/值"
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr "要应用于新项目的配置键/值"
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr "要应用于目标实例的配置键/值"
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr "配置选项的格式应为 KEY=VALUE"
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "配置解析错误：%s"
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr "配置标志需要 --auto"
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr "配置守护进程"
 
@@ -1661,43 +1661,43 @@ msgstr "配置守护进程"
 msgid "Configure the refresh delay in seconds"
 msgstr "配置刷新延迟（秒）"
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "正在连接到守护进程（第 %d 次尝试）"
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr "内容类型、块或文件系统"
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr "内容类型：%s"
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr "控制：%s（%s）"
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr "无状态复制有状态实例"
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 #, fuzzy
 msgid "Copy aliases from source"
 msgstr "从源复制别名"
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr "复制自定义存储卷"
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr "在服务器之间复制镜像"
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1709,11 +1709,11 @@ msgstr ""
 "auto-update 标志指示服务器保持此镜像的最新状态。\n"
 "需要源是别名，并且是公开的。"
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr "在服务器内或服务器之间复制实例"
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1738,141 +1738,141 @@ msgstr ""
 "\n"
 "默认为 pull 传输模式，因为它兼容所有服务器版本。\n"
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "复制配置文件继承的设备并覆盖配置密钥"
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr "复制配置文件"
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr "复制实例但不复制快照"
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr "复制卷但不复制快照"
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr "复制到与源不同的项目"
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr "复制虚拟机镜像"
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr "正在复制镜像：%s"
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "正在复制储存卷：%s"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr "核心 %d"
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr "核心："
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "无法关闭服务器证书文件 %q：%w"
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr "无法创建服务器证书目录"
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "找不到证书文件路径：%s"
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "找不到证书密钥文件路径：%s"
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "无法读取证书文件：%s，出现错误：%v"
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "无法读取证书密钥文件：%s，出现错误：%v"
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "无法为远程服务器“%s”写入新的远程证书，出现错误：%v"
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "无法写入服务器证书文件 %q：%w"
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr "找不到匹配的条目"
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, fuzzy, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr "无法获取 %s 的相关信息：%w"
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr "创建集群组"
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr "要创建新的 %s 池吗？"
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr "创建虚拟机"
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr "为现有镜像创建别名"
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr "创建空实例"
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr "从镜像创建和启动实例"
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr "创建任何必要的目录"
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr "在实例中创建文件和目录"
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr "创建实例备份：%w"
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr "创建实例快照"
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1883,31 +1883,31 @@ msgstr ""
 "\n"
 "在使用 --stateful 时，尝试检查实例的运行状态，包括进程内存状态、TCP连接等"
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr "从镜像创建实例"
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr "为存储桶创建密钥"
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr "创建网络集成"
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr "创建新的自定义存储桶"
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr "创建新的自定义存储卷"
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr "创建新的实例文件模板"
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr "创建新的网络 ACL"
 
@@ -1916,86 +1916,86 @@ msgstr "创建新的网络 ACL"
 msgid "Create new network address sets"
 msgstr "创建新的网络区域"
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr "创建新的网络转发"
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr "创建新的网络负载均衡器"
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr "创建新的网络对等互联"
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr "创建新的网络区域记录"
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr "创建新的网络区域"
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr "创建新网络"
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr "创建配置文件"
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr "创建项目"
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr "创建存储池"
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr "创建未应用配置文件的实例"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "已创建：%s"
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr "正在创建 %s"
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr "正在创建实例"
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr "目前 VF 的数目：%d"
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "默认目标地址"
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr "描述"
 
@@ -2003,29 +2003,29 @@ msgstr "描述"
 msgid "DISK"
 msgstr "磁盘"
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr "磁盘利用率"
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr "驱动"
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr "DRM："
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr "超时 %d 秒后守护进程仍未运行（%v）"
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr "超时 %d 秒后，守护进程仍在运行"
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr "日期：%s"
@@ -2038,11 +2038,11 @@ msgstr "调试命令"
 msgid "Debug commands for instances"
 msgstr "实例的调试命令"
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr "默认 VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr "定义压缩算法：用于备份与否"
 
@@ -2050,51 +2050,51 @@ msgstr "定义压缩算法：用于备份与否"
 msgid "Delay:"
 msgstr "延迟："
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "删除后台操作（将尝试取消）"
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr "删除集群组"
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr "删除所有警告"
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr "删除自定义存储卷"
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr "删除实例中的文件"
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr "删除镜像别名"
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr "删除镜像"
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr "删除实例文件模板"
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr "删除实例快照"
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr "删除实例"
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr "从存储桶中删除密钥"
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr "删除网络 ACL"
 
@@ -2103,361 +2103,361 @@ msgstr "删除网络 ACL"
 msgid "Delete network address sets"
 msgstr "删除网络区域"
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr "删除网络转发"
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr "删除网络集成"
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr "删除网络负载均衡器"
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr "删除网络对等互联"
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr "删除网络区域记录"
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr "删除网络区域"
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr "删除网络"
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr "删除配置文件"
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr "删除项目"
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr "删除存储桶"
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr "删除存储池"
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr "删除存储卷快照"
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr "删除警告"
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "描述"
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr "描述：%s"
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr "目标集群成员名称"
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr "从实例中分离自定义存储卷"
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr "从配置文件中分离自定义存储卷"
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr "从实例中分离网络接口"
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr "从配置文件中分离网络接口"
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr "设备 %d："
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr "设备 %s 添加到 %s"
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "设备 %s 被 %s 覆盖"
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "设备 %s 已从 %s 中移除"
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr "设备地址：%v"
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr "设备已存在：%s"
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr "设备不存在"
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr "无法为单个实例修改配置文件中的设备。改为替代设备或修改配置文件"
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr "无法为单个实例移除配置文件中的设备。改为替代设备或修改配置文件"
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "无法为单个实例检索配置文件中的设备"
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr "设备：%s"
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr "未从服务器获取新实例的名称"
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr "目录导入在此平台上不可用"
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr "运行命令的目录（默认/根目录）"
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "使用 SSH SFTP 监听器时禁用身份验证"
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr "禁用伪终端分配"
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "禁用标准输入（从 /dev/null 读取）"
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr "磁盘 %d："
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr "磁盘使用情况："
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr "磁盘："
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr "磁盘："
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr "显示所有项目的集群"
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr "显示所有项目的镜像"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr "显示所有项目的实例"
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr "显示所有项目的网络区域"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr "显示所有项目的配置文件"
 
@@ -2465,7 +2465,7 @@ msgstr "显示所有项目的配置文件"
 msgid "Display resource usage info per instance"
 msgstr "显示每个实例的资源使用信息"
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr "显示所有项目的存储池桶"
 
@@ -2508,110 +2508,110 @@ msgstr ""
 "  n - 实例名称\n"
 "  u - CPU 使用率（秒）"
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr "是否要配置新的本地存储池？"
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr "是否要配置新的远程存储池？"
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr "是否要配置新的存储池？"
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr "您想在不进行精简置备的情况下继续吗？"
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr "使用 --force 不需要用户确认"
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr "不显示进度信息"
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr "下行延迟"
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr "驱动：%v"
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr "驱动：%v（%v）"
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr "将 YAML 配置转储到标准输出"
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr "在增量复制期间，排除早于最新目标快照的源快照"
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr "在刷新期间，排除早于最新目标快照的源快照"
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr "条目"
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr "临时"
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr "过期时间"
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr "有效期限"
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr "编辑集群组"
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr "将集群成员配置编辑为 YAML"
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr "编辑实例中的文件"
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr "编辑镜像属性"
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr "编辑实例文件模板"
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr "编辑实例元数据文件"
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr "将实例或服务器配置编辑为 YAML"
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr "将网络 ACL 配置编辑为 YAML"
 
@@ -2620,60 +2620,60 @@ msgstr "将网络 ACL 配置编辑为 YAML"
 msgid "Edit network address set configurations as YAML"
 msgstr "将网络对等配置编辑为 YAML"
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr "将网络配置编辑为 YAML"
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr "将网络转发配置编辑为 YAML"
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr "将网络集成配置编辑为 YAML"
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr "将网络负载均衡器配置编辑为 YAML"
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr "将网络对等配置编辑为 YAML"
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr "将网络区域配置编辑为 YAML"
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr "将网络区域记录配置编辑为 YAML"
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr "将配置文件配置编辑为YAML"
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr "将项目配置编辑为 YAML"
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr "将存储桶配置编辑为 YAML"
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr "将存储桶键编辑为 YAML"
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr "将存储池配置编辑为 YAML"
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr "将存储卷配置编辑为 YAML"
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2686,32 +2686,32 @@ msgstr ""
 "如果未指定类型，则 Incus 假定该类型为“自定义”。\n"
 "类型支持的值为“自定义”、“容器”和“虚拟机”。"
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr "将信任配置编辑为 YAML"
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr "“%s”中的空列条目（冗余、前导或尾随命令）"
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr "在单个非集群服务器上启用集群"
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2743,47 +2743,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr "输入新的延迟（秒）："
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr "条目 TTL"
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "要设置的环境变量（例如 HOME=/HOME/foo）"
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr "临时实例"
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr "连接到现有集群成员 %q 时出错：%v"
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr "创建解码器时出错：%v"
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr "解码数据时出错：%v"
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr "检索别名时出错：%w"
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "设置属性时出错：%v"
@@ -2793,56 +2793,56 @@ msgstr "设置属性时出错：%v"
 msgid "Error setting term size %s"
 msgstr "设置术语大小 %s 时出错"
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr "取消设置属性时出错：%v"
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "取消设置属性时出错：%v"
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "更新模板文件时出错：%s"
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr "执行别名扩展时出错：%s\n"
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr "错误：%v\n"
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr "解散集群成员"
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "正在解散集群成员：%s"
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr "要监听的事件类型"
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr "对本地或全局数据库执行 SQL 查询"
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2890,11 +2890,11 @@ msgstr ""
 "  开发团队有时会以数据库查询的形式向用户提供修补程序，以修复一些数据不一致的"
 "问题。"
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr "在实例中执行命令"
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2918,22 +2918,22 @@ msgstr ""
 "默认为非交互式模式，如果标准输入和输出都是终端，则选择交互式模式（不考虑 "
 "stderr）。"
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr "需要结构体，已有 %v"
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr "过期时间"
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr "过期：%s"
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr "过期：永不"
 
@@ -2941,11 +2941,11 @@ msgstr "过期：永不"
 msgid "Export a virtual machine's memory state"
 msgstr "导出虚拟机内存状态"
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr "导出并下载镜像"
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2955,23 +2955,23 @@ msgstr ""
 "\n"
 "输出目标可选，默认为工作目录。"
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr "导出自定义存储卷"
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr "导出实例备份"
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr "将实例导出为备份 tar 包。"
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr "导出存储桶"
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr "将存储桶导出为 tar 包。"
 
@@ -2984,241 +2984,241 @@ msgstr ""
 "将正在运行的虚拟机当前内存状态导出到转储文件中。\n"
 "\t\t可用于调试或分析目的。"
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr "导出不带快照的卷"
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr "正在导出存储桶备份：%s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "导出备份：%s"
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "正在导出镜像：%s"
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr "故障域"
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr "文件名"
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr "指纹"
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr "首次发现"
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "与客户端 %q 的 SSH 握手失败：%v"
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "接受通道客户端 %q 失败：%v"
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "检查实例是否存在“%s:%s”失败：%w"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "检查实例快照是否存在“%s:%s”失败：%w"
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "连接到客户端 %q 的实例 SFTP 失败：%v"
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "连接到实例 SFTP 失败：%w"
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr "连接到守护进程失败（第 %d 次尝试）：%v"
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "将令牌操作转换为证书添加令牌失败：%w"
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr "将令牌操作转换为加入令牌失败：%w"
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "在项目 %q 中删除实例 %q 失败：%w"
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "复制后删除源卷失败：%w"
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "生成 SSH 主机密钥失败：%w"
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr "生成信任证书失败：%w"
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr "获取现有存储池失败：%w"
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "获取对等体状态失败：%w"
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr "导入请求失败：%w"
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "加载网络 %q 失败：%w"
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr "加载覆盖设备的配置文件 %q 失败：%w"
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "加载存储池 %q 失败：%w"
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "解析 SSH 主机密钥失败：%w"
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr "解析验证响应失败：%w"
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "启动命令失败：%w"
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "启动 sshfs 失败：%w"
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "接受传入连接失败：%w"
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr "添加远程服务器失败"
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr "无法将服务器证书添加到集群：%w"
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr "无法检查守护进程是否已就绪（第 %d 次尝试）：%v"
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr "关闭导出文件失败：%w"
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "关闭服务器证书文件 %q 失败：%w"
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr "配置集群失败：%w"
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "无法连接到集群成员：%w"
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr "无法连接以获取服务器信息：%w"
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr "无法连接到本地守护进程：%w"
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "无法连接到目标集群节点 %q：%w"
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "创建 %q 失败：%w"
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "创建别名 %s 失败：%w"
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr "创建备份失败：%v"
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "创建证书失败：%w"
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "创建存储卷备份失败：%w"
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "复制后删除原始实例失败：%w"
@@ -3228,104 +3228,104 @@ msgstr "复制后删除原始实例失败：%w"
 msgid "Failed to dump instance memory: %w"
 msgstr "转储实例内存失败：%w"
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "获取存储桶备份失败：%w"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "获取存储卷备份文件失败：%w"
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "找不到项目：%w"
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr "加入集群失败：%w"
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "监听连接失败：%w"
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr "加载配置失败：%s"
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr "解析转储响应失败：%w"
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr "解析服务器失败：%w"
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, fuzzy, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr "解析 preseed 失败：%w"
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr "无法从标准输入读取：%w"
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "刷新目标实例“%s”失败：%v"
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "删除别名 %s 失败：%w"
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr "重命名导出文件失败：%w"
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr "呈现配置失败：%w"
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr "请求转储失败：%w"
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr "检索集群信息失败：%w"
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr "检索当前集群配置失败：%w"
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr "检索当前服务器配置失败：%w"
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr "检索当前服务器配置失败：%w"
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -3341,96 +3341,96 @@ msgstr "检索网络列表失败：%w"
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr "检索存储池列表失败：%w"
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr "无法与集群建立信任关系：%w"
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr "更新群集成员状态失败：%w"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "为 %s 遍历路径失败：%s"
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "无法写入服务器证书文件 %q：%w"
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr "验证请求失败：%w"
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "快速模式（等价于 --columns=nsacPt）"
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr "获取实例备份文件：%w"
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr "尚不支持筛选"
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "指纹：%s"
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr "强制采取特定的解散操作"
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr "强制创建文件或目录"
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr "强制删除项目及其包含的所有内容。"
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr "强制删除文件、目录和子目录"
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr "未经用户确认的强制解散"
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr "强制伪终端分配"
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr "强制移除成员，即使已降级"
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr "强制实例停止"
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr "强制删除正在运行的实例"
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr "强制使用本地 unix 套接字"
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3465,7 +3465,7 @@ msgstr ""
 "\n"
 "您确定要强制删除 %s 吗？（yes/no）： "
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3476,7 +3476,7 @@ msgstr "强制连接到控制台，即使已存在活动会话"
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "格式化（table|compact）"
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
@@ -3484,20 +3484,20 @@ msgstr ""
 "格式化（csv|json|table|yaml|compact），使用后缀“,noheader”可禁用表头，需要时"
 "可使用“,header”启用表头，例如 csv,header"
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
@@ -3505,11 +3505,11 @@ msgstr ""
 "格式化（csv|json|table|yaml|compact），使用后缀“,noheader”可禁用表头，需要时"
 "可使用“,header”启用表头，例如 csv,header"
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr "格式化（json|pretty|yaml）"
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr "格式化（man|md|rest|yaml）"
 
@@ -3522,7 +3522,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr "内存转储格式（如 elf、win-dmp、kdump-zlib、kdump-raw-zlib 等）"
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr "转发延迟"
 
@@ -3531,200 +3531,200 @@ msgstr "转发延迟"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "发现别名 %q 引用了给定数字之外的参数"
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr "空闲：%v"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "频率：%v Mhz"
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "频率：%v Mhz（最低：%v Mhz，最高：%v Mhz）"
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr "全局"
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr "GPU："
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr "GPU："
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr "为所有命令生成手册"
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr "生成客户端证书"
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "正在生成客户端证书。这可能会花点时间……"
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr "获取资源分配摘要"
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr "获取当前负载均衡器状态"
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr "获取当前负载均衡器状态"
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr "获取镜像属性"
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr "获取网络运行时信息"
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr "获取作为集群组属性的密钥"
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr "获取作为集群属性的密钥"
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr "获取作为网络 ACL 属性的密钥"
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr "获取作为网络转发属性的密钥"
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr "获取作为网络集成属性的密钥"
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr "获取作为网络负载均衡器属性的密钥"
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr "获取作为网络对等属性的密钥"
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr "获取作为网络属性的密钥"
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr "获取作为网络区域属性的密钥"
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr "获取作为网络区域记录属性的密钥"
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr "获取作为配置文件属性的密钥"
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr "获取作为项目属性的密钥"
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr "获取作为存储桶属性的密钥"
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr "获取作为存储属性的密钥"
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr "获取作为存储卷属性的密钥"
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr "获取作为实例属性的密钥"
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr "获取集群组配置键的值"
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr "获取集群成员配置键的值"
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr "获取设备配置键的值"
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr "获取实例或服务器配置键的值"
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr "获取网络 ACL 配置键的值"
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr "获取网络配置键的值"
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr "获取网络转发配置键的值"
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr "获取网络集成配置键的值"
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr "获取网络负载均衡器配置键的值"
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr "获取网络对等配置键的值"
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr "获取网络区域配置键的值"
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr "获取网络区域记录配置键的值"
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr "获取配置文件配置键的值"
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr "获取项目配置键的值"
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr "获取储存桶配置键的值"
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr "获取储存池配置键的值"
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr "获取储存卷配置键的值"
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3742,66 +3742,66 @@ msgstr ""
 "\n"
 "对于快照，添加快照名称（当且仅当类型为自定义、容器或虚拟机时）。"
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "给定的目标 %q 与源卷位置 %q 不匹配"
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr "运行命令的组 ID（默认为 0）"
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr "主机名"
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr "主机接口"
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr "主机名"
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr "大页内存：\n"
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "从 SSH 到实例的 I/O 复制操作失败：%v"
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "从实例到 SSH 的 I/O 复制操作失败：%v"
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3809,304 +3809,304 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -4116,7 +4116,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -4130,58 +4130,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -4193,103 +4193,103 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -4322,11 +4322,11 @@ msgstr "显示所有项目的集群"
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -4348,11 +4348,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -4374,11 +4374,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4400,11 +4400,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4426,15 +4426,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4442,11 +4442,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4470,11 +4470,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4497,11 +4497,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4525,15 +4525,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4556,11 +4556,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4581,11 +4581,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4610,11 +4610,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4640,11 +4640,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4668,11 +4668,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4700,19 +4700,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4735,11 +4735,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4812,8 +4812,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4823,15 +4823,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4854,11 +4854,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4881,23 +4881,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4913,11 +4913,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4938,11 +4938,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4964,11 +4964,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4991,11 +4991,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5009,14 +5009,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -5032,11 +5044,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -5062,11 +5074,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -5090,11 +5102,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -5117,87 +5129,87 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -5205,57 +5217,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -5263,23 +5275,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -5299,32 +5311,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -5332,249 +5344,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5585,165 +5597,165 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 #, fuzzy
 msgid "More than one file to download, but target is not a directory"
 msgstr "将下载多个文件, 但目标不是目录"
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5759,217 +5771,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5994,169 +6006,169 @@ msgstr "集群组 %s 已重命名为 %s"
 msgid "Network address set description"
 msgstr "桶描述"
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -6167,19 +6179,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -6187,31 +6199,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -6224,171 +6236,171 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6404,260 +6416,260 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr "协议: %s"
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "提供的证书路径不存在: %s"
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr "代理已超时 (无连接时退出)"
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr "公共镜像服务器"
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "公共: %s"
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr "发布实例为镜像"
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "正在发布实例: %s"
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr "从实例拉取文件"
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, fuzzy, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "正在从 %[2]s 拉取 %[1]s: %%s"
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr "向实例推送文件"
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, fuzzy, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "正在向 %[2]s 推送 %[1]s: %%s"
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr "查询路径必须以 / 开头"
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr "查询虚拟机镜像"
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr "只读: %v"
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "重新初始化为空白实例"
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr "重新初始化实例"
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 #, fuzzy
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr "从现有和未知存储池中恢复丢失的实例和存储卷"
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6670,25 +6682,25 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "递归传输文件"
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr "刷新镜像列表"
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "正在刷新实例: %s"
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "正在刷新镜像: %s"
@@ -6698,13 +6710,13 @@ msgstr "正在刷新镜像: %s"
 msgid "Remote %s already exists"
 msgstr "远程 %s 已存在"
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "远程 %s 不存在"
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "远程 %s 已存在地址 <%s>"
@@ -6719,43 +6731,43 @@ msgstr "远程服务器 %s 是全局的，无法移除"
 msgid "Remote %s is static and cannot be modified"
 msgstr "远程 %s 是静态的, 无法修改"
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 #, fuzzy
 msgid "Remote names may not contain colons"
 msgstr "远程名称不应包含冒号"
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 #, fuzzy
 msgid "Remote trust token"
 msgstr "远程验证令牌"
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr "是否可移除: %v"
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "移除 %s (yes/no): "
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr "移除项目 %s 及其所有内容 (实例, 镜像, 存储卷, 网络, ...) (yes/no): "
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "将一个集群成员从集群组移除"
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr "将一个成员从集群移除"
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "移除一条网络区域记录条目"
@@ -6769,46 +6781,46 @@ msgstr "从转发中移除端口"
 msgid "Remove aliases"
 msgstr "移除别名"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr "移除所有匹配的端口"
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr "移除所有匹配的规则"
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr "从负载均衡器中移除后端"
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "从负载均衡器中移除后端"
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr "移除实例的设备"
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr "从转发中移除端口"
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "从负载均衡器中移除端口"
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6816,49 +6828,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6866,19 +6878,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6886,281 +6898,281 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7169,7 +7181,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -7178,15 +7190,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -7195,11 +7207,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -7213,11 +7225,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr "获取网络对等配置键的值"
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -7226,11 +7238,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -7239,11 +7251,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -7253,11 +7265,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7266,11 +7278,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7279,11 +7291,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -7292,15 +7304,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7309,11 +7321,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7322,11 +7334,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -7335,11 +7347,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -7348,11 +7360,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7370,39 +7382,39 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7411,135 +7423,135 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr "获取作为网络对等属性的密钥"
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7548,64 +7560,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr "将网络对等配置编辑为 YAML"
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7617,19 +7629,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7638,94 +7650,94 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7734,13 +7746,13 @@ msgstr ""
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7748,75 +7760,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7825,94 +7837,94 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7920,15 +7932,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7936,37 +7948,37 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "目标路径和 --listen 标记不能一起使用"
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7977,20 +7989,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -8004,7 +8016,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -8013,62 +8025,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8077,107 +8089,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -8192,18 +8204,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -8213,28 +8225,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8248,265 +8260,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8515,67 +8527,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr "获取网络对等配置键的值"
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8584,15 +8596,15 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8601,78 +8613,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr "获取作为网络对等属性的密钥"
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8681,119 +8693,119 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8803,11 +8815,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8824,235 +8836,235 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -9083,142 +9095,142 @@ msgstr "<远程> <新名称>"
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -9226,458 +9238,458 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9700,13 +9712,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9715,7 +9727,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9723,7 +9735,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9734,13 +9746,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9749,7 +9761,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9757,15 +9769,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9775,7 +9787,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9784,13 +9796,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9798,26 +9810,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9826,13 +9838,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9841,7 +9853,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9852,19 +9864,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9875,7 +9887,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9887,7 +9899,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9901,7 +9913,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9917,7 +9929,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9929,7 +9941,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9937,24 +9949,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9963,7 +9975,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9979,7 +9991,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9987,7 +9999,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9995,13 +10007,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10013,7 +10025,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10022,7 +10034,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -10033,13 +10045,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10048,19 +10060,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -10070,13 +10082,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -10086,31 +10098,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -10120,21 +10132,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -10143,13 +10155,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10159,7 +10171,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10169,7 +10181,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10179,7 +10191,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10189,7 +10201,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10199,7 +10211,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10209,7 +10221,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10223,7 +10235,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10233,7 +10245,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -10243,67 +10255,67 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-03-22 22:30-0400\n"
+"POT-Creation-Date: 2025-04-07 21:21+0000\n"
 "PO-Revision-Date: 2024-12-30 10:00+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.10-dev\n"
 
-#: cmd/incus/info.go:439
+#: cmd/incus/info.go:441
 msgid "  Chassis:"
 msgstr "  機櫃："
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:481
 msgid "  Firmware:"
 msgstr "  韌體："
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:461
 msgid "  Motherboard:"
 msgstr "  主機板："
 
-#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:1230
+#: cmd/incus/storage_bucket.go:288 cmd/incus/storage_bucket.go:1256
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -44,7 +44,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/storage.go:297
+#: cmd/incus/storage.go:304
 msgid ""
 "### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:995
+#: cmd/incus/storage_volume.go:1012
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -75,7 +75,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: cmd/incus/config_trust.go:287
+#: cmd/incus/config_trust.go:294
 msgid ""
 "### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -83,13 +83,13 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:445
+#: cmd/incus/cluster_group.go:446
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/config.go:117
+#: cmd/incus/config.go:118
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -110,7 +110,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/image.go:386
+#: cmd/incus/image.go:395
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -120,7 +120,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:71
+#: cmd/incus/config_metadata.go:74
 msgid ""
 "### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -144,7 +144,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:636
+#: cmd/incus/network_acl.go:653
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -187,7 +187,7 @@ msgid ""
 "###  user.foo: bar\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:701
+#: cmd/incus/network_forward.go:716
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -211,7 +211,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_integration.go:242
+#: cmd/incus/network_integration.go:243
 msgid ""
 "### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -219,7 +219,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:670
+#: cmd/incus/network_load_balancer.go:685
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -253,7 +253,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:729
+#: cmd/incus/network_peer.go:746
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -270,7 +270,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1352
+#: cmd/incus/network_zone.go:1383
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -284,7 +284,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:644
+#: cmd/incus/network_zone.go:658
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -298,7 +298,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network.go:728
+#: cmd/incus/network.go:743
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -318,7 +318,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:526
+#: cmd/incus/profile.go:539
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -339,7 +339,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:327
+#: cmd/incus/project.go:334
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -360,97 +360,97 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/cluster.go:897
+#: cmd/incus/cluster.go:918
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:349
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, 上線: %v, NUMA 節點: %v)"
 
-#: cmd/incus/admin_init_interactive.go:663
+#: cmd/incus/admin_init_interactive.go:669
 #, c-format
 msgid "%q is not a block device"
 msgstr "%q 不是一個區塊裝置"
 
-#: cmd/incus/admin_init_interactive.go:800
+#: cmd/incus/admin_init_interactive.go:806
 #, c-format
 msgid "%q is not an IP address"
 msgstr "%q 不是一個 IP 位址"
 
-#: cmd/incus/admin_recover.go:209
+#: cmd/incus/admin_recover.go:212
 #, c-format
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q 於 %q 池的 %q 專案(包含 %d 快照)"
 
-#: cmd/incus/image.go:1159
+#: cmd/incus/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (還有 %d)"
 
-#: cmd/incus/info.go:189
+#: cmd/incus/info.go:191
 #, c-format
 msgid "%s (%s) (%d available)"
 msgstr "%s (%s) (%d 可用)"
 
-#: cmd/incus/admin_recover.go:65
+#: cmd/incus/admin_recover.go:68
 #, c-format
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (後端=%q, 來源=%q)"
 
-#: cmd/incus/file.go:1310
+#: cmd/incus/file.go:1321
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是目錄"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1210
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' 不是受支援的檔案類型"
 
-#: cmd/incus/cluster_group.go:165 cmd/incus/profile.go:251
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
 msgid "(none)"
 msgstr "(沒有)"
 
-#: cmd/incus/info.go:337
+#: cmd/incus/info.go:339
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- 等級 %d (類型： %s)： %s"
 
-#: cmd/incus/info.go:316
+#: cmd/incus/info.go:318
 #, c-format
 msgid "- Partition %d"
 msgstr "- 分割區 %d"
 
-#: cmd/incus/info.go:225
+#: cmd/incus/info.go:227
 #, c-format
 msgid "- Port %d (%s)"
 msgstr "- 連接埠 %d (%s)"
 
-#: cmd/incus/action.go:266
+#: cmd/incus/action.go:260
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "強制關閉實體時無法使用 --console"
 
-#: cmd/incus/action.go:435
+#: cmd/incus/action.go:429
 msgid "--console can't be used with --all"
 msgstr "--console 不能與 --all 一起使用"
 
-#: cmd/incus/action.go:439
+#: cmd/incus/action.go:433
 msgid "--console only works with a single instance"
 msgstr "--console 僅適用於單個實體"
 
-#: cmd/incus/create.go:141 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:144 cmd/incus/rebuild.go:66
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty 不能與映像檔名稱結合使用"
 
-#: cmd/incus/config.go:488 cmd/incus/config.go:796
+#: cmd/incus/config.go:489 cmd/incus/config.go:797
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded 不能與伺服器一起使用"
 
-#: cmd/incus/copy.go:169
+#: cmd/incus/copy.go:171
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "當來源是快照時，無法傳遞 --instance-only"
 
@@ -458,24 +458,24 @@ msgstr "當來源是快照時，無法傳遞 --instance-only"
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port 不能在沒有 --network-address 的情況下使用"
 
-#: cmd/incus/copy.go:103
+#: cmd/incus/copy.go:105
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles 不能與 --refresh 一起使用"
 
-#: cmd/incus/query.go:73
+#: cmd/incus/query.go:75
 msgid "--project cannot be used with the query command"
 msgstr "--project 不能與 query 命令一起使用"
 
-#: cmd/incus/copy.go:180
+#: cmd/incus/copy.go:182
 msgid "--refresh can only be used with instances"
 msgstr "--refresh 只能與實體一起使用"
 
-#: cmd/incus/move.go:265
+#: cmd/incus/move.go:268
 msgid "--target can only be used with clusters"
 msgstr "--target 只能與叢集一起使用"
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:625
+#: cmd/incus/config.go:166 cmd/incus/config.go:439 cmd/incus/config.go:616
+#: cmd/incus/config.go:823 cmd/incus/info.go:627
 msgid "--target cannot be used with instances"
 msgstr "--target 不能與實體一起使用"
 
@@ -487,7 +487,7 @@ msgstr "<別名>"
 msgid "<alias> <target>"
 msgstr "<別名> <目標>"
 
-#: cmd/incus/admin_sql.go:28
+#: cmd/incus/admin_sql.go:30
 msgid "<local|global> <query>"
 msgstr "<本地|全域> <查詢>"
 
@@ -507,41 +507,41 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:35
+#: cmd/incus/remote_unix.go:36
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:692
+#: cmd/incus/file.go:702
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:665
+#: cmd/incus/image.go:678
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
-#: cmd/incus/manpage.go:22
+#: cmd/incus/manpage.go:23
 msgid "<target>"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:143
+#: cmd/incus/admin_sql.go:146
 #, c-format
 msgid "=> Query %d:"
 msgstr ""
 
-#: cmd/incus/remote.go:658
+#: cmd/incus/remote.go:659
 msgid "A client certificate is already present"
 msgstr ""
 
-#: cmd/incus/config_trust.go:120
+#: cmd/incus/config_trust.go:123
 msgid "A client name must be provided"
 msgstr ""
 
-#: cmd/incus/cluster.go:1030
+#: cmd/incus/cluster.go:1054
 msgid "A cluster member name must be provided"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:77
+#: cmd/incus/network_allocations.go:78
 msgid "ADDRESS"
 msgstr ""
 
@@ -549,61 +549,61 @@ msgstr ""
 msgid "ADDRESSES"
 msgstr ""
 
-#: cmd/incus/alias.go:153 cmd/incus/image.go:1126 cmd/incus/image_alias.go:248
+#: cmd/incus/alias.go:153 cmd/incus/image.go:1147 cmd/incus/image_alias.go:255
 msgid "ALIAS"
 msgstr ""
 
-#: cmd/incus/image.go:1127
+#: cmd/incus/image.go:1148
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/list.go:894
+#: cmd/incus/list.go:816
 msgid "APP"
 msgstr ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/image.go:1121 cmd/incus/list.go:578
+#: cmd/incus/cluster.go:181 cmd/incus/image.go:1142 cmd/incus/list.go:500
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:767
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:119
+#: cmd/incus/remote.go:120
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1055
+#: cmd/incus/storage_bucket.go:1077
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1161
 #, c-format
 msgid "Access key: %s"
 msgstr ""
 
-#: cmd/incus/config.go:391
+#: cmd/incus/config.go:392
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: cmd/incus/warning.go:267 cmd/incus/warning.go:268
+#: cmd/incus/warning.go:272 cmd/incus/warning.go:273
 msgid "Acknowledge warning"
 msgstr ""
 
-#: cmd/incus/query.go:77
+#: cmd/incus/query.go:79
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
-#: cmd/incus/query.go:44
+#: cmd/incus/query.go:45
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:824
+#: cmd/incus/cluster_group.go:826
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1537
+#: cmd/incus/network_zone.go:1573
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -611,23 +611,23 @@ msgstr ""
 msgid "Add addresses to a network address set"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:903
+#: cmd/incus/network_load_balancer.go:923
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:902
+#: cmd/incus/network_load_balancer.go:922
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1538
+#: cmd/incus/network_zone.go:1574
 msgid "Add entries to a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:77 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:80 cmd/incus/config_device.go:81
 msgid "Add instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:823
+#: cmd/incus/cluster_group.go:825
 msgid "Add member to group"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:108
+#: cmd/incus/remote.go:109
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:109
+#: cmd/incus/remote.go:110
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -651,15 +651,15 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:90
+#: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
 msgstr ""
 
-#: cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:175
 msgid "Add new trusted client certificate"
 msgstr ""
 
-#: cmd/incus/config_trust.go:172
+#: cmd/incus/config_trust.go:176
 msgid ""
 "Add new trusted client certificate\n"
 "\n"
@@ -668,7 +668,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:93
 msgid ""
 "Add new trusted client\n"
 "\n"
@@ -676,56 +676,56 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:923 cmd/incus/network_forward.go:924
+#: cmd/incus/network_forward.go:943 cmd/incus/network_forward.go:944
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1094
-#: cmd/incus/network_load_balancer.go:1095
+#: cmd/incus/network_load_balancer.go:1119
+#: cmd/incus/network_load_balancer.go:1120
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:108 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
 msgid "Add profiles to instances"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:52
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:888 cmd/incus/network_acl.go:889
+#: cmd/incus/network_acl.go:912 cmd/incus/network_acl.go:913
 msgid "Add rules to an ACL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:128
+#: cmd/incus/admin_recover.go:131
 msgid ""
 "Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
-#: cmd/incus/admin_init.go:59
+#: cmd/incus/admin_init.go:61
 msgid "Address to bind to (default: none)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:806
+#: cmd/incus/admin_init_interactive.go:812
 msgid "Address to bind to (not including port)"
 msgstr ""
 
-#: cmd/incus/info.go:229
+#: cmd/incus/info.go:231
 #, c-format
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:375
 #, c-format
 msgid "Address: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:190
+#: cmd/incus/storage_bucket.go:194
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:191
+#: cmd/incus/storage_bucket.go:195
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -740,102 +740,102 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:167
-#: cmd/incus/image_alias.go:409
+#: cmd/incus/image_alias.go:115 cmd/incus/image_alias.go:173
+#: cmd/incus/image_alias.go:419
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:1037
+#: cmd/incus/image.go:1057
 #, c-format
 msgid "Alias: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:254
+#: cmd/incus/publish.go:257
 #, c-format
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1041
 msgid "Aliases:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:226
+#: cmd/incus/admin_init_interactive.go:228
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1568 cmd/incus/storage_volume.go:2566
+#: cmd/incus/storage_volume.go:1591 cmd/incus/storage_volume.go:2641
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:199
+#: cmd/incus/remote.go:200
 msgid "All server addresses are unavailable"
 msgstr ""
 
-#: cmd/incus/config_trust.go:182
+#: cmd/incus/config_trust.go:186
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:503 cmd/incus/info.go:507
-#: cmd/incus/info.go:653
+#: cmd/incus/image.go:1013 cmd/incus/info.go:505 cmd/incus/info.go:509
+#: cmd/incus/info.go:655
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: cmd/incus/info.go:155
+#: cmd/incus/info.go:157
 #, c-format
 msgid "Architecture: %v"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:162
+#: cmd/incus/admin_init_interactive.go:164
 msgid "Are you joining an existing cluster?"
 msgstr ""
 
-#: cmd/incus/cluster.go:1523
+#: cmd/incus/cluster.go:1557
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:393
+#: cmd/incus/console.go:400
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:388 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:391 cmd/incus/rebuild.go:133
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:100 cmd/incus/cluster_group.go:101
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:102
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:183 cmd/incus/profile.go:184
+#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
-#: cmd/incus/network.go:146
+#: cmd/incus/network.go:149
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/network.go:243 cmd/incus/network.go:244
+#: cmd/incus/network.go:248 cmd/incus/network.go:249
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:165 cmd/incus/storage_volume.go:166
 msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:258 cmd/incus/storage_volume.go:259
 msgid "Attach new custom storage volumes to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:147
+#: cmd/incus/network.go:150
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:38
+#: cmd/incus/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -843,152 +843,152 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:564
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
-#: cmd/incus/info.go:248
+#: cmd/incus/info.go:250
 #, c-format
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:189
+#: cmd/incus/image.go:195
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:1031
+#: cmd/incus/image.go:1051
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:54
+#: cmd/incus/admin_init.go:56
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:154
+#: cmd/incus/remote.go:155
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:499
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
 
-#: cmd/incus/list.go:584 cmd/incus/list.go:585
+#: cmd/incus/list.go:506 cmd/incus/list.go:507
 msgid "BASE IMAGE"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:927
 msgid "Backend description"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1336
+#: cmd/incus/network_load_balancer.go:1364
 msgid "Backend health:"
 msgstr ""
 
-#: cmd/incus/export.go:85
+#: cmd/incus/export.go:87
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1484
+#: cmd/incus/storage_bucket.go:1513
 #, c-format
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3054
+#: cmd/incus/storage_volume.go:3138
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1561
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/export.go:193 cmd/incus/storage_bucket.go:1590
+#: cmd/incus/storage_volume.go:3215
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:845 cmd/incus/storage_volume.go:1499
+#: cmd/incus/info.go:847 cmd/incus/storage_volume.go:1521
 msgid "Backups:"
 msgstr ""
 
-#: cmd/incus/utils.go:102
+#: cmd/incus/utils.go:103
 #, c-format
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:420 cmd/incus/network_acl.go:459
-#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:389
-#: cmd/incus/network_load_balancer.go:392 cmd/incus/network_peer.go:415
-#: cmd/incus/network_zone.go:467 cmd/incus/network_zone.go:1166
-#: cmd/incus/storage_bucket.go:158
+#: cmd/incus/network.go:428 cmd/incus/network_acl.go:471
+#: cmd/incus/network_address_set.go:314 cmd/incus/network_forward.go:397
+#: cmd/incus/network_load_balancer.go:400 cmd/incus/network_peer.go:423
+#: cmd/incus/network_zone.go:476 cmd/incus/network_zone.go:1192
+#: cmd/incus/storage_bucket.go:162
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:152 cmd/incus/create.go:247 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:173
+#: cmd/incus/copy.go:154 cmd/incus/create.go:250 cmd/incus/move.go:305
+#: cmd/incus/network_integration.go:146 cmd/incus/project.go:177
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:179
-#: cmd/incus/storage_volume.go:657
+#: cmd/incus/publish.go:194 cmd/incus/storage.go:183
+#: cmd/incus/storage_volume.go:667
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:785
+#: cmd/incus/image.go:799
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1012
+#: cmd/incus/network.go:1032
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:391
+#: cmd/incus/action.go:183 cmd/incus/action.go:385
 msgid "Both --all and instance name given"
 msgstr ""
 
-#: cmd/incus/info.go:156
+#: cmd/incus/info.go:158
 #, c-format
 msgid "Brand: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1025
+#: cmd/incus/network.go:1045
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:106
+#: cmd/incus/storage_bucket.go:109
 msgid "Bucket description"
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:367
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/network.go:1003
+#: cmd/incus/info.go:770 cmd/incus/network.go:1023
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:769 cmd/incus/network.go:1004
+#: cmd/incus/info.go:771 cmd/incus/network.go:1024
 msgid "Bytes sent"
 msgstr ""
 
-#: cmd/incus/operation.go:158
+#: cmd/incus/operation.go:163
 msgid "CANCELABLE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:440
+#: cmd/incus/config_trust.go:449
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1687
+#: cmd/incus/storage_volume.go:1722
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: cmd/incus/warning.go:215
+#: cmd/incus/warning.go:219
 msgid "COUNT"
 msgstr ""
 
@@ -996,72 +996,72 @@ msgstr ""
 msgid "CPU TIME(s)"
 msgstr ""
 
-#: cmd/incus/list.go:596
+#: cmd/incus/list.go:518
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:709
+#: cmd/incus/info.go:711
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:713
+#: cmd/incus/info.go:715
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:502
+#: cmd/incus/info.go:504
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:506
+#: cmd/incus/info.go:508
 msgid "CPUs:"
 msgstr ""
 
-#: cmd/incus/operation.go:159
+#: cmd/incus/operation.go:164
 msgid "CREATED"
 msgstr ""
 
-#: cmd/incus/list.go:580
+#: cmd/incus/list.go:502
 msgid "CREATED AT"
 msgstr ""
 
-#: cmd/incus/info.go:158
+#: cmd/incus/info.go:160
 #, c-format
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:1030
+#: cmd/incus/image.go:1050
 #, c-format
 msgid "Cached: %s"
 msgstr ""
 
-#: cmd/incus/info.go:335
+#: cmd/incus/info.go:337
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:147
-#: cmd/incus/admin_init_interactive.go:831
+#: cmd/incus/admin_init_interactive.go:149
+#: cmd/incus/admin_init_interactive.go:837
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:127
+#: cmd/incus/move.go:130
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:212
+#: cmd/incus/image.go:218
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:597
+#: cmd/incus/file.go:607
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: cmd/incus/utils.go:304
+#: cmd/incus/utils.go:305
 #, c-format
 msgid "Can't read from environment file: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:269 cmd/incus/utils.go:289
+#: cmd/incus/utils.go:270 cmd/incus/utils.go:290
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1070,253 +1070,253 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: cmd/incus/list.go:611
+#: cmd/incus/list.go:533
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:253 cmd/incus/list.go:475 cmd/incus/profile.go:817
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
-#: cmd/incus/rename.go:59
+#: cmd/incus/rename.go:62
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:628 cmd/incus/storage_volume.go:1697
-#: cmd/incus/warning.go:230
+#: cmd/incus/list.go:550 cmd/incus/storage_volume.go:1732
+#: cmd/incus/warning.go:234
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:786
+#: cmd/incus/file.go:797
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: cmd/incus/config.go:681
+#: cmd/incus/config.go:682
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: cmd/incus/admin_init.go:72
+#: cmd/incus/admin_init.go:75
 msgid "Can't use --auto and --preseed together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:94
+#: cmd/incus/admin_init.go:97
 msgid "Can't use --dump with other flags"
 msgstr ""
 
-#: cmd/incus/admin_init.go:80
+#: cmd/incus/admin_init.go:83
 msgid "Can't use --minimal and --auto together"
 msgstr ""
 
-#: cmd/incus/admin_init.go:76
+#: cmd/incus/admin_init.go:79
 msgid "Can't use --minimal and --preseed together"
 msgstr ""
 
-#: cmd/incus/rebuild.go:161
+#: cmd/incus/rebuild.go:163
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:357
+#: cmd/incus/create.go:360
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:459
+#: cmd/incus/storage_volume.go:467
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:413
+#: cmd/incus/storage_volume.go:421
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:434
+#: cmd/incus/storage_volume.go:442
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:961
+#: cmd/incus/network_acl.go:985
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:551 cmd/incus/info.go:563
+#: cmd/incus/info.go:553 cmd/incus/info.go:565
 #, c-format
 msgid "Card %d:"
 msgstr ""
 
-#: cmd/incus/info.go:141
+#: cmd/incus/info.go:143
 #, c-format
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: cmd/incus/config_trust.go:850
+#: cmd/incus/config_trust.go:866
 #, c-format
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/config_trust.go:184
+#: cmd/incus/config_trust.go:188
 msgid "Certificate description"
 msgstr ""
 
-#: cmd/incus/remote.go:237
+#: cmd/incus/remote.go:238
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:210
+#: cmd/incus/admin_init.go:188 cmd/incus/admin_init_interactive.go:212
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:466
+#: cmd/incus/remote.go:467
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1048
+#: cmd/incus/network.go:1068
 msgid "Chassis"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:69
+#: cmd/incus/admin_waitready.go:71
 #, c-format
 msgid "Checking if the daemon is ready (attempt %d)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:270
+#: cmd/incus/admin_init_interactive.go:272
 #, c-format
 msgid "Choose %s:"
 msgstr ""
 
-#: cmd/incus/config_trust.go:147
+#: cmd/incus/config_trust.go:150
 #, c-format
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:610
+#: cmd/incus/remote.go:611
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: cmd/incus/version.go:37
+#: cmd/incus/version.go:39
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:262
+#: cmd/incus/cluster_group.go:263
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:323
+#: cmd/incus/cluster_group.go:324
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:668
+#: cmd/incus/cluster_group.go:669
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:745
+#: cmd/incus/cluster_group.go:746
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:196
+#: cmd/incus/cluster_group.go:197
 msgid "Cluster group description"
 msgstr ""
 
-#: cmd/incus/cluster.go:1308
+#: cmd/incus/cluster.go:1336
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:169
+#: cmd/incus/cluster_group.go:170
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:881
+#: cmd/incus/cluster_group.go:884
 #, c-format
 msgid "Cluster member %s added to group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:870
+#: cmd/incus/cluster_group.go:873
 #, c-format
 msgid "Cluster member %s is already in group %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:688
+#: cmd/incus/cluster_group.go:689
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
-#: cmd/incus/create.go:63 cmd/incus/info.go:49 cmd/incus/move.go:64
-#: cmd/incus/network.go:353 cmd/incus/network.go:850 cmd/incus/network.go:931
-#: cmd/incus/network.go:1513 cmd/incus/network.go:1606
-#: cmd/incus/network.go:1678 cmd/incus/network_forward.go:255
-#: cmd/incus/network_forward.go:338 cmd/incus/network_forward.go:531
-#: cmd/incus/network_forward.go:683 cmd/incus/network_forward.go:837
-#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:1011
-#: cmd/incus/network_load_balancer.go:259
-#: cmd/incus/network_load_balancer.go:341
-#: cmd/incus/network_load_balancer.go:517
-#: cmd/incus/network_load_balancer.go:652
-#: cmd/incus/network_load_balancer.go:817
-#: cmd/incus/network_load_balancer.go:906
-#: cmd/incus/network_load_balancer.go:984
-#: cmd/incus/network_load_balancer.go:1098
-#: cmd/incus/network_load_balancer.go:1174 cmd/incus/storage.go:110
-#: cmd/incus/storage.go:412 cmd/incus/storage.go:495 cmd/incus/storage.go:843
-#: cmd/incus/storage.go:945 cmd/incus/storage.go:1038
-#: cmd/incus/storage_bucket.go:105 cmd/incus/storage_bucket.go:211
-#: cmd/incus/storage_bucket.go:274 cmd/incus/storage_bucket.go:405
-#: cmd/incus/storage_bucket.go:657 cmd/incus/storage_bucket.go:750
-#: cmd/incus/storage_bucket.go:816 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_bucket.go:1053 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_bucket.go:1223 cmd/incus/storage_bucket.go:1359
-#: cmd/incus/storage_bucket.go:1433 cmd/incus/storage_bucket.go:1582
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:588
-#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:976
-#: cmd/incus/storage_volume.go:1202 cmd/incus/storage_volume.go:1335
-#: cmd/incus/storage_volume.go:1792 cmd/incus/storage_volume.go:1884
-#: cmd/incus/storage_volume.go:1976 cmd/incus/storage_volume.go:2140
-#: cmd/incus/storage_volume.go:2240 cmd/incus/storage_volume.go:2347
-#: cmd/incus/storage_volume.go:2475 cmd/incus/storage_volume.go:2731
-#: cmd/incus/storage_volume.go:2817 cmd/incus/storage_volume.go:2897
-#: cmd/incus/storage_volume.go:2989 cmd/incus/storage_volume.go:3155
+#: cmd/incus/config.go:102 cmd/incus/config.go:394 cmd/incus/config.go:538
+#: cmd/incus/config.go:756 cmd/incus/config.go:887 cmd/incus/copy.go:63
+#: cmd/incus/create.go:65 cmd/incus/info.go:50 cmd/incus/move.go:66
+#: cmd/incus/network.go:360 cmd/incus/network.go:867 cmd/incus/network.go:950
+#: cmd/incus/network.go:1540 cmd/incus/network.go:1635
+#: cmd/incus/network.go:1709 cmd/incus/network_forward.go:260
+#: cmd/incus/network_forward.go:345 cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:698 cmd/incus/network_forward.go:854
+#: cmd/incus/network_forward.go:947 cmd/incus/network_forward.go:1033
+#: cmd/incus/network_load_balancer.go:264
+#: cmd/incus/network_load_balancer.go:348
+#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:667
+#: cmd/incus/network_load_balancer.go:834
+#: cmd/incus/network_load_balancer.go:926
+#: cmd/incus/network_load_balancer.go:1006
+#: cmd/incus/network_load_balancer.go:1123
+#: cmd/incus/network_load_balancer.go:1201 cmd/incus/storage.go:113
+#: cmd/incus/storage.go:421 cmd/incus/storage.go:506 cmd/incus/storage.go:858
+#: cmd/incus/storage.go:962 cmd/incus/storage.go:1057
+#: cmd/incus/storage_bucket.go:108 cmd/incus/storage_bucket.go:216
+#: cmd/incus/storage_bucket.go:281 cmd/incus/storage_bucket.go:414
+#: cmd/incus/storage_bucket.go:670 cmd/incus/storage_bucket.go:765
+#: cmd/incus/storage_bucket.go:833 cmd/incus/storage_bucket.go:935
+#: cmd/incus/storage_bucket.go:1075 cmd/incus/storage_bucket.go:1182
+#: cmd/incus/storage_bucket.go:1249 cmd/incus/storage_bucket.go:1387
+#: cmd/incus/storage_bucket.go:1462 cmd/incus/storage_bucket.go:1611
+#: cmd/incus/storage_volume.go:373 cmd/incus/storage_volume.go:597
+#: cmd/incus/storage_volume.go:710 cmd/incus/storage_volume.go:993
+#: cmd/incus/storage_volume.go:1221 cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1852 cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:2040 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2308 cmd/incus/storage_volume.go:2418
+#: cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_volume.go:2896 cmd/incus/storage_volume.go:2978
+#: cmd/incus/storage_volume.go:3072 cmd/incus/storage_volume.go:3240
 msgid "Cluster member name"
 msgstr ""
 
-#: cmd/incus/cluster.go:863
+#: cmd/incus/cluster.go:883
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1096
-#: cmd/incus/cluster_group.go:485 cmd/incus/config_trust.go:424
-#: cmd/incus/config_trust.go:617 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:211 cmd/incus/list.go:134 cmd/incus/network.go:1105
-#: cmd/incus/network.go:1311 cmd/incus/network_allocations.go:63
-#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
-#: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
-#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:139
-#: cmd/incus/profile.go:733 cmd/incus/project.go:537 cmd/incus/remote.go:750
-#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:694
-#: cmd/incus/storage_bucket.go:510 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1567 cmd/incus/storage_volume.go:2565
-#: cmd/incus/top.go:64 cmd/incus/warning.go:94
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433
+#: cmd/incus/config_trust.go:628 cmd/incus/image.go:1114
+#: cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126
+#: cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64
+#: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
+#: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
+#: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
+#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
+#: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
+#: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
+#: cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1327,54 +1327,54 @@ msgid ""
 "control those."
 msgstr ""
 
-#: cmd/incus/publish.go:39
+#: cmd/incus/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: cmd/incus/export.go:43
+#: cmd/incus/export.go:44
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:55
+#: cmd/incus/copy.go:55 cmd/incus/create.go:57
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/network_integration.go:92
+#: cmd/incus/network_integration.go:93
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:113
+#: cmd/incus/project.go:116
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:56
+#: cmd/incus/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:131
+#: cmd/incus/admin_recover.go:134
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:966 cmd/incus/cluster_group.go:421
-#: cmd/incus/config.go:276 cmd/incus/config.go:351
-#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:356
-#: cmd/incus/image.go:464 cmd/incus/network.go:813 cmd/incus/network_acl.go:726
-#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:801
-#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:781
-#: cmd/incus/network_peer.go:814 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:1429 cmd/incus/profile.go:608
-#: cmd/incus/project.go:409 cmd/incus/storage.go:375
-#: cmd/incus/storage_bucket.go:369 cmd/incus/storage_bucket.go:1322
-#: cmd/incus/storage_volume.go:1121 cmd/incus/storage_volume.go:1153
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364
+#: cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744
+#: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
+#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/project.go:417 cmd/incus/storage.go:383
+#: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:86
+#: cmd/incus/admin_init.go:89
 msgid "Configuration flags require --auto"
 msgstr ""
 
-#: cmd/incus/admin_init.go:44 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_init.go:46 cmd/incus/admin_init.go:47
 msgid "Configure the daemon"
 msgstr ""
 
@@ -1382,42 +1382,42 @@ msgstr ""
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:54
+#: cmd/incus/admin_waitready.go:56
 #, c-format
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:598
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1439
+#: cmd/incus/storage_volume.go:1461
 #, c-format
 msgid "Content type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:145
+#: cmd/incus/info.go:147
 #, c-format
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/move.go:62
+#: cmd/incus/copy.go:61 cmd/incus/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: cmd/incus/image.go:155
+#: cmd/incus/image.go:160
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
+#: cmd/incus/storage_volume.go:368 cmd/incus/storage_volume.go:369
 msgid "Copy custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:147
+#: cmd/incus/image.go:152
 msgid "Copy images between servers"
 msgstr ""
 
-#: cmd/incus/image.go:148
+#: cmd/incus/image.go:153
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1425,11 +1425,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:42
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:41
+#: cmd/incus/copy.go:43
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1445,141 +1445,141 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:408 cmd/incus/config_device.go:409
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:274 cmd/incus/profile.go:275
+#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:58
+#: cmd/incus/copy.go:60
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:375
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
+#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: cmd/incus/image.go:158
+#: cmd/incus/image.go:163
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:275
+#: cmd/incus/image.go:281
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:481
+#: cmd/incus/storage_volume.go:489
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: cmd/incus/info.go:341
+#: cmd/incus/info.go:343
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:502
+#: cmd/incus/remote.go:503
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:243 cmd/incus/remote.go:486
+#: cmd/incus/remote.go:244 cmd/incus/remote.go:487
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: cmd/incus/cluster.go:1389
+#: cmd/incus/cluster.go:1419
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1393
+#: cmd/incus/cluster.go:1423
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1398
+#: cmd/incus/cluster.go:1428
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1403
+#: cmd/incus/cluster.go:1433
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:1420
+#: cmd/incus/cluster.go:1450
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:497
+#: cmd/incus/remote.go:498
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1649
+#: cmd/incus/network_zone.go:1688
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:675
+#: cmd/incus/admin_init_interactive.go:681
 #, c-format
 msgid "Couldn't statfs %s: %w"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:188
+#: cmd/incus/cluster_group.go:188 cmd/incus/cluster_group.go:189
 msgid "Create a cluster group"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:612
+#: cmd/incus/admin_init_interactive.go:614
 #, c-format
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:66
+#: cmd/incus/create.go:68
 msgid "Create a virtual machine"
 msgstr ""
 
-#: cmd/incus/image_alias.go:67 cmd/incus/image_alias.go:68
+#: cmd/incus/image_alias.go:70 cmd/incus/image_alias.go:71
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:65
+#: cmd/incus/create.go:67
 msgid "Create an empty instance"
 msgstr ""
 
-#: cmd/incus/launch.go:23 cmd/incus/launch.go:24
+#: cmd/incus/launch.go:24 cmd/incus/launch.go:25
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:113 cmd/incus/file.go:468 cmd/incus/file.go:701
+#: cmd/incus/file.go:114 cmd/incus/file.go:476 cmd/incus/file.go:711
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:104 cmd/incus/file.go:105
+#: cmd/incus/file.go:105 cmd/incus/file.go:106
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: cmd/incus/export.go:80
+#: cmd/incus/export.go:82
 #, c-format
 msgid "Create instance backup: %w"
 msgstr ""
 
-#: cmd/incus/snapshot.go:77
+#: cmd/incus/snapshot.go:80
 msgid "Create instance snapshot"
 msgstr ""
 
-#: cmd/incus/snapshot.go:78
+#: cmd/incus/snapshot.go:81
 msgid ""
 "Create instance snapshots\n"
 "\n"
@@ -1587,31 +1587,31 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:43 cmd/incus/create.go:44
+#: cmd/incus/create.go:45 cmd/incus/create.go:46
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1043 cmd/incus/storage_bucket.go:1044
+#: cmd/incus/storage_bucket.go:1065 cmd/incus/storage_bucket.go:1066
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_integration.go:84 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:86
 msgid "Create network integrations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:97 cmd/incus/storage_bucket.go:98
+#: cmd/incus/storage_bucket.go:100 cmd/incus/storage_bucket.go:101
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:580
+#: cmd/incus/storage_volume.go:588 cmd/incus/storage_volume.go:589
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: cmd/incus/config_template.go:65 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:68 cmd/incus/config_template.go:69
 msgid "Create new instance file templates"
 msgstr ""
 
-#: cmd/incus/network_acl.go:385 cmd/incus/network_acl.go:386
+#: cmd/incus/network_acl.go:396 cmd/incus/network_acl.go:397
 msgid "Create new network ACLs"
 msgstr ""
 
@@ -1619,86 +1619,86 @@ msgstr ""
 msgid "Create new network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:329 cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:336 cmd/incus/network_forward.go:337
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:332
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:339
+#: cmd/incus/network_load_balancer.go:340
 msgid "Create new network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:324 cmd/incus/network_peer.go:325
+#: cmd/incus/network_peer.go:331 cmd/incus/network_peer.go:332
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
+#: cmd/incus/network_zone.go:1116 cmd/incus/network_zone.go:1117
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:395 cmd/incus/network_zone.go:396
+#: cmd/incus/network_zone.go:403 cmd/incus/network_zone.go:404
 msgid "Create new network zones"
 msgstr ""
 
-#: cmd/incus/network.go:342 cmd/incus/network.go:343
+#: cmd/incus/network.go:349 cmd/incus/network.go:350
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:358 cmd/incus/profile.go:359
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:104 cmd/incus/project.go:105
+#: cmd/incus/project.go:107 cmd/incus/project.go:108
 msgid "Create projects"
 msgstr ""
 
-#: cmd/incus/storage.go:101 cmd/incus/storage.go:102
+#: cmd/incus/storage.go:104 cmd/incus/storage.go:105
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:63 cmd/incus/create.go:64
+#: cmd/incus/copy.go:65 cmd/incus/create.go:66
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:664
-#: cmd/incus/storage_volume.go:1453
+#: cmd/incus/image.go:1019 cmd/incus/info.go:666
+#: cmd/incus/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:181
+#: cmd/incus/create.go:184
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:260
+#: cmd/incus/file.go:263
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:179
+#: cmd/incus/create.go:182
 msgid "Creating the instance"
 msgstr ""
 
-#: cmd/incus/info.go:165 cmd/incus/info.go:274
+#: cmd/incus/info.go:167 cmd/incus/info.go:276
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:138
+#: cmd/incus/network_forward.go:141
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:180 cmd/incus/cluster_group.go:511
-#: cmd/incus/config_trust.go:442 cmd/incus/image.go:1122
-#: cmd/incus/image_alias.go:251 cmd/incus/list.go:581 cmd/incus/network.go:1136
-#: cmd/incus/network_acl.go:173 cmd/incus/network_address_set.go:164
-#: cmd/incus/network_forward.go:137 cmd/incus/network_integration.go:454
-#: cmd/incus/network_load_balancer.go:145 cmd/incus/network_peer.go:133
-#: cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:933
-#: cmd/incus/operation.go:156 cmd/incus/profile.go:761 cmd/incus/project.go:569
-#: cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:527
-#: cmd/incus/storage_bucket.go:932 cmd/incus/storage_volume.go:1686
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512
+#: cmd/incus/config_trust.go:451 cmd/incus/image.go:1143
+#: cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157
+#: cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164
+#: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
+#: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
+#: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
+#: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1706,29 +1706,29 @@ msgstr ""
 msgid "DISK"
 msgstr ""
 
-#: cmd/incus/list.go:582
+#: cmd/incus/list.go:504
 msgid "DISK USAGE"
 msgstr ""
 
-#: cmd/incus/storage.go:720
+#: cmd/incus/storage.go:733
 msgid "DRIVER"
 msgstr ""
 
-#: cmd/incus/info.go:137
+#: cmd/incus/info.go:139
 msgid "DRM:"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:93
+#: cmd/incus/admin_waitready.go:94
 #, c-format
 msgid "Daemon still not running after %ds timeout (%v)"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:83
+#: cmd/incus/admin_shutdown.go:91
 #, c-format
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:491
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1741,11 +1741,11 @@ msgstr ""
 msgid "Debug commands for instances"
 msgstr ""
 
-#: cmd/incus/network.go:1029
+#: cmd/incus/network.go:1049
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1432 cmd/incus/storage_volume.go:2988
+#: cmd/incus/storage_bucket.go:1461 cmd/incus/storage_volume.go:3071
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1753,51 +1753,51 @@ msgstr ""
 msgid "Delay:"
 msgstr ""
 
-#: cmd/incus/operation.go:62 cmd/incus/operation.go:63
+#: cmd/incus/operation.go:65 cmd/incus/operation.go:66
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:279 cmd/incus/cluster_group.go:280
+#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:281
 msgid "Delete a cluster group"
 msgstr ""
 
-#: cmd/incus/warning.go:366
+#: cmd/incus/warning.go:375
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:695 cmd/incus/storage_volume.go:696
+#: cmd/incus/storage_volume.go:706 cmd/incus/storage_volume.go:707
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:301 cmd/incus/file.go:302
+#: cmd/incus/file.go:305 cmd/incus/file.go:306
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:134 cmd/incus/image_alias.go:135
+#: cmd/incus/image_alias.go:139 cmd/incus/image_alias.go:140
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:307 cmd/incus/image.go:308
+#: cmd/incus/image.go:314 cmd/incus/image.go:315
 msgid "Delete images"
 msgstr ""
 
-#: cmd/incus/config_template.go:133 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:138 cmd/incus/config_template.go:139
 msgid "Delete instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:202 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:207 cmd/incus/snapshot.go:208
 msgid "Delete instance snapshots"
 msgstr ""
 
-#: cmd/incus/delete.go:31 cmd/incus/delete.go:32
+#: cmd/incus/delete.go:33 cmd/incus/delete.go:34
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1154 cmd/incus/storage_bucket.go:1155
+#: cmd/incus/storage_bucket.go:1178 cmd/incus/storage_bucket.go:1179
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:815 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:836 cmd/incus/network_acl.go:837
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1805,361 +1805,361 @@ msgstr ""
 msgid "Delete network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:834
+#: cmd/incus/network_forward.go:850 cmd/incus/network_forward.go:851
 msgid "Delete network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:177 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:179
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:813
-#: cmd/incus/network_load_balancer.go:814
+#: cmd/incus/network_load_balancer.go:830
+#: cmd/incus/network_load_balancer.go:831
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:846 cmd/incus/network_peer.go:847
+#: cmd/incus/network_peer.go:865 cmd/incus/network_peer.go:866
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1461 cmd/incus/network_zone.go:1462
+#: cmd/incus/network_zone.go:1494 cmd/incus/network_zone.go:1495
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:754 cmd/incus/network_zone.go:755
+#: cmd/incus/network_zone.go:770 cmd/incus/network_zone.go:771
 msgid "Delete network zones"
 msgstr ""
 
-#: cmd/incus/network.go:458 cmd/incus/network.go:459
+#: cmd/incus/network.go:467 cmd/incus/network.go:468
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:447 cmd/incus/profile.go:448
+#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:208 cmd/incus/project.go:209
+#: cmd/incus/project.go:213 cmd/incus/project.go:214
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:208 cmd/incus/storage_bucket.go:209
+#: cmd/incus/storage_bucket.go:213 cmd/incus/storage_bucket.go:214
 msgid "Delete storage buckets"
 msgstr ""
 
-#: cmd/incus/storage.go:218 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:223 cmd/incus/storage.go:224
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2472
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2545
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/warning.go:362 cmd/incus/warning.go:363
+#: cmd/incus/warning.go:371 cmd/incus/warning.go:372
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:24 cmd/incus/alias.go:62
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81
+#: cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21
+#: cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47
+#: cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31
+#: cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32
+#: cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62
 #: cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:322
-#: cmd/incus/cluster.go:379 cmd/incus/cluster.go:438 cmd/incus/cluster.go:511
-#: cmd/incus/cluster.go:591 cmd/incus/cluster.go:635 cmd/incus/cluster.go:693
-#: cmd/incus/cluster.go:784 cmd/incus/cluster.go:877 cmd/incus/cluster.go:998
-#: cmd/incus/cluster.go:1076 cmd/incus/cluster.go:1241
-#: cmd/incus/cluster.go:1329 cmd/incus/cluster.go:1453
-#: cmd/incus/cluster.go:1482 cmd/incus/cluster_group.go:35
-#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:188
-#: cmd/incus/cluster_group.go:280 cmd/incus/cluster_group.go:340
-#: cmd/incus/cluster_group.go:465 cmd/incus/cluster_group.go:621
-#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:762
-#: cmd/incus/cluster_group.go:824 cmd/incus/cluster_group.go:900
-#: cmd/incus/cluster_group.go:975 cmd/incus/cluster_group.go:1057
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:360
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:172 cmd/incus/config_trust.go:278
-#: cmd/incus/config_trust.go:403 cmd/incus/config_trust.go:597
-#: cmd/incus/config_trust.go:754 cmd/incus/config_trust.go:800
-#: cmd/incus/config_trust.go:871 cmd/incus/console.go:38 cmd/incus/copy.go:41
-#: cmd/incus/create.go:44 cmd/incus/debug.go:24 cmd/incus/debug.go:45
-#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
-#: cmd/incus/file.go:58 cmd/incus/file.go:105 cmd/incus/file.go:302
-#: cmd/incus/file.go:384 cmd/incus/file.go:462 cmd/incus/file.go:694
-#: cmd/incus/file.go:1361 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498
-#: cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067
-#: cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575
-#: cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:30
-#: cmd/incus/image_alias.go:68 cmd/incus/image_alias.go:135
-#: cmd/incus/image_alias.go:189 cmd/incus/image_alias.go:377
-#: cmd/incus/import.go:27 cmd/incus/info.go:36 cmd/incus/launch.go:24
-#: cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:24
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36
-#: cmd/incus/network.go:147 cmd/incus/network.go:244 cmd/incus/network.go:343
-#: cmd/incus/network.go:459 cmd/incus/network.go:517 cmd/incus/network.go:614
-#: cmd/incus/network.go:711 cmd/incus/network.go:847 cmd/incus/network.go:928
-#: cmd/incus/network.go:1086 cmd/incus/network.go:1289
-#: cmd/incus/network.go:1447 cmd/incus/network.go:1507
-#: cmd/incus/network.go:1603 cmd/incus/network.go:1675
-#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
-#: cmd/incus/network_acl.go:194 cmd/incus/network_acl.go:255
-#: cmd/incus/network_acl.go:311 cmd/incus/network_acl.go:386
-#: cmd/incus/network_acl.go:489 cmd/incus/network_acl.go:577
-#: cmd/incus/network_acl.go:620 cmd/incus/network_acl.go:759
-#: cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:874
-#: cmd/incus/network_acl.go:889 cmd/incus/network_acl.go:1033
+#: cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327
+#: cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522
+#: cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710
+#: cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021
+#: cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268
+#: cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484
+#: cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36
+#: cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189
+#: cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341
+#: cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622
+#: cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763
+#: cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903
+#: cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060
+#: cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52
+#: cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96
+#: cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752
+#: cmd/incus/config.go:884 cmd/incus/config_device.go:26
+#: cmd/incus/config_device.go:81 cmd/incus/config_device.go:225
+#: cmd/incus/config_device.go:324 cmd/incus/config_device.go:409
+#: cmd/incus/config_device.go:513 cmd/incus/config_device.go:631
+#: cmd/incus/config_device.go:638 cmd/incus/config_device.go:773
+#: cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28
+#: cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192
+#: cmd/incus/config_template.go:28 cmd/incus/config_template.go:69
+#: cmd/incus/config_template.go:139 cmd/incus/config_template.go:195
+#: cmd/incus/config_template.go:297 cmd/incus/config_template.go:371
+#: cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93
+#: cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285
+#: cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608
+#: cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815
+#: cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43
+#: cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45
+#: cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33
+#: cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306
+#: cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704
+#: cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153
+#: cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509
+#: cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088
+#: cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599
+#: cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32
+#: cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140
+#: cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386
+#: cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25
+#: cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25
+#: cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38
+#: cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350
+#: cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627
+#: cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947
+#: cmd/incus/network.go:1107 cmd/incus/network.go:1312
+#: cmd/incus/network.go:1472 cmd/incus/network.go:1534
+#: cmd/incus/network.go:1632 cmd/incus/network.go:1706
+#: cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97
+#: cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262
+#: cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592
+#: cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778
+#: cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897
+#: cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060
 #: cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93
 #: cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247
 #: cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429
 #: cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594
 #: cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703
-#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:35
-#: cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91
-#: cmd/incus/network_forward.go:252 cmd/incus/network_forward.go:330
-#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:523
-#: cmd/incus/network_forward.go:633 cmd/incus/network_forward.go:680
-#: cmd/incus/network_forward.go:834 cmd/incus/network_forward.go:909
-#: cmd/incus/network_forward.go:924 cmd/incus/network_forward.go:1007
-#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
-#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
-#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416
-#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:617
-#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:731
-#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:333
-#: cmd/incus/network_load_balancer.go:441
-#: cmd/incus/network_load_balancer.go:509
-#: cmd/incus/network_load_balancer.go:619
-#: cmd/incus/network_load_balancer.go:649
-#: cmd/incus/network_load_balancer.go:814
-#: cmd/incus/network_load_balancer.go:888
-#: cmd/incus/network_load_balancer.go:903
-#: cmd/incus/network_load_balancer.go:981
-#: cmd/incus/network_load_balancer.go:1080
-#: cmd/incus/network_load_balancer.go:1095
-#: cmd/incus/network_load_balancer.go:1170
-#: cmd/incus/network_load_balancer.go:1293 cmd/incus/network_peer.go:28
-#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:253
-#: cmd/incus/network_peer.go:325 cmd/incus/network_peer.go:476
-#: cmd/incus/network_peer.go:561 cmd/incus/network_peer.go:663
-#: cmd/incus/network_peer.go:710 cmd/incus/network_peer.go:847
-#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
-#: cmd/incus/network_zone.go:258 cmd/incus/network_zone.go:321
-#: cmd/incus/network_zone.go:396 cmd/incus/network_zone.go:497
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:628
-#: cmd/incus/network_zone.go:755 cmd/incus/network_zone.go:811
-#: cmd/incus/network_zone.go:868 cmd/incus/network_zone.go:950
-#: cmd/incus/network_zone.go:1014 cmd/incus/network_zone.go:1092
-#: cmd/incus/network_zone.go:1196 cmd/incus/network_zone.go:1285
-#: cmd/incus/network_zone.go:1332 cmd/incus/network_zone.go:1462
-#: cmd/incus/network_zone.go:1523 cmd/incus/network_zone.go:1538
-#: cmd/incus/network_zone.go:1596 cmd/incus/operation.go:30
-#: cmd/incus/operation.go:63 cmd/incus/operation.go:114
-#: cmd/incus/operation.go:293 cmd/incus/profile.go:34 cmd/incus/profile.go:109
-#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:359
-#: cmd/incus/profile.go:448 cmd/incus/profile.go:506 cmd/incus/profile.go:642
-#: cmd/incus/profile.go:718 cmd/incus/profile.go:882 cmd/incus/profile.go:970
-#: cmd/incus/profile.go:1030 cmd/incus/profile.go:1119
-#: cmd/incus/profile.go:1183 cmd/incus/project.go:36 cmd/incus/project.go:105
-#: cmd/incus/project.go:209 cmd/incus/project.go:307 cmd/incus/project.go:443
-#: cmd/incus/project.go:518 cmd/incus/project.go:737 cmd/incus/project.go:802
-#: cmd/incus/project.go:890 cmd/incus/project.go:934 cmd/incus/project.go:995
-#: cmd/incus/project.go:1063 cmd/incus/project.go:1178 cmd/incus/publish.go:32
-#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
-#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
-#: cmd/incus/remote.go:724 cmd/incus/remote.go:902 cmd/incus/remote.go:983
+#: cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36
+#: cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94
+#: cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337
+#: cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534
+#: cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695
+#: cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928
+#: cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029
+#: cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86
+#: cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231
+#: cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417
+#: cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618
+#: cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732
+#: cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:340
+#: cmd/incus/network_load_balancer.go:450
+#: cmd/incus/network_load_balancer.go:520
+#: cmd/incus/network_load_balancer.go:632
+#: cmd/incus/network_load_balancer.go:664
+#: cmd/incus/network_load_balancer.go:831
+#: cmd/incus/network_load_balancer.go:907
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1003
+#: cmd/incus/network_load_balancer.go:1104
+#: cmd/incus/network_load_balancer.go:1120
+#: cmd/incus/network_load_balancer.go:1197
+#: cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30
+#: cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258
+#: cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487
+#: cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678
+#: cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866
+#: cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94
+#: cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327
+#: cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507
+#: cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642
+#: cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971
+#: cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117
+#: cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314
+#: cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495
+#: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
+#: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
+#: cmd/incus/operation.go:66 cmd/incus/operation.go:119
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
+#: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
+#: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
+#: cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34
+#: cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45
+#: cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686
+#: cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983
 #: cmd/incus/remote.go:1048 cmd/incus/remote.go:1096
-#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
-#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
-#: cmd/incus/snapshot.go:453 cmd/incus/snapshot.go:514
-#: cmd/incus/snapshot.go:593 cmd/incus/storage.go:37 cmd/incus/storage.go:102
-#: cmd/incus/storage.go:219 cmd/incus/storage.go:277 cmd/incus/storage.go:409
-#: cmd/incus/storage.go:491 cmd/incus/storage.go:672 cmd/incus/storage.go:837
-#: cmd/incus/storage.go:941 cmd/incus/storage.go:1035
-#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:98
-#: cmd/incus/storage_bucket.go:209 cmd/incus/storage_bucket.go:270
-#: cmd/incus/storage_bucket.go:403 cmd/incus/storage_bucket.go:487
-#: cmd/incus/storage_bucket.go:651 cmd/incus/storage_bucket.go:745
-#: cmd/incus/storage_bucket.go:814 cmd/incus/storage_bucket.go:848
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:1044
-#: cmd/incus/storage_bucket.go:1155 cmd/incus/storage_bucket.go:1219
-#: cmd/incus/storage_bucket.go:1354 cmd/incus/storage_bucket.go:1426
-#: cmd/incus/storage_bucket.go:1577 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:580
-#: cmd/incus/storage_volume.go:696 cmd/incus/storage_volume.go:769
-#: cmd/incus/storage_volume.go:867 cmd/incus/storage_volume.go:964
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1324
-#: cmd/incus/storage_volume.go:1485 cmd/incus/storage_volume.go:1569
-#: cmd/incus/storage_volume.go:1788 cmd/incus/storage_volume.go:1881
-#: cmd/incus/storage_volume.go:1961 cmd/incus/storage_volume.go:2124
-#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2287
-#: cmd/incus/storage_volume.go:2337 cmd/incus/storage_volume.go:2472
-#: cmd/incus/storage_volume.go:2561 cmd/incus/storage_volume.go:2567
-#: cmd/incus/storage_volume.go:2728 cmd/incus/storage_volume.go:2815
-#: cmd/incus/storage_volume.go:2895 cmd/incus/storage_volume.go:2982
-#: cmd/incus/storage_volume.go:3148 cmd/incus/top.go:43 cmd/incus/version.go:22
-#: cmd/incus/warning.go:30 cmd/incus/warning.go:73 cmd/incus/warning.go:268
-#: cmd/incus/warning.go:309 cmd/incus/warning.go:363 cmd/incus/webui.go:19
+#: cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33
+#: cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301
+#: cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525
+#: cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105
+#: cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418
+#: cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852
+#: cmd/incus/storage.go:958 cmd/incus/storage.go:1054
+#: cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101
+#: cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277
+#: cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498
+#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760
+#: cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867
+#: cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066
+#: cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245
+#: cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455
+#: cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58
+#: cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259
+#: cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589
+#: cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782
+#: cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345
+#: cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592
+#: cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190
+#: cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357
+#: cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545
+#: cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642
+#: cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065
+#: cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23
+#: cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273
+#: cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/info.go:635 cmd/incus/storage_volume.go:1426
+#: cmd/incus/info.go:637 cmd/incus/storage_volume.go:1448
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1793
+#: cmd/incus/storage_volume.go:374 cmd/incus/storage_volume.go:1853
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:768 cmd/incus/storage_volume.go:769
+#: cmd/incus/storage_volume.go:781 cmd/incus/storage_volume.go:782
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:866 cmd/incus/storage_volume.go:867
+#: cmd/incus/storage_volume.go:881 cmd/incus/storage_volume.go:882
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/network.go:516 cmd/incus/network.go:517
+#: cmd/incus/network.go:527 cmd/incus/network.go:528
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: cmd/incus/network.go:613 cmd/incus/network.go:614
+#: cmd/incus/network.go:626 cmd/incus/network.go:627
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:587 cmd/incus/info.go:599
+#: cmd/incus/info.go:589 cmd/incus/info.go:601
 #, c-format
 msgid "Device %d:"
 msgstr ""
 
-#: cmd/incus/config_device.go:197
+#: cmd/incus/config_device.go:201
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:478
+#: cmd/incus/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:599
+#: cmd/incus/config_device.go:611
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:366
+#: cmd/incus/info.go:368
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:58 cmd/incus/utils.go:82
+#: cmd/incus/utils.go:59 cmd/incus/utils.go:83
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
-#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
-#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:285 cmd/incus/config_device.go:299
+#: cmd/incus/config_device.go:569 cmd/incus/config_device.go:590
+#: cmd/incus/config_device.go:706 cmd/incus/config_device.go:729
 msgid "Device doesn't exist"
 msgstr ""
 
-#: cmd/incus/config_device.go:718
+#: cmd/incus/config_device.go:732
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:581
+#: cmd/incus/config_device.go:593
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: cmd/incus/config_device.go:296
+#: cmd/incus/config_device.go:302
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: cmd/incus/info.go:294 cmd/incus/info.go:318
+#: cmd/incus/info.go:296 cmd/incus/info.go:320
 #, c-format
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:445
+#: cmd/incus/create.go:448
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
-#: cmd/incus/image.go:695
+#: cmd/incus/image.go:708
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: cmd/incus/exec.go:66
+#: cmd/incus/exec.go:67
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1368
+#: cmd/incus/file.go:1380
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/exec.go:62
+#: cmd/incus/exec.go:63
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/exec.go:63
+#: cmd/incus/exec.go:64
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:575
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:702
+#: cmd/incus/info.go:704
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:570
+#: cmd/incus/info.go:572
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:575
 msgid "Disks:"
 msgstr ""
 
-#: cmd/incus/cluster.go:152
+#: cmd/incus/cluster.go:155
 msgid "Display clusters from all projects"
 msgstr ""
 
-#: cmd/incus/image.go:1095
+#: cmd/incus/image.go:1116
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:63
+#: cmd/incus/list.go:139 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
-#: cmd/incus/network_zone.go:114
+#: cmd/incus/network_zone.go:117
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:752
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2167,7 +2167,7 @@ msgstr ""
 msgid "Display resource usage info per instance"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:509
+#: cmd/incus/storage_bucket.go:520
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
@@ -2193,110 +2193,110 @@ msgid ""
 "  u - CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:419
+#: cmd/incus/admin_init_interactive.go:421
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:431
+#: cmd/incus/admin_init_interactive.go:433
 msgid "Do you want to configure a new remote storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:446
+#: cmd/incus/admin_init_interactive.go:448
 msgid "Do you want to configure a new storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:748
+#: cmd/incus/admin_init_interactive.go:754
 msgid "Do you want to continue without thin provisioning?"
 msgstr ""
 
-#: cmd/incus/cluster.go:698
+#: cmd/incus/cluster.go:715
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Don't show progress information"
 msgstr ""
 
-#: cmd/incus/network.go:1016
+#: cmd/incus/network.go:1036
 msgid "Down delay"
 msgstr ""
 
-#: cmd/incus/info.go:380
+#: cmd/incus/info.go:382
 #, c-format
 msgid "Driver: %v"
 msgstr ""
 
-#: cmd/incus/info.go:133 cmd/incus/info.go:219
+#: cmd/incus/info.go:135 cmd/incus/info.go:221
 #, c-format
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: cmd/incus/admin_init.go:57
+#: cmd/incus/admin_init.go:59
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/copy.go:65
+#: cmd/incus/copy.go:67
 msgid ""
 "During incremental copy, exclude source snapshots earlier than latest target "
 "snapshot"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:371
+#: cmd/incus/storage_volume.go:378
 msgid ""
 "During refresh, exclude source snapshots earlier than latest target snapshot"
 msgstr ""
 
-#: cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:954
 msgid "ENTRIES"
 msgstr ""
 
-#: cmd/incus/list.go:898
+#: cmd/incus/list.go:820
 msgid "EPHEMERAL"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:153
+#: cmd/incus/admin_recover.go:156
 #, c-format
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1117 cmd/incus/config_trust.go:634
-#: cmd/incus/snapshot.go:341 cmd/incus/storage_volume.go:2671
+#: cmd/incus/cluster.go:1142 cmd/incus/config_trust.go:645
+#: cmd/incus/snapshot.go:348 cmd/incus/storage_volume.go:2747
 msgid "EXPIRES AT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:444
+#: cmd/incus/config_trust.go:453
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:340
+#: cmd/incus/cluster_group.go:340 cmd/incus/cluster_group.go:341
 msgid "Edit a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:876 cmd/incus/cluster.go:877
+#: cmd/incus/cluster.go:897 cmd/incus/cluster.go:898
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:383 cmd/incus/file.go:384
+#: cmd/incus/file.go:389 cmd/incus/file.go:390
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:362 cmd/incus/image.go:363
+#: cmd/incus/image.go:371 cmd/incus/image.go:372
 msgid "Edit image properties"
 msgstr ""
 
-#: cmd/incus/config_template.go:187 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:194 cmd/incus/config_template.go:195
 msgid "Edit instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:53 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:56 cmd/incus/config_metadata.go:57
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:94 cmd/incus/config.go:95
+#: cmd/incus/config.go:95 cmd/incus/config.go:96
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:619 cmd/incus/network_acl.go:620
+#: cmd/incus/network_acl.go:636 cmd/incus/network_acl.go:637
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2304,60 +2304,60 @@ msgstr ""
 msgid "Edit network address set configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network.go:710 cmd/incus/network.go:711
+#: cmd/incus/network.go:725 cmd/incus/network.go:726
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:679 cmd/incus/network_forward.go:680
+#: cmd/incus/network_forward.go:694 cmd/incus/network_forward.go:695
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_integration.go:229 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:231
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:648
-#: cmd/incus/network_load_balancer.go:649
+#: cmd/incus/network_load_balancer.go:663
+#: cmd/incus/network_load_balancer.go:664
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:709 cmd/incus/network_peer.go:710
+#: cmd/incus/network_peer.go:726 cmd/incus/network_peer.go:727
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:627 cmd/incus/network_zone.go:628
+#: cmd/incus/network_zone.go:641 cmd/incus/network_zone.go:642
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1331 cmd/incus/network_zone.go:1332
+#: cmd/incus/network_zone.go:1362 cmd/incus/network_zone.go:1363
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:505 cmd/incus/profile.go:506
+#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:306 cmd/incus/project.go:307
+#: cmd/incus/project.go:313 cmd/incus/project.go:314
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:269 cmd/incus/storage_bucket.go:270
+#: cmd/incus/storage_bucket.go:276 cmd/incus/storage_bucket.go:277
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1218 cmd/incus/storage_bucket.go:1219
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1245
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
-#: cmd/incus/storage.go:276 cmd/incus/storage.go:277
+#: cmd/incus/storage.go:283 cmd/incus/storage.go:284
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:963
+#: cmd/incus/storage_volume.go:980
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:964
+#: cmd/incus/storage_volume.go:981
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2366,32 +2366,32 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/config_trust.go:277 cmd/incus/config_trust.go:278
+#: cmd/incus/config_trust.go:284 cmd/incus/config_trust.go:285
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:191 cmd/incus/cluster.go:1125
-#: cmd/incus/cluster_group.go:519 cmd/incus/config_trust.go:454
-#: cmd/incus/config_trust.go:642 cmd/incus/image.go:1140
-#: cmd/incus/image_alias.go:260 cmd/incus/list.go:640 cmd/incus/network.go:1151
-#: cmd/incus/network.go:1349 cmd/incus/network_allocations.go:88
-#: cmd/incus/network_forward.go:151 cmd/incus/network_integration.go:464
-#: cmd/incus/network_load_balancer.go:158 cmd/incus/network_peer.go:144
-#: cmd/incus/network_zone.go:151 cmd/incus/operation.go:171
-#: cmd/incus/profile.go:777 cmd/incus/project.go:579 cmd/incus/remote.go:777
-#: cmd/incus/snapshot.go:350 cmd/incus/storage.go:733
-#: cmd/incus/storage_bucket.go:544 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_volume.go:1714 cmd/incus/storage_volume.go:2679
-#: cmd/incus/top.go:92 cmd/incus/warning.go:241
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150
+#: cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463
+#: cmd/incus/config_trust.go:653 cmd/incus/image.go:1161
+#: cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172
+#: cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
+#: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
+#: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
+#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
+#: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
+#: cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: cmd/incus/cluster.go:783
+#: cmd/incus/cluster.go:802
 msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
-#: cmd/incus/cluster.go:784
+#: cmd/incus/cluster.go:803
 msgid ""
 "Enable clustering on a single non-clustered server\n"
 "\n"
@@ -2415,47 +2415,47 @@ msgstr ""
 msgid "Enter new delay in seconds:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1540
+#: cmd/incus/network_zone.go:1576
 msgid "Entry TTL"
 msgstr ""
 
-#: cmd/incus/exec.go:59
+#: cmd/incus/exec.go:60
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:56 cmd/incus/create.go:58
+#: cmd/incus/copy.go:58 cmd/incus/create.go:60
 msgid "Ephemeral instance"
 msgstr ""
 
-#: cmd/incus/admin_init.go:179 cmd/incus/admin_init_interactive.go:204
+#: cmd/incus/admin_init.go:182 cmd/incus/admin_init_interactive.go:206
 #, c-format
 msgid "Error connecting to existing cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:206
+#: cmd/incus/utils_properties.go:223
 #, c-format
 msgid "Error creating decoder: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:211
+#: cmd/incus/utils_properties.go:228
 #, c-format
 msgid "Error decoding data: %v"
 msgstr ""
 
-#: cmd/incus/publish.go:245 cmd/incus/utils.go:217
+#: cmd/incus/publish.go:248 cmd/incus/utils.go:218
 #, c-format
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:566 cmd/incus/cluster_group.go:1031
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1581
-#: cmd/incus/network_acl.go:552 cmd/incus/network_address_set.go:404
-#: cmd/incus/network_forward.go:606 cmd/incus/network_integration.go:672
-#: cmd/incus/network_load_balancer.go:592 cmd/incus/network_peer.go:638
-#: cmd/incus/network_zone.go:560 cmd/incus/network_zone.go:1260
-#: cmd/incus/profile.go:1097 cmd/incus/project.go:865 cmd/incus/storage.go:907
-#: cmd/incus/storage_bucket.go:718 cmd/incus/storage_volume.go:2052
-#: cmd/incus/storage_volume.go:2095
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034
+#: cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609
+#: cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404
+#: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
+#: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
+#: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
+#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2160
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2465,56 +2465,56 @@ msgstr ""
 msgid "Error setting term size %s"
 msgstr ""
 
-#: cmd/incus/config.go:635 cmd/incus/config.go:667
+#: cmd/incus/config.go:636 cmd/incus/config.go:668
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:560 cmd/incus/cluster_group.go:1025
-#: cmd/incus/network.go:1575 cmd/incus/network_acl.go:546
-#: cmd/incus/network_forward.go:600 cmd/incus/network_integration.go:666
-#: cmd/incus/network_load_balancer.go:586 cmd/incus/network_peer.go:632
-#: cmd/incus/network_zone.go:554 cmd/incus/network_zone.go:1254
-#: cmd/incus/profile.go:1091 cmd/incus/project.go:859 cmd/incus/storage.go:901
-#: cmd/incus/storage_bucket.go:712 cmd/incus/storage_volume.go:2046
-#: cmd/incus/storage_volume.go:2089
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028
+#: cmd/incus/network.go:1603 cmd/incus/network_acl.go:560
+#: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
+#: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
+#: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
+#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
+#: cmd/incus/storage_volume.go:2154
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
 
-#: cmd/incus/config_template.go:253
+#: cmd/incus/config_template.go:261
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: cmd/incus/main.go:352
+#: cmd/incus/main.go:353
 #, c-format
 msgid "Error while executing alias expansion: %s\n"
 msgstr ""
 
-#: cmd/incus/main.go:355
+#: cmd/incus/main.go:356
 #, c-format
 msgid "Error: %v\n"
 msgstr ""
 
-#: cmd/incus/cluster.go:1452 cmd/incus/cluster.go:1453
+#: cmd/incus/cluster.go:1483 cmd/incus/cluster.go:1484
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: cmd/incus/cluster.go:1548
+#: cmd/incus/cluster.go:1582
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:51
+#: cmd/incus/monitor.go:53
 msgid "Event type to listen for"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_sql.go:31
 msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:30
+#: cmd/incus/admin_sql.go:32
 msgid ""
 "Execute a SQL query against the local or global database\n"
 "\n"
@@ -2543,11 +2543,11 @@ msgid ""
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
-#: cmd/incus/exec.go:40
+#: cmd/incus/exec.go:41
 msgid "Execute commands in instances"
 msgstr ""
 
-#: cmd/incus/exec.go:41
+#: cmd/incus/exec.go:42
 msgid ""
 "Execute commands in instances\n"
 "\n"
@@ -2562,22 +2562,22 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: cmd/incus/utils_properties.go:95
+#: cmd/incus/utils_properties.go:112
 #, c-format
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1486
-#: cmd/incus/storage_volume.go:1536
+#: cmd/incus/info.go:833 cmd/incus/info.go:884 cmd/incus/storage_volume.go:1508
+#: cmd/incus/storage_volume.go:1558
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:1005
+#: cmd/incus/image.go:1025
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1007
+#: cmd/incus/image.go:1027
 msgid "Expires: never"
 msgstr ""
 
@@ -2585,34 +2585,34 @@ msgstr ""
 msgid "Export a virtual machine's memory state"
 msgstr ""
 
-#: cmd/incus/image.go:497
+#: cmd/incus/image.go:508
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:498
+#: cmd/incus/image.go:509
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2981 cmd/incus/storage_volume.go:2982
+#: cmd/incus/storage_volume.go:3064 cmd/incus/storage_volume.go:3065
 msgid "Export custom storage volume"
 msgstr ""
 
-#: cmd/incus/export.go:31
+#: cmd/incus/export.go:32
 msgid "Export instance backups"
 msgstr ""
 
-#: cmd/incus/export.go:32
+#: cmd/incus/export.go:33
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1425
+#: cmd/incus/storage_bucket.go:1454
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1426
+#: cmd/incus/storage_bucket.go:1455
 msgid "Export storage buckets as tarball."
 msgstr ""
 
@@ -2623,241 +2623,241 @@ msgid ""
 "\t\tThis can be useful for debugging or analysis purposes."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2985
+#: cmd/incus/storage_volume.go:3068
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1544
+#: cmd/incus/storage_bucket.go:1573
 #, c-format
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3114
+#: cmd/incus/export.go:153 cmd/incus/storage_volume.go:3198
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:573
+#: cmd/incus/image.go:585
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:179
+#: cmd/incus/cluster.go:182
 msgid "FAILURE DOMAIN"
 msgstr ""
 
-#: cmd/incus/config_template.go:343
+#: cmd/incus/config_template.go:353
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:441 cmd/incus/image.go:1124
-#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:249
+#: cmd/incus/config_trust.go:450 cmd/incus/image.go:1145
+#: cmd/incus/image.go:1146 cmd/incus/image_alias.go:256
 msgid "FINGERPRINT"
 msgstr ""
 
-#: cmd/incus/warning.go:216
+#: cmd/incus/warning.go:220
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/info.go:683
+#: cmd/incus/info.go:685
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1625
+#: cmd/incus/file.go:1638
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1648
+#: cmd/incus/file.go:1661
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:356
+#: cmd/incus/utils.go:357
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:349
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1675
+#: cmd/incus/file.go:1688
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1460
+#: cmd/incus/file.go:1473
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:61
+#: cmd/incus/admin_waitready.go:63
 #, c-format
 msgid "Failed connecting to the daemon (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/config_trust.go:143
+#: cmd/incus/config_trust.go:146
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1046
+#: cmd/incus/cluster.go:1070
 #, c-format
 msgid "Failed converting token operation to join token: %w"
 msgstr ""
 
-#: cmd/incus/delete.go:154
+#: cmd/incus/delete.go:157
 #, c-format
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:559
+#: cmd/incus/storage_volume.go:567
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1581
+#: cmd/incus/file.go:1594
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:472
+#: cmd/incus/admin_init_interactive.go:474
 #, c-format
 msgid "Failed generating trust certificate: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:60
+#: cmd/incus/admin_recover.go:63
 #, c-format
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:449
+#: cmd/incus/network_peer.go:458
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:250
+#: cmd/incus/admin_recover.go:253
 #, c-format
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:195
+#: cmd/incus/create.go:198
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:336
+#: cmd/incus/create.go:339
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:257
+#: cmd/incus/create.go:260
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1586
+#: cmd/incus/file.go:1599
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:196
+#: cmd/incus/admin_recover.go:199
 #, c-format
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:371
+#: cmd/incus/console.go:378
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1486
+#: cmd/incus/file.go:1499
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1613
+#: cmd/incus/file.go:1626
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:209
+#: cmd/incus/remote.go:210
 msgid "Failed to add remote"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:482
+#: cmd/incus/admin_init_interactive.go:484
 #, c-format
 msgid "Failed to add server cert to cluster: %w"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:76
+#: cmd/incus/admin_waitready.go:78
 #, c-format
 msgid "Failed to check if the daemon is ready (attempt %d): %v"
 msgstr ""
 
-#: cmd/incus/export.go:188
+#: cmd/incus/export.go:190
 #, c-format
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:260
+#: cmd/incus/remote.go:261
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:855 cmd/incus/cluster.go:860
+#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:880
 #, c-format
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:261
+#: cmd/incus/move.go:264
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:105
+#: cmd/incus/admin_init.go:108
 #, c-format
 msgid "Failed to connect to get server info: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:100
+#: cmd/incus/admin_init.go:103
 #, c-format
 msgid "Failed to connect to local daemon: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:467
+#: cmd/incus/admin_init_interactive.go:469
 #, c-format
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:250
+#: cmd/incus/remote.go:251
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:190
+#: cmd/incus/utils.go:191
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1479
+#: cmd/incus/storage_bucket.go:1508
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:275
+#: cmd/incus/remote.go:276
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3049
+#: cmd/incus/storage_volume.go:3133
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:226
+#: cmd/incus/move.go:229
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2867,104 +2867,104 @@ msgstr ""
 msgid "Failed to dump instance memory: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1558
+#: cmd/incus/storage_bucket.go:1587
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3212
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:282
+#: cmd/incus/remote.go:283
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:215 cmd/incus/admin_init.go:220
+#: cmd/incus/admin_init.go:218 cmd/incus/admin_init.go:223
 #, c-format
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1598
+#: cmd/incus/file.go:1611
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:402 cmd/incus/main_aliases.go:222
+#: cmd/incus/main.go:404 cmd/incus/main_aliases.go:221
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:118
+#: cmd/incus/admin_sql.go:121
 #, c-format
 msgid "Failed to parse dump response: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1513
+#: cmd/incus/cluster.go:1547
 #, c-format
 msgid "Failed to parse servers: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:30
+#: cmd/incus/admin_init_preseed.go:29
 #, c-format
 msgid "Failed to parse the preseed: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_preseed.go:22 cmd/incus/admin_sql.go:88
+#: cmd/incus/admin_init_preseed.go:21 cmd/incus/admin_sql.go:91
 #, c-format
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:387
+#: cmd/incus/copy.go:391
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: cmd/incus/utils.go:179
+#: cmd/incus/utils.go:180
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: cmd/incus/export.go:182
+#: cmd/incus/export.go:184
 #, c-format
 msgid "Failed to rename export file: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:100
+#: cmd/incus/admin_init_interactive.go:102
 #, c-format
 msgid "Failed to render the config: %w"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:112
+#: cmd/incus/admin_sql.go:115
 #, c-format
 msgid "Failed to request dump: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:266
+#: cmd/incus/admin_init_interactive.go:268
 #, c-format
 msgid "Failed to retrieve cluster information: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:842
+#: cmd/incus/cluster.go:862
 #, c-format
 msgid "Failed to retrieve current cluster config: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:832
+#: cmd/incus/cluster.go:852
 #, c-format
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
-#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
-#: cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:19 cmd/incus/admin_init_dump.go:50
+#: cmd/incus/admin_init_dump.go:65 cmd/incus/admin_init_dump.go:80
+#: cmd/incus/admin_init_dump.go:94
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:28
+#: cmd/incus/admin_init_dump.go:29
 #, c-format
 msgid ""
 "Failed to retrieve current server network configuration for project %q: %w"
@@ -2980,96 +2980,96 @@ msgstr ""
 msgid "Failed to retrieve list of storage pools: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:243
+#: cmd/incus/admin_init_interactive.go:245
 #, c-format
 msgid "Failed to setup trust relationship with cluster: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:1540
+#: cmd/incus/cluster.go:1574
 #, c-format
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1205
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:255
+#: cmd/incus/remote.go:256
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:189
+#: cmd/incus/admin_recover.go:192
 #, c-format
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:418
+#: cmd/incus/info.go:420
 #, c-format
 msgid "Family: %v"
 msgstr ""
 
-#: cmd/incus/list.go:136
+#: cmd/incus/list.go:138
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: cmd/incus/export.go:165
+#: cmd/incus/export.go:167
 #, c-format
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1229 cmd/incus/network_acl.go:137
-#: cmd/incus/network_zone.go:205 cmd/incus/operation.go:241
+#: cmd/incus/network.go:1251 cmd/incus/network_acl.go:141
+#: cmd/incus/network_zone.go:209 cmd/incus/operation.go:247
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1011
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1455
+#: cmd/incus/cluster.go:1486
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:114
+#: cmd/incus/file.go:115
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:212
+#: cmd/incus/project.go:217
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:305
+#: cmd/incus/file.go:309
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
-#: cmd/incus/cluster.go:1498
+#: cmd/incus/cluster.go:1531
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
-#: cmd/incus/exec.go:61
+#: cmd/incus/exec.go:62
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: cmd/incus/cluster.go:697
+#: cmd/incus/cluster.go:714
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: cmd/incus/action.go:175
+#: cmd/incus/action.go:171
 msgid "Force the instance to stop"
 msgstr ""
 
-#: cmd/incus/delete.go:36
+#: cmd/incus/delete.go:38
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:117
+#: cmd/incus/main.go:118
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: cmd/incus/cluster.go:713
+#: cmd/incus/cluster.go:730
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -3093,7 +3093,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Forces a connection to the console, even if there is already an active "
 "session"
@@ -3103,36 +3103,36 @@ msgstr ""
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1095
+#: cmd/incus/cluster.go:1120
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:114 cmd/incus/cluster.go:151
-#: cmd/incus/cluster_group.go:486 cmd/incus/config_template.go:290
-#: cmd/incus/config_trust.go:425 cmd/incus/config_trust.go:616
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:210 cmd/incus/list.go:135
-#: cmd/incus/network.go:1106 cmd/incus/network.go:1310
-#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:60
-#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
-#: cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110
-#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:871
-#: cmd/incus/operation.go:137 cmd/incus/profile.go:734 cmd/incus/project.go:539
-#: cmd/incus/project.go:1066 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
-#: cmd/incus/storage.go:696 cmd/incus/storage_bucket.go:508
-#: cmd/incus/storage_bucket.go:914 cmd/incus/storage_volume.go:1585
-#: cmd/incus/storage_volume.go:2578 cmd/incus/warning.go:95
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154
+#: cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299
+#: cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627
+#: cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137
+#: cmd/incus/network.go:1127 cmd/incus/network.go:1333
+#: cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61
+#: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
+#: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
+#: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
+#: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
+#: cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid ""
 "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable "
 "headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr ""
 
-#: cmd/incus/monitor.go:53
+#: cmd/incus/monitor.go:55
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
-#: cmd/incus/manpage.go:27
+#: cmd/incus/manpage.go:28
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgid ""
 "Format of memory dump (e.g. elf, win-dmp, kdump-zlib, kdump-raw-zlib, ...)"
 msgstr ""
 
-#: cmd/incus/network.go:1028
+#: cmd/incus/network.go:1048
 msgid "Forward delay"
 msgstr ""
 
@@ -3154,200 +3154,200 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
+#: cmd/incus/info.go:542
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:355
+#: cmd/incus/info.go:346 cmd/incus/info.go:357
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: cmd/incus/info.go:353
+#: cmd/incus/info.go:355
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:769
+#: cmd/incus/remote.go:770
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:546
+#: cmd/incus/info.go:548
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:549
+#: cmd/incus/info.go:551
 msgid "GPUs:"
 msgstr ""
 
-#: cmd/incus/manpage.go:23 cmd/incus/manpage.go:24
+#: cmd/incus/manpage.go:24 cmd/incus/manpage.go:25
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:637
+#: cmd/incus/remote.go:638
 msgid "Generate the client certificate"
 msgstr ""
 
-#: cmd/incus/remote.go:177 cmd/incus/remote.go:412 cmd/incus/remote.go:663
+#: cmd/incus/remote.go:178 cmd/incus/remote.go:413 cmd/incus/remote.go:664
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1062 cmd/incus/project.go:1063
+#: cmd/incus/project.go:1085 cmd/incus/project.go:1086
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1292
+#: cmd/incus/network_load_balancer.go:1320
 msgid "Get current load balancer status"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1293
+#: cmd/incus/network_load_balancer.go:1321
 msgid "Get current load-balacner status"
 msgstr ""
 
-#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
+#: cmd/incus/image.go:1598 cmd/incus/image.go:1599
 msgid "Get image properties"
 msgstr ""
 
-#: cmd/incus/network.go:927 cmd/incus/network.go:928
+#: cmd/incus/network.go:946 cmd/incus/network.go:947
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:902
+#: cmd/incus/cluster_group.go:905
 msgid "Get the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:440
+#: cmd/incus/cluster.go:449
 msgid "Get the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:313
+#: cmd/incus/network_acl.go:322
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:449
 msgid "Get the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:356
+#: cmd/incus/network_integration.go:357
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:444
+#: cmd/incus/network_load_balancer.go:453
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:479
+#: cmd/incus/network_peer.go:490
 msgid "Get the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:851
+#: cmd/incus/network.go:868
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:324
+#: cmd/incus/network_zone.go:330
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1017
+#: cmd/incus/network_zone.go:1040
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:647
+#: cmd/incus/profile.go:662
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:447
+#: cmd/incus/project.go:456
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:406
+#: cmd/incus/storage_bucket.go:415
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:413
+#: cmd/incus/storage.go:422
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1203
+#: cmd/incus/storage_volume.go:1222
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:392
+#: cmd/incus/config.go:393
 msgid "Get the key as an instance property"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:899
+#: cmd/incus/cluster_group.go:902
 msgid "Get values for cluster group configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:437
+#: cmd/incus/cluster.go:446
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:224 cmd/incus/config_device.go:225
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:387 cmd/incus/config.go:388
+#: cmd/incus/config.go:388 cmd/incus/config.go:389
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:310 cmd/incus/network_acl.go:311
+#: cmd/incus/network_acl.go:319 cmd/incus/network_acl.go:320
 msgid "Get values for network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:846 cmd/incus/network.go:847
+#: cmd/incus/network.go:863 cmd/incus/network.go:864
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:437 cmd/incus/network_forward.go:438
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:447
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:353
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:440
-#: cmd/incus/network_load_balancer.go:441
+#: cmd/incus/network_load_balancer.go:449
+#: cmd/incus/network_load_balancer.go:450
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:475 cmd/incus/network_peer.go:476
+#: cmd/incus/network_peer.go:486 cmd/incus/network_peer.go:487
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:320 cmd/incus/network_zone.go:321
+#: cmd/incus/network_zone.go:326 cmd/incus/network_zone.go:327
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1014
+#: cmd/incus/network_zone.go:1036 cmd/incus/network_zone.go:1037
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:641 cmd/incus/profile.go:642
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:442 cmd/incus/project.go:443
+#: cmd/incus/project.go:451 cmd/incus/project.go:452
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:402 cmd/incus/storage_bucket.go:403
+#: cmd/incus/storage_bucket.go:411 cmd/incus/storage_bucket.go:412
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:408 cmd/incus/storage.go:409
+#: cmd/incus/storage.go:417 cmd/incus/storage.go:418
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1187
+#: cmd/incus/storage_volume.go:1206
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1188
+#: cmd/incus/storage_volume.go:1207
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3359,66 +3359,66 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:442
+#: cmd/incus/storage_volume.go:450
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: cmd/incus/exec.go:65
+#: cmd/incus/exec.go:66
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/network.go:1334
+#: cmd/incus/network.go:1357
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:757
+#: cmd/incus/info.go:759
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:682
+#: cmd/incus/info.go:684
 msgid "Hostname"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528
+#: cmd/incus/info.go:519 cmd/incus/info.go:530
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1698
+#: cmd/incus/file.go:1711
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1687
+#: cmd/incus/file.go:1700
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1510
+#: cmd/incus/file.go:1523
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1520
+#: cmd/incus/file.go:1533
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1026 cmd/incus/operation.go:154
+#: cmd/incus/network.go:1046 cmd/incus/operation.go:159
 msgid "ID"
 msgstr ""
 
-#: cmd/incus/info.go:138
+#: cmd/incus/info.go:140
 #, c-format
 msgid "ID: %d"
 msgstr ""
 
-#: cmd/incus/info.go:226 cmd/incus/info.go:293 cmd/incus/info.go:317
+#: cmd/incus/info.go:228 cmd/incus/info.go:295 cmd/incus/info.go:319
 #, c-format
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:563
+#: cmd/incus/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3426,304 +3426,304 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:381
 #, c-format
 msgid "IOMMU group: %v"
 msgstr ""
 
-#: cmd/incus/network.go:1336
+#: cmd/incus/network.go:1359
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:773
+#: cmd/incus/info.go:775
 msgid "IP addresses"
 msgstr ""
 
-#: cmd/incus/network.go:993
+#: cmd/incus/network.go:1013
 msgid "IP addresses:"
 msgstr ""
 
-#: cmd/incus/list.go:576 cmd/incus/network.go:1134
+#: cmd/incus/list.go:498 cmd/incus/network.go:1155
 msgid "IPV4"
 msgstr ""
 
-#: cmd/incus/list.go:577 cmd/incus/network.go:1135
+#: cmd/incus/list.go:499 cmd/incus/network.go:1156
 msgid "IPV6"
 msgstr ""
 
-#: cmd/incus/network.go:1060
+#: cmd/incus/network.go:1080
 msgid "IPv4 uplink address"
 msgstr ""
 
-#: cmd/incus/network.go:1064
+#: cmd/incus/network.go:1084
 msgid "IPv6 uplink address"
 msgstr ""
 
-#: cmd/incus/config_trust.go:443
+#: cmd/incus/config_trust.go:452
 msgid "ISSUE DATE"
 msgstr ""
 
-#: cmd/incus/rebuild.go:32
+#: cmd/incus/rebuild.go:34
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
-#: cmd/incus/image.go:673 cmd/incus/publish.go:41
+#: cmd/incus/image.go:686 cmd/incus/publish.go:43
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2346
+#: cmd/incus/snapshot.go:94 cmd/incus/storage_volume.go:2417
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:463
+#: cmd/incus/main.go:465
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
 msgstr ""
 
-#: cmd/incus/snapshot.go:90
+#: cmd/incus/snapshot.go:93
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2345
+#: cmd/incus/storage_volume.go:2416
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:66 cmd/incus/move.go:66
+#: cmd/incus/copy.go:68 cmd/incus/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: cmd/incus/action.go:166
+#: cmd/incus/action.go:162
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image_alias.go:71
+#: cmd/incus/image_alias.go:74
 msgid "Image alias description"
 msgstr ""
 
-#: cmd/incus/image.go:1489
+#: cmd/incus/image.go:1510
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:292
+#: cmd/incus/image.go:298
 msgid "Image copied successfully!"
 msgstr ""
 
-#: cmd/incus/publish.go:40
+#: cmd/incus/publish.go:42
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:649
+#: cmd/incus/image.go:661
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:335 cmd/incus/image.go:1451
+#: cmd/incus/image.go:343 cmd/incus/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:411 cmd/incus/image.go:1672
+#: cmd/incus/image.go:421 cmd/incus/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:883
+#: cmd/incus/image.go:901
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1487
+#: cmd/incus/image.go:1508
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: cmd/incus/action.go:170 cmd/incus/launch.go:44
+#: cmd/incus/action.go:166 cmd/incus/launch.go:45
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/import.go:27
+#: cmd/incus/import.go:28
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1577
+#: cmd/incus/storage_bucket.go:1606
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3147
+#: cmd/incus/storage_volume.go:3232
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3148
+#: cmd/incus/storage_volume.go:3233
 msgid "Import custom storage volumes."
 msgstr ""
 
-#: cmd/incus/image.go:667
+#: cmd/incus/image.go:680
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:666
+#: cmd/incus/image.go:679
 msgid "Import images into the image store"
 msgstr ""
 
-#: cmd/incus/import.go:26
+#: cmd/incus/import.go:27
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1576
+#: cmd/incus/storage_bucket.go:1605
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3222
+#: cmd/incus/storage_volume.go:3308
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3157
+#: cmd/incus/storage_volume.go:3242
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3227
+#: cmd/incus/storage_volume.go:3313
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1632
+#: cmd/incus/storage_bucket.go:1661
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3231
+#: cmd/incus/storage_volume.go:3317
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: cmd/incus/import.go:93
+#: cmd/incus/import.go:95
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Include environment variables from file"
 msgstr ""
 
-#: cmd/incus/manpage.go:28
+#: cmd/incus/manpage.go:29
 msgid "Include less common commands"
 msgstr ""
 
-#: cmd/incus/manpage.go:65
+#: cmd/incus/manpage.go:67
 msgid "Incus - Command line client"
 msgstr ""
 
-#: cmd/incus/info.go:255
+#: cmd/incus/info.go:257
 msgid "Infiniband:"
 msgstr ""
 
-#: cmd/incus/query.go:45
+#: cmd/incus/query.go:46
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:883
+#: cmd/incus/info.go:885
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/create.go:67
+#: cmd/incus/create.go:69
 msgid "Instance description"
 msgstr ""
 
-#: cmd/incus/file.go:1512
+#: cmd/incus/file.go:1525
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1689
+#: cmd/incus/file.go:1702
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: cmd/incus/publish.go:91
+#: cmd/incus/publish.go:94
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:458
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1432
+#: cmd/incus/file.go:1445
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: cmd/incus/publish.go:328
+#: cmd/incus/publish.go:334
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/rebuild.go:75
+#: cmd/incus/rebuild.go:77
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:62
+#: cmd/incus/create.go:64
 msgid "Instance type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:135
+#: cmd/incus/admin_init_interactive.go:137
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1512
-#: cmd/incus/storage_volume.go:3082
+#: cmd/incus/export.go:115 cmd/incus/storage_bucket.go:1541
+#: cmd/incus/storage_volume.go:3166
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:364
+#: cmd/incus/remote.go:365
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:186
+#: cmd/incus/main_aliases.go:143 cmd/incus/main_aliases.go:185
 #, c-format
 msgid "Invalid argument %q"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:42
+#: cmd/incus/admin_recover.go:45
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1517
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/export.go:120 cmd/incus/storage_bucket.go:1546
+#: cmd/incus/storage_volume.go:3171
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:47
+#: cmd/incus/utils_properties.go:56
 #, c-format
 msgid "Invalid boolean value: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:550
+#: cmd/incus/config_trust.go:560
 msgid "Invalid certificate"
 msgstr ""
 
-#: cmd/incus/admin_init.go:164
+#: cmd/incus/admin_init.go:167
 #, c-format
 msgid "Invalid cluster join token: %w"
 msgstr ""
 
-#: cmd/incus/list.go:674
+#: cmd/incus/list.go:596
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:667
+#: cmd/incus/list.go:589
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:81
+#: cmd/incus/admin_sql.go:84
 msgid "Invalid database type"
 msgstr ""
 
-#: cmd/incus/publish.go:237
+#: cmd/incus/publish.go:240
 #, c-format
 msgid "Invalid expiration date: %w"
 msgstr ""
@@ -3733,7 +3733,7 @@ msgstr ""
 msgid "Invalid format %q"
 msgstr ""
 
-#: cmd/incus/monitor.go:71
+#: cmd/incus/monitor.go:74
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3747,58 +3747,58 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1440
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:181
+#: cmd/incus/admin_init_interactive.go:183
 #, c-format
 msgid "Invalid join token: %w"
 msgstr ""
 
-#: cmd/incus/utils.go:283
+#: cmd/incus/utils.go:284
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
 
-#: cmd/incus/list.go:695
+#: cmd/incus/list.go:617
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:691
+#: cmd/incus/list.go:613
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: cmd/incus/list.go:681
+#: cmd/incus/list.go:603
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:559 cmd/incus/storage.go:138
+#: cmd/incus/main.go:562 cmd/incus/storage.go:142
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:341
+#: cmd/incus/file.go:346
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:360
+#: cmd/incus/network_peer.go:368
 msgid "Invalid peer type"
 msgstr ""
 
-#: cmd/incus/remote.go:353
+#: cmd/incus/remote.go:354
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1035 cmd/incus/storage_volume.go:1252
-#: cmd/incus/storage_volume.go:1380 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2942
+#: cmd/incus/storage_volume.go:1053 cmd/incus/storage_volume.go:1272
+#: cmd/incus/storage_volume.go:1402 cmd/incus/storage_volume.go:2094
+#: cmd/incus/storage_volume.go:3024
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3810,103 +3810,103 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:546
+#: cmd/incus/file.go:555
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:156 cmd/incus/file.go:731
+#: cmd/incus/file.go:157 cmd/incus/file.go:742
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:143
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
 
-#: cmd/incus/info.go:258
+#: cmd/incus/info.go:260
 #, c-format
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:173
+#: cmd/incus/admin_init_interactive.go:175
 msgid "Joining an existing cluster requires root privileges"
 msgstr ""
 
-#: cmd/incus/image.go:156
+#: cmd/incus/image.go:161
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: cmd/incus/info.go:681
+#: cmd/incus/info.go:683
 msgid "Kernel Version"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1057
+#: cmd/incus/storage_bucket.go:1079
 msgid "Key description"
 msgstr ""
 
-#: cmd/incus/warning.go:217
+#: cmd/incus/warning.go:221
 msgid "LAST SEEN"
 msgstr ""
 
-#: cmd/incus/list.go:586
+#: cmd/incus/list.go:508
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1160
+#: cmd/incus/project.go:1184
 msgid "LIMIT"
 msgstr ""
 
-#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:144
+#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:147
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:623 cmd/incus/network.go:1338
-#: cmd/incus/network_forward.go:140 cmd/incus/network_load_balancer.go:147
-#: cmd/incus/operation.go:160 cmd/incus/storage_bucket.go:528
-#: cmd/incus/storage_volume.go:1693 cmd/incus/warning.go:226
+#: cmd/incus/list.go:545 cmd/incus/network.go:1361
+#: cmd/incus/network_forward.go:143 cmd/incus/network_load_balancer.go:150
+#: cmd/incus/operation.go:165 cmd/incus/storage_bucket.go:539
+#: cmd/incus/storage_volume.go:1728 cmd/incus/warning.go:230
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:670
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1011
+#: cmd/incus/image.go:1031
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1013
+#: cmd/incus/image.go:1033
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:175
+#: cmd/incus/create.go:178
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:173
+#: cmd/incus/create.go:176
 msgid "Launching the instance"
-msgstr ""
-
-#: cmd/incus/info.go:249
-#, c-format
-msgid "Link detected: %v"
 msgstr ""
 
 #: cmd/incus/info.go:251
 #, c-format
+msgid "Link detected: %v"
+msgstr ""
+
+#: cmd/incus/info.go:253
+#, c-format
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: cmd/incus/network.go:1288
+#: cmd/incus/network.go:1311
 msgid "List DHCP leases"
 msgstr ""
 
-#: cmd/incus/network.go:1289
+#: cmd/incus/network.go:1312
 msgid ""
 "List DHCP leases\n"
 "\n"
@@ -3938,11 +3938,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: cmd/incus/config_trust.go:596
+#: cmd/incus/config_trust.go:607
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: cmd/incus/config_trust.go:597
+#: cmd/incus/config_trust.go:608
 msgid ""
 "List all active certificate add tokens\n"
 "\n"
@@ -3964,11 +3964,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster.go:1075
+#: cmd/incus/cluster.go:1100
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: cmd/incus/cluster.go:1076
+#: cmd/incus/cluster.go:1101
 msgid ""
 "List all active cluster member join tokens\n"
 "\n"
@@ -3990,11 +3990,11 @@ msgid ""
 "  E - Expires At"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:464
+#: cmd/incus/cluster_group.go:465
 msgid "List all the cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:465
+#: cmd/incus/cluster_group.go:466
 msgid ""
 "List all the cluster groups\n"
 "\n"
@@ -4016,11 +4016,11 @@ msgid ""
 "  m - Member"
 msgstr ""
 
-#: cmd/incus/cluster.go:129
+#: cmd/incus/cluster.go:132
 msgid "List all the cluster members"
 msgstr ""
 
-#: cmd/incus/cluster.go:130
+#: cmd/incus/cluster.go:133
 msgid ""
 "List all the cluster members\n"
 "\n"
@@ -4042,15 +4042,15 @@ msgid ""
 "    m - Message"
 msgstr ""
 
-#: cmd/incus/warning.go:96
+#: cmd/incus/warning.go:99
 msgid "List all warnings"
 msgstr ""
 
-#: cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:97
 msgid "List available network ACL"
 msgstr ""
 
-#: cmd/incus/network_acl.go:93
+#: cmd/incus/network_acl.go:96
 msgid "List available network ACLS"
 msgstr ""
 
@@ -4058,11 +4058,11 @@ msgstr ""
 msgid "List available network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:90
+#: cmd/incus/network_forward.go:93
 msgid "List available network forwards"
 msgstr ""
 
-#: cmd/incus/network_forward.go:91
+#: cmd/incus/network_forward.go:94
 msgid ""
 "List available network forwards\n"
 "\n"
@@ -4086,11 +4086,11 @@ msgid ""
 "L - Location of the network zone (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:99
+#: cmd/incus/network_load_balancer.go:102
 msgid "List available network load balancers"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_load_balancer.go:103
 msgid ""
 "List available network load balancers\n"
 "\n"
@@ -4113,11 +4113,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/network_peer.go:86
+#: cmd/incus/network_peer.go:89
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:87
+#: cmd/incus/network_peer.go:90
 msgid ""
 "List available network peers\n"
 "\n"
@@ -4141,15 +4141,15 @@ msgid ""
 "  s - State"
 msgstr ""
 
-#: cmd/incus/network_zone.go:867 cmd/incus/network_zone.go:868
+#: cmd/incus/network_zone.go:886 cmd/incus/network_zone.go:887
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:90
+#: cmd/incus/network_zone.go:93
 msgid "List available network zoneS"
 msgstr ""
 
-#: cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:94
 msgid ""
 "List available network zone\n"
 "\n"
@@ -4172,11 +4172,11 @@ msgid ""
 "  u - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1085
+#: cmd/incus/network.go:1106
 msgid "List available networks"
 msgstr ""
 
-#: cmd/incus/network.go:1086
+#: cmd/incus/network.go:1107
 msgid ""
 "List available networks\n"
 "\n"
@@ -4197,11 +4197,11 @@ msgid ""
 "u - Used by (count)"
 msgstr ""
 
-#: cmd/incus/storage.go:671
+#: cmd/incus/storage.go:684
 msgid "List available storage pools"
 msgstr ""
 
-#: cmd/incus/storage.go:672
+#: cmd/incus/storage.go:685
 msgid ""
 "List available storage pools\n"
 "\n"
@@ -4226,11 +4226,11 @@ msgid ""
 "  s - state"
 msgstr ""
 
-#: cmd/incus/operation.go:113
+#: cmd/incus/operation.go:118
 msgid "List background operations"
 msgstr ""
 
-#: cmd/incus/operation.go:114
+#: cmd/incus/operation.go:119
 msgid ""
 "List background operations\n"
 "\n"
@@ -4256,11 +4256,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:188
+#: cmd/incus/image_alias.go:195
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:189
+#: cmd/incus/image_alias.go:196
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4284,11 +4284,11 @@ msgid ""
 "  d - Description"
 msgstr ""
 
-#: cmd/incus/image.go:1066
+#: cmd/incus/image.go:1087
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1067
+#: cmd/incus/image.go:1088
 msgid ""
 "List images\n"
 "\n"
@@ -4316,19 +4316,19 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/config_device.go:316 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:323 cmd/incus/config_device.go:324
 msgid "List instance devices"
 msgstr ""
 
-#: cmd/incus/config_template.go:287 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:296 cmd/incus/config_template.go:297
 msgid "List instance file templates"
 msgstr ""
 
-#: cmd/incus/snapshot.go:293
+#: cmd/incus/snapshot.go:300
 msgid "List instance snapshots"
 msgstr ""
 
-#: cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:301
 msgid ""
 "List instance snapshots\n"
 "\n"
@@ -4351,11 +4351,11 @@ msgid ""
 "  s - Stateful"
 msgstr ""
 
-#: cmd/incus/list.go:49
+#: cmd/incus/list.go:51
 msgid "List instances"
 msgstr ""
 
-#: cmd/incus/list.go:50
+#: cmd/incus/list.go:52
 #, c-format
 msgid ""
 "List instances\n"
@@ -4428,8 +4428,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4439,15 +4439,15 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: cmd/incus/network_acl.go:98
+#: cmd/incus/network_acl.go:101
 msgid "List network ACLs across all projects"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:34
+#: cmd/incus/network_allocations.go:35
 msgid "List network allocations in use"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:35
+#: cmd/incus/network_allocations.go:36
 msgid ""
 "List network allocations in use\n"
 "Default column layout: uatnm\n"
@@ -4470,11 +4470,11 @@ msgid ""
 "  m - Mac Address"
 msgstr ""
 
-#: cmd/incus/network_integration.go:415
+#: cmd/incus/network_integration.go:416
 msgid "List network integrations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:416
+#: cmd/incus/network_integration.go:417
 msgid ""
 "List network integrations\n"
 "\n"
@@ -4497,23 +4497,23 @@ msgid ""
 "\tu - Used by"
 msgstr ""
 
-#: cmd/incus/network.go:1107
+#: cmd/incus/network.go:1128
 msgid "List networks in all projects"
 msgstr ""
 
-#: cmd/incus/config_trust.go:98 cmd/incus/config_trust.go:181
+#: cmd/incus/config_trust.go:100 cmd/incus/config_trust.go:185
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: cmd/incus/operation.go:138
+#: cmd/incus/operation.go:143
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:717
+#: cmd/incus/profile.go:734
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:718
+#: cmd/incus/profile.go:735
 msgid ""
 "List profiles\n"
 "\n"
@@ -4529,11 +4529,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:517
+#: cmd/incus/project.go:528
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:518
+#: cmd/incus/project.go:529
 msgid ""
 "List projects\n"
 "\n"
@@ -4554,11 +4554,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:913
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895
+#: cmd/incus/storage_bucket.go:915
 msgid ""
 "List storage bucket keys\n"
 "\n"
@@ -4580,11 +4580,11 @@ msgid ""
 "  r - Role"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:485
+#: cmd/incus/storage_bucket.go:496
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:487
+#: cmd/incus/storage_bucket.go:498
 msgid ""
 "List storage buckets\n"
 "\n"
@@ -4607,11 +4607,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2560 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:2635 cmd/incus/storage_volume.go:2636
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2567
+#: cmd/incus/storage_volume.go:2642
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4625,14 +4625,26 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1564
+#: cmd/incus/storage_volume.go:1587
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1569
+#: cmd/incus/storage_volume.go:1592
 msgid ""
 "List storage volumes\n"
 "\n"
+"A single keyword like \"vol\" which will list any storage volume with a name "
+"starting by \"vol\".\n"
+"A regular expression on the storage volume name. (e.g. .*vol.*01$).\n"
+"A key/value pair where the key is a storage volume field name. Multiple "
+"values must be delimited by ','.\n"
+"\n"
+"Examples:\n"
+"  - \"type=custom\" will list all custom storage volumes\n"
+"  - \"type=custom content_type=block\" will list all custom block storage "
+"volumes\n"
+"\n"
+"== Columns ==\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
 "or csv format.\n"
@@ -4648,11 +4660,11 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:723
+#: cmd/incus/remote.go:724
 msgid "List the available remotes"
 msgstr ""
 
-#: cmd/incus/remote.go:724
+#: cmd/incus/remote.go:725
 msgid ""
 "List the available remotes\n"
 "\n"
@@ -4678,11 +4690,11 @@ msgid ""
 "  g - Global"
 msgstr ""
 
-#: cmd/incus/config_trust.go:402
+#: cmd/incus/config_trust.go:411
 msgid "List trusted clients"
 msgstr ""
 
-#: cmd/incus/config_trust.go:403
+#: cmd/incus/config_trust.go:412
 msgid ""
 "List trusted clients\n"
 "\n"
@@ -4706,11 +4718,11 @@ msgid ""
 "\tp - Newline-separated list of projects"
 msgstr ""
 
-#: cmd/incus/warning.go:72
+#: cmd/incus/warning.go:75
 msgid "List warnings"
 msgstr ""
 
-#: cmd/incus/warning.go:73
+#: cmd/incus/warning.go:76
 msgid ""
 "List warnings\n"
 "\n"
@@ -4733,87 +4745,87 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: cmd/incus/operation.go:29 cmd/incus/operation.go:30
+#: cmd/incus/operation.go:31 cmd/incus/operation.go:32
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:342
+#: cmd/incus/network_load_balancer.go:349
 msgid "Load balancer description"
 msgstr ""
 
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:496
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:656 cmd/incus/storage_volume.go:1442
+#: cmd/incus/info.go:658 cmd/incus/storage_volume.go:1464
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: cmd/incus/monitor.go:80
+#: cmd/incus/monitor.go:83
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:911
+#: cmd/incus/info.go:916
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/network.go:1052
+#: cmd/incus/network.go:1072
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/network.go:1056
+#: cmd/incus/network.go:1076
 msgid "Logical switch"
 msgstr ""
 
-#: cmd/incus/file.go:1604
+#: cmd/incus/file.go:1617
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1606
+#: cmd/incus/file.go:1619
 msgid "Login without username and password"
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:25
+#: cmd/incus/admin_cluster.go:26
 msgid "Low level administration tools for inspecting and recovering clusters."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:24
+#: cmd/incus/admin_cluster.go:25
 msgid "Low-level cluster administration commands"
 msgstr ""
 
-#: cmd/incus/network.go:1038
+#: cmd/incus/network.go:1058
 msgid "Lower device"
 msgstr ""
 
-#: cmd/incus/network.go:1019
+#: cmd/incus/network.go:1039
 msgid "Lower devices"
 msgstr ""
 
-#: cmd/incus/network.go:1335 cmd/incus/network_allocations.go:80
+#: cmd/incus/network.go:1358 cmd/incus/network_allocations.go:81
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:763
 msgid "MAC address"
 msgstr ""
 
-#: cmd/incus/network.go:983
+#: cmd/incus/network.go:1003
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: cmd/incus/info.go:262
+#: cmd/incus/info.go:264
 #, c-format
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: cmd/incus/network.go:1133
+#: cmd/incus/network.go:1154
 msgid "MANAGED"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:510
+#: cmd/incus/cluster_group.go:511
 msgid "MEMBERS"
 msgstr ""
 
@@ -4821,57 +4833,57 @@ msgstr ""
 msgid "MEMORY"
 msgstr ""
 
-#: cmd/incus/list.go:587
+#: cmd/incus/list.go:509
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: cmd/incus/list.go:588
+#: cmd/incus/list.go:510
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: cmd/incus/cluster.go:182
+#: cmd/incus/cluster.go:185
 msgid "MESSAGE"
 msgstr ""
 
-#: cmd/incus/network.go:1017
+#: cmd/incus/network.go:1037
 msgid "MII Frequency"
 msgstr ""
 
-#: cmd/incus/network.go:1018
+#: cmd/incus/network.go:1038
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:765
+#: cmd/incus/info.go:767
 msgid "MTU"
 msgstr ""
 
-#: cmd/incus/network.go:986
+#: cmd/incus/network.go:1006
 #, c-format
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:672
+#: cmd/incus/image.go:159 cmd/incus/image.go:685
 msgid "Make image public"
 msgstr ""
 
-#: cmd/incus/publish.go:36
+#: cmd/incus/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
-#: cmd/incus/network.go:35 cmd/incus/network.go:36
+#: cmd/incus/network.go:37 cmd/incus/network.go:38
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:34 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:36
 msgid "Manage cluster groups"
 msgstr ""
 
-#: cmd/incus/cluster.go:34 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:36 cmd/incus/cluster.go:37
 msgid "Manage cluster members"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:25
 msgid "Manage cluster roles"
 msgstr ""
 
@@ -4879,23 +4891,23 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: cmd/incus/config_device.go:23 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:25 cmd/incus/config_device.go:26
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:57 cmd/incus/file.go:58
+#: cmd/incus/file.go:58 cmd/incus/file.go:59
 msgid "Manage files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:30
+#: cmd/incus/image_alias.go:31 cmd/incus/image_alias.go:32
 msgid "Manage image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:39
+#: cmd/incus/image.go:43
 msgid "Manage images"
 msgstr ""
 
-#: cmd/incus/image.go:40
+#: cmd/incus/image.go:44
 msgid ""
 "Manage images\n"
 "\n"
@@ -4915,32 +4927,32 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
-#: cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:20 cmd/incus/admin.go:21 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_other.go:21
 msgid "Manage incus daemon"
 msgstr ""
 
-#: cmd/incus/config.go:31 cmd/incus/config.go:32
+#: cmd/incus/config.go:32 cmd/incus/config.go:33
 msgid "Manage instance and server configuration options"
 msgstr ""
 
-#: cmd/incus/config_template.go:25 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:27 cmd/incus/config_template.go:28
 msgid "Manage instance file templates"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:25 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:27 cmd/incus/config_metadata.go:28
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: cmd/incus/snapshot.go:30 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:32 cmd/incus/snapshot.go:33
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:873 cmd/incus/network_acl.go:874
+#: cmd/incus/network_acl.go:896 cmd/incus/network_acl.go:897
 msgid "Manage network ACL rules"
 msgstr ""
 
-#: cmd/incus/network_acl.go:27 cmd/incus/network_acl.go:28
+#: cmd/incus/network_acl.go:29 cmd/incus/network_acl.go:30
 msgid "Manage network ACLs"
 msgstr ""
 
@@ -4948,249 +4960,249 @@ msgstr ""
 msgid "Manage network address sets"
 msgstr ""
 
-#: cmd/incus/network_forward.go:908 cmd/incus/network_forward.go:909
+#: cmd/incus/network_forward.go:927 cmd/incus/network_forward.go:928
 msgid "Manage network forward ports"
 msgstr ""
 
-#: cmd/incus/network_forward.go:27 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:29 cmd/incus/network_forward.go:30
 msgid "Manage network forwards"
 msgstr ""
 
-#: cmd/incus/network_integration.go:27 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:29
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:887
-#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:906
+#: cmd/incus/network_load_balancer.go:907
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1079
-#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1103
+#: cmd/incus/network_load_balancer.go:1104
 msgid "Manage network load balancer ports"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:28 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:30 cmd/incus/network_load_balancer.go:31
 msgid "Manage network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:29 cmd/incus/network_peer.go:30
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1522 cmd/incus/network_zone.go:1523
+#: cmd/incus/network_zone.go:1557 cmd/incus/network_zone.go:1558
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:811
+#: cmd/incus/network_zone.go:828 cmd/incus/network_zone.go:829
 msgid "Manage network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:31 cmd/incus/network_zone.go:32
+#: cmd/incus/network_zone.go:33 cmd/incus/network_zone.go:34
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:33 cmd/incus/profile.go:34
+#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
 msgid "Manage profiles"
 msgstr ""
 
-#: cmd/incus/project.go:35 cmd/incus/project.go:36
+#: cmd/incus/project.go:37 cmd/incus/project.go:38
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:847
+#: cmd/incus/storage_bucket.go:866
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:848
+#: cmd/incus/storage_bucket.go:867
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:33
+#: cmd/incus/storage_bucket.go:35
 msgid "Manage storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:34
+#: cmd/incus/storage_bucket.go:36
 msgid "Manage storage buckets."
 msgstr ""
 
-#: cmd/incus/storage.go:36 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:38 cmd/incus/storage.go:39
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2286 cmd/incus/storage_volume.go:2287
+#: cmd/incus/storage_volume.go:2356 cmd/incus/storage_volume.go:2357
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:57
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:58
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:43 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:44 cmd/incus/remote.go:45
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:37
 msgid "Manage trusted clients"
 msgstr ""
 
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:30
+#: cmd/incus/warning.go:31 cmd/incus/warning.go:32
 msgid "Manage warnings"
 msgstr ""
 
-#: cmd/incus/remote.go:638
+#: cmd/incus/remote.go:639
 msgid "Manually trigger the generation of a client certificate"
 msgstr ""
 
-#: cmd/incus/info.go:166 cmd/incus/info.go:275
+#: cmd/incus/info.go:168 cmd/incus/info.go:277
 #, c-format
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: cmd/incus/info.go:177
+#: cmd/incus/info.go:179
 msgid "Mdev profiles:"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:95
+#: cmd/incus/cluster_role.go:96
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:163
+#: cmd/incus/cluster_role.go:164
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:1050
+#: cmd/incus/cluster.go:1074
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: cmd/incus/cluster.go:768
+#: cmd/incus/cluster.go:786
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: cmd/incus/cluster.go:673
+#: cmd/incus/cluster.go:689
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:722
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:726
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:736
+#: cmd/incus/info.go:738
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:338
+#: cmd/incus/move.go:341
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:357
+#: cmd/incus/move.go:360
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: cmd/incus/admin_init.go:55
+#: cmd/incus/admin_init.go:57
 msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
-#: cmd/incus/monitor.go:52
+#: cmd/incus/monitor.go:54
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:700
+#: cmd/incus/admin_init_interactive.go:706
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:237
-#: cmd/incus/storage_bucket.go:313 cmd/incus/storage_bucket.go:432
-#: cmd/incus/storage_bucket.go:684 cmd/incus/storage_bucket.go:776
-#: cmd/incus/storage_bucket.go:989 cmd/incus/storage_bucket.go:1082
-#: cmd/incus/storage_bucket.go:1183 cmd/incus/storage_bucket.go:1262
-#: cmd/incus/storage_bucket.go:1385 cmd/incus/storage_bucket.go:1461
+#: cmd/incus/storage_bucket.go:137 cmd/incus/storage_bucket.go:243
+#: cmd/incus/storage_bucket.go:321 cmd/incus/storage_bucket.go:442
+#: cmd/incus/storage_bucket.go:698 cmd/incus/storage_bucket.go:792
+#: cmd/incus/storage_bucket.go:1010 cmd/incus/storage_bucket.go:1105
+#: cmd/incus/storage_bucket.go:1208 cmd/incus/storage_bucket.go:1289
+#: cmd/incus/storage_bucket.go:1414 cmd/incus/storage_bucket.go:1490
 msgid "Missing bucket name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:310 cmd/incus/config_trust.go:896
+#: cmd/incus/config_trust.go:318 cmd/incus/config_trust.go:914
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:243 cmd/incus/cluster_group.go:313
-#: cmd/incus/cluster_group.go:373 cmd/incus/cluster_group.go:795
+#: cmd/incus/cluster_group.go:244 cmd/incus/cluster_group.go:314
+#: cmd/incus/cluster_group.go:374 cmd/incus/cluster_group.go:796
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:918 cmd/incus/cluster.go:1519
-#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:658
-#: cmd/incus/cluster_group.go:860 cmd/incus/cluster_role.go:82
-#: cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:940 cmd/incus/cluster.go:1553
+#: cmd/incus/cluster_group.go:146 cmd/incus/cluster_group.go:659
+#: cmd/incus/cluster_group.go:863 cmd/incus/cluster_role.go:83
+#: cmd/incus/cluster_role.go:151
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
-#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
-#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:325
-#: cmd/incus/config_template.go:396 cmd/incus/profile.go:145
-#: cmd/incus/profile.go:226 cmd/incus/profile.go:918 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
+#: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
+#: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
+#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1086 cmd/incus/storage_bucket.go:1187
-#: cmd/incus/storage_bucket.go:1266 cmd/incus/storage_bucket.go:1389
+#: cmd/incus/storage_bucket.go:1109 cmd/incus/storage_bucket.go:1212
+#: cmd/incus/storage_bucket.go:1293 cmd/incus/storage_bucket.go:1418
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:292 cmd/incus/network_forward.go:364
-#: cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:568
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:874
-#: cmd/incus/network_forward.go:969 cmd/incus/network_forward.go:1052
-#: cmd/incus/network_load_balancer.go:296
-#: cmd/incus/network_load_balancer.go:367
-#: cmd/incus/network_load_balancer.go:469
-#: cmd/incus/network_load_balancer.go:554
-#: cmd/incus/network_load_balancer.go:722
-#: cmd/incus/network_load_balancer.go:854
-#: cmd/incus/network_load_balancer.go:944
-#: cmd/incus/network_load_balancer.go:1021
-#: cmd/incus/network_load_balancer.go:1136
-#: cmd/incus/network_load_balancer.go:1211
-#: cmd/incus/network_load_balancer.go:1321
+#: cmd/incus/network_forward.go:298 cmd/incus/network_forward.go:372
+#: cmd/incus/network_forward.go:493 cmd/incus/network_forward.go:580
+#: cmd/incus/network_forward.go:759 cmd/incus/network_forward.go:892
+#: cmd/incus/network_forward.go:990 cmd/incus/network_forward.go:1075
+#: cmd/incus/network_load_balancer.go:302
+#: cmd/incus/network_load_balancer.go:375
+#: cmd/incus/network_load_balancer.go:479
+#: cmd/incus/network_load_balancer.go:566
+#: cmd/incus/network_load_balancer.go:738
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:965
+#: cmd/incus/network_load_balancer.go:1044
+#: cmd/incus/network_load_balancer.go:1162
+#: cmd/incus/network_load_balancer.go:1239
+#: cmd/incus/network_load_balancer.go:1349
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
-#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
-#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
-#: cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:135 cmd/incus/config_device.go:270
+#: cmd/incus/config_device.go:366 cmd/incus/config_device.go:442
+#: cmd/incus/config_device.go:556 cmd/incus/config_device.go:687
+#: cmd/incus/config_device.go:810
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:224 cmd/incus/network_acl.go:284
-#: cmd/incus/network_acl.go:347 cmd/incus/network_acl.go:423
-#: cmd/incus/network_acl.go:525 cmd/incus/network_acl.go:678
-#: cmd/incus/network_acl.go:789 cmd/incus/network_acl.go:846
-#: cmd/incus/network_acl.go:986 cmd/incus/network_acl.go:1073
+#: cmd/incus/network_acl.go:230 cmd/incus/network_acl.go:292
+#: cmd/incus/network_acl.go:357 cmd/incus/network_acl.go:435
+#: cmd/incus/network_acl.go:539 cmd/incus/network_acl.go:696
+#: cmd/incus/network_acl.go:809 cmd/incus/network_acl.go:868
+#: cmd/incus/network_acl.go:1011 cmd/incus/network_acl.go:1101
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -5201,164 +5213,164 @@ msgstr ""
 msgid "Missing network address set name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
-#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
-#: cmd/incus/network_integration.go:588 cmd/incus/network_integration.go:645
-#: cmd/incus/network_integration.go:756
+#: cmd/incus/network_integration.go:132 cmd/incus/network_integration.go:204
+#: cmd/incus/network_integration.go:267 cmd/incus/network_integration.go:378
+#: cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:646
+#: cmd/incus/network_integration.go:757
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:183 cmd/incus/network.go:280 cmd/incus/network.go:491
-#: cmd/incus/network.go:553 cmd/incus/network.go:650 cmd/incus/network.go:763
-#: cmd/incus/network.go:886 cmd/incus/network.go:962 cmd/incus/network.go:1401
-#: cmd/incus/network.go:1479 cmd/incus/network.go:1545
-#: cmd/incus/network.go:1637 cmd/incus/network_forward.go:208
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:360
-#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:564
-#: cmd/incus/network_forward.go:739 cmd/incus/network_forward.go:870
-#: cmd/incus/network_forward.go:965 cmd/incus/network_forward.go:1048
-#: cmd/incus/network_load_balancer.go:211
-#: cmd/incus/network_load_balancer.go:292
-#: cmd/incus/network_load_balancer.go:363
-#: cmd/incus/network_load_balancer.go:465
-#: cmd/incus/network_load_balancer.go:550
-#: cmd/incus/network_load_balancer.go:718
-#: cmd/incus/network_load_balancer.go:850
-#: cmd/incus/network_load_balancer.go:940
-#: cmd/incus/network_load_balancer.go:1017
-#: cmd/incus/network_load_balancer.go:1132
-#: cmd/incus/network_load_balancer.go:1207
-#: cmd/incus/network_load_balancer.go:1317 cmd/incus/network_peer.go:209
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:372
-#: cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:601
-#: cmd/incus/network_peer.go:760 cmd/incus/network_peer.go:881
+#: cmd/incus/network.go:187 cmd/incus/network.go:286 cmd/incus/network.go:501
+#: cmd/incus/network.go:565 cmd/incus/network.go:664 cmd/incus/network.go:779
+#: cmd/incus/network.go:904 cmd/incus/network.go:982 cmd/incus/network.go:1425
+#: cmd/incus/network.go:1505 cmd/incus/network.go:1573
+#: cmd/incus/network.go:1667 cmd/incus/network_forward.go:212
+#: cmd/incus/network_forward.go:294 cmd/incus/network_forward.go:368
+#: cmd/incus/network_forward.go:489 cmd/incus/network_forward.go:576
+#: cmd/incus/network_forward.go:755 cmd/incus/network_forward.go:888
+#: cmd/incus/network_forward.go:986 cmd/incus/network_forward.go:1071
+#: cmd/incus/network_load_balancer.go:215
+#: cmd/incus/network_load_balancer.go:298
+#: cmd/incus/network_load_balancer.go:371
+#: cmd/incus/network_load_balancer.go:475
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:734
+#: cmd/incus/network_load_balancer.go:868
+#: cmd/incus/network_load_balancer.go:961
+#: cmd/incus/network_load_balancer.go:1040
+#: cmd/incus/network_load_balancer.go:1158
+#: cmd/incus/network_load_balancer.go:1235
+#: cmd/incus/network_load_balancer.go:1345 cmd/incus/network_peer.go:213
+#: cmd/incus/network_peer.go:293 cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:529 cmd/incus/network_peer.go:615
+#: cmd/incus/network_peer.go:778 cmd/incus/network_peer.go:901
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:288 cmd/incus/network_zone.go:357
-#: cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:533
-#: cmd/incus/network_zone.go:674 cmd/incus/network_zone.go:785
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:983
-#: cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1233
-#: cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1572
-#: cmd/incus/network_zone.go:1629
+#: cmd/incus/network_zone.go:293 cmd/incus/network_zone.go:364
+#: cmd/incus/network_zone.go:442 cmd/incus/network_zone.go:544
+#: cmd/incus/network_zone.go:689 cmd/incus/network_zone.go:802
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1005
+#: cmd/incus/network_zone.go:1158 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1529 cmd/incus/network_zone.go:1609
+#: cmd/incus/network_zone.go:1668
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1053 cmd/incus/network_zone.go:1381
+#: cmd/incus/network_zone.go:1077 cmd/incus/network_zone.go:1413
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:376
-#: cmd/incus/network_peer.go:521 cmd/incus/network_peer.go:605
-#: cmd/incus/network_peer.go:764 cmd/incus/network_peer.go:885
+#: cmd/incus/network_peer.go:297 cmd/incus/network_peer.go:384
+#: cmd/incus/network_peer.go:533 cmd/incus/network_peer.go:619
+#: cmd/incus/network_peer.go:782 cmd/incus/network_peer.go:905
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:251 cmd/incus/storage.go:329 cmd/incus/storage.go:447
-#: cmd/incus/storage.go:525 cmd/incus/storage.go:875 cmd/incus/storage.go:981
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:233
-#: cmd/incus/storage_bucket.go:309 cmd/incus/storage_bucket.go:428
-#: cmd/incus/storage_bucket.go:592 cmd/incus/storage_bucket.go:680
-#: cmd/incus/storage_bucket.go:772 cmd/incus/storage_bucket.go:985
-#: cmd/incus/storage_bucket.go:1078 cmd/incus/storage_bucket.go:1179
-#: cmd/incus/storage_bucket.go:1258 cmd/incus/storage_bucket.go:1381
-#: cmd/incus/storage_bucket.go:1456 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:621
-#: cmd/incus/storage_volume.go:732 cmd/incus/storage_volume.go:809
-#: cmd/incus/storage_volume.go:907 cmd/incus/storage_volume.go:1024
-#: cmd/incus/storage_volume.go:1241 cmd/incus/storage_volume.go:1620
-#: cmd/incus/storage_volume.go:1918 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2174 cmd/incus/storage_volume.go:2397
-#: cmd/incus/storage_volume.go:2512 cmd/incus/storage_volume.go:2617
-#: cmd/incus/storage_volume.go:2770 cmd/incus/storage_volume.go:2855
-#: cmd/incus/storage_volume.go:2932
+#: cmd/incus/storage.go:257 cmd/incus/storage.go:337 cmd/incus/storage.go:457
+#: cmd/incus/storage.go:537 cmd/incus/storage.go:891 cmd/incus/storage.go:999
+#: cmd/incus/storage_bucket.go:133 cmd/incus/storage_bucket.go:239
+#: cmd/incus/storage_bucket.go:317 cmd/incus/storage_bucket.go:438
+#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_bucket.go:694
+#: cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:1006
+#: cmd/incus/storage_bucket.go:1101 cmd/incus/storage_bucket.go:1204
+#: cmd/incus/storage_bucket.go:1285 cmd/incus/storage_bucket.go:1410
+#: cmd/incus/storage_bucket.go:1485 cmd/incus/storage_volume.go:207
+#: cmd/incus/storage_volume.go:300 cmd/incus/storage_volume.go:631
+#: cmd/incus/storage_volume.go:744 cmd/incus/storage_volume.go:823
+#: cmd/incus/storage_volume.go:923 cmd/incus/storage_volume.go:1042
+#: cmd/incus/storage_volume.go:1261 cmd/incus/storage_volume.go:1653
+#: cmd/incus/storage_volume.go:1981 cmd/incus/storage_volume.go:2077
+#: cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:2586 cmd/incus/storage_volume.go:2693
+#: cmd/incus/storage_volume.go:2848 cmd/incus/storage_volume.go:2935
+#: cmd/incus/storage_volume.go:3014
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:413 cmd/incus/profile.go:480 cmd/incus/profile.go:562
-#: cmd/incus/profile.go:680 cmd/incus/profile.go:1002 cmd/incus/profile.go:1070
-#: cmd/incus/profile.go:1151
+#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
+#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
+#: cmd/incus/profile.go:1177
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:160 cmd/incus/project.go:261 cmd/incus/project.go:363
-#: cmd/incus/project.go:480 cmd/incus/project.go:769 cmd/incus/project.go:838
-#: cmd/incus/project.go:966 cmd/incus/project.go:1101
+#: cmd/incus/project.go:164 cmd/incus/project.go:267 cmd/incus/project.go:371
+#: cmd/incus/project.go:490 cmd/incus/project.go:783 cmd/incus/project.go:854
+#: cmd/incus/project.go:986 cmd/incus/project.go:1125
 msgid "Missing project name"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:72
+#: cmd/incus/admin_sql.go:75
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:314
+#: cmd/incus/profile.go:322
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1828
+#: cmd/incus/storage_volume.go:413 cmd/incus/storage_volume.go:1889
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1369
+#: cmd/incus/storage_volume.go:1391
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:834
+#: cmd/incus/file.go:845
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:380
+#: cmd/incus/network_peer.go:388
 msgid "Missing target network or integration"
 msgstr ""
 
-#: cmd/incus/network.go:1013
+#: cmd/incus/network.go:1033
 msgid "Mode"
 msgstr ""
 
-#: cmd/incus/info.go:297
+#: cmd/incus/info.go:299
 #, c-format
 msgid "Model: %s"
 msgstr ""
 
-#: cmd/incus/info.go:157
+#: cmd/incus/info.go:159
 #, c-format
 msgid "Model: %v"
 msgstr ""
 
-#: cmd/incus/monitor.go:32
+#: cmd/incus/monitor.go:34
 msgid "Monitor a local or remote server"
 msgstr ""
 
-#: cmd/incus/monitor.go:33
+#: cmd/incus/monitor.go:35
 msgid ""
 "Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:573 cmd/incus/network.go:670
-#: cmd/incus/storage_volume.go:829 cmd/incus/storage_volume.go:926
+#: cmd/incus/network.go:585 cmd/incus/network.go:684
+#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:942
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:513
+#: cmd/incus/file.go:522
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1360 cmd/incus/file.go:1361
+#: cmd/incus/file.go:1372 cmd/incus/file.go:1373
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1787 cmd/incus/storage_volume.go:1788
+#: cmd/incus/storage_volume.go:1847 cmd/incus/storage_volume.go:1848
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:34
+#: cmd/incus/move.go:36
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:37
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5374,217 +5386,217 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1794
+#: cmd/incus/storage_volume.go:1854
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:485
+#: cmd/incus/storage_volume.go:493
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1096 cmd/incus/network_load_balancer.go:1255
+#: cmd/incus/network_forward.go:1119 cmd/incus/network_load_balancer.go:1283
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1128
+#: cmd/incus/network_acl.go:1156
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:697
+#: cmd/incus/image.go:710
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: cmd/incus/action.go:280
+#: cmd/incus/action.go:274
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:175 cmd/incus/cluster.go:1115
-#: cmd/incus/cluster_group.go:509 cmd/incus/config_trust.go:438
-#: cmd/incus/config_trust.go:632 cmd/incus/list.go:589
-#: cmd/incus/network.go:1131 cmd/incus/network_acl.go:172
-#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:453
-#: cmd/incus/network_peer.go:132 cmd/incus/network_zone.go:137
-#: cmd/incus/network_zone.go:932 cmd/incus/profile.go:759
-#: cmd/incus/project.go:562 cmd/incus/project.go:704 cmd/incus/remote.go:763
-#: cmd/incus/snapshot.go:339 cmd/incus/storage.go:719
-#: cmd/incus/storage_bucket.go:526 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1685 cmd/incus/storage_volume.go:2669
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140
+#: cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:643 cmd/incus/list.go:511
+#: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
+#: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
+#: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
+#: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
+#: cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid "NAME"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:79
+#: cmd/incus/network_allocations.go:80
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:568
+#: cmd/incus/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:567
+#: cmd/incus/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:157
+#: cmd/incus/admin_recover.go:160
 #, c-format
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:558
+#: cmd/incus/info.go:560
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:563
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1180 cmd/incus/operation.go:204
-#: cmd/incus/project.go:600 cmd/incus/project.go:609 cmd/incus/project.go:618
-#: cmd/incus/project.go:627 cmd/incus/project.go:636 cmd/incus/project.go:645
-#: cmd/incus/remote.go:827 cmd/incus/remote.go:836 cmd/incus/remote.go:845
+#: cmd/incus/network.go:1201 cmd/incus/operation.go:209
+#: cmd/incus/project.go:611 cmd/incus/project.go:620 cmd/incus/project.go:629
+#: cmd/incus/project.go:638 cmd/incus/project.go:647 cmd/incus/project.go:656
+#: cmd/incus/remote.go:828 cmd/incus/remote.go:837 cmd/incus/remote.go:846
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:118 cmd/incus/info.go:204 cmd/incus/info.go:291
-#: cmd/incus/info.go:378
+#: cmd/incus/info.go:120 cmd/incus/info.go:206 cmd/incus/info.go:293
+#: cmd/incus/info.go:380
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "NUMA nodes:\n"
 msgstr ""
 
-#: cmd/incus/info.go:154
+#: cmd/incus/info.go:156
 msgid "NVIDIA information:"
 msgstr ""
 
-#: cmd/incus/info.go:159
+#: cmd/incus/info.go:161
 #, c-format
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1484
-#: cmd/incus/storage_volume.go:1534
+#: cmd/incus/info.go:831 cmd/incus/info.go:882 cmd/incus/storage_volume.go:1506
+#: cmd/incus/storage_volume.go:1556
 msgid "Name"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:644
+#: cmd/incus/admin_init_interactive.go:648
 msgid "Name of the CEPHfs volume:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:626
+#: cmd/incus/admin_init_interactive.go:629
 msgid "Name of the OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:731
+#: cmd/incus/admin_init_interactive.go:737
 #, c-format
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:620
-#: cmd/incus/admin_init_interactive.go:718
+#: cmd/incus/admin_init_interactive.go:623
+#: cmd/incus/admin_init_interactive.go:724
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:638
+#: cmd/incus/admin_init_interactive.go:642
 msgid "Name of the existing CEPHfs cluster"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:724
+#: cmd/incus/admin_init_interactive.go:730
 msgid "Name of the existing OSD storage pool"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:313
+#: cmd/incus/admin_init_interactive.go:315
 msgid "Name of the existing bridge or host interface:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:520
+#: cmd/incus/admin_init_interactive.go:522
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:159
+#: cmd/incus/remote.go:160
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:650
+#: cmd/incus/admin_init_interactive.go:655
 msgid "Name of the shared LVM volume group:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:116
+#: cmd/incus/admin_recover.go:119
 #, c-format
 msgid "Name of the storage backend (%s):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:558
+#: cmd/incus/admin_init_interactive.go:560
 #, c-format
 msgid "Name of the storage backend to use (%s)"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:99
+#: cmd/incus/admin_recover.go:102
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:634 cmd/incus/network.go:980
-#: cmd/incus/storage_volume.go:1424
+#: cmd/incus/info.go:636 cmd/incus/network.go:1000
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: cmd/incus/info.go:331
+#: cmd/incus/info.go:333
 #, c-format
 msgid "Name: %v"
 msgstr ""
 
-#: cmd/incus/network.go:441
+#: cmd/incus/network.go:449
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: cmd/incus/network.go:501
+#: cmd/incus/network.go:511
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: cmd/incus/network.go:439
+#: cmd/incus/network.go:447
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/network.go:1489
+#: cmd/incus/network.go:1515
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:471
+#: cmd/incus/network_acl.go:483
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:856
+#: cmd/incus/network_acl.go:878
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:799
+#: cmd/incus/network_acl.go:819
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:392
+#: cmd/incus/network_acl.go:403
 msgid "Network ACL description"
 msgstr ""
 
-#: cmd/incus/network_zone.go:479
+#: cmd/incus/network_zone.go:488
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:795
+#: cmd/incus/network_zone.go:812
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5608,169 +5620,169 @@ msgstr ""
 msgid "Network address set description"
 msgstr ""
 
-#: cmd/incus/network.go:355
+#: cmd/incus/network.go:362
 msgid "Network description"
 msgstr ""
 
-#: cmd/incus/network_forward.go:420
+#: cmd/incus/network_forward.go:428
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:891
+#: cmd/incus/network_forward.go:909
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:339
+#: cmd/incus/network_forward.go:346
 msgid "Network forward description"
 msgstr ""
 
-#: cmd/incus/network_integration.go:160
+#: cmd/incus/network_integration.go:161
 #, c-format
 msgid "Network integration %s created"
 msgstr ""
 
-#: cmd/incus/network_integration.go:213
+#: cmd/incus/network_integration.go:214
 #, c-format
 msgid "Network integration %s deleted"
 msgstr ""
 
-#: cmd/incus/network_integration.go:598
+#: cmd/incus/network_integration.go:599
 #, c-format
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:423
+#: cmd/incus/network_load_balancer.go:431
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:871
+#: cmd/incus/network_load_balancer.go:889
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:453
+#: cmd/incus/network_peer.go:463
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:897
+#: cmd/incus/network_peer.go:917
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:457
+#: cmd/incus/network_peer.go:467
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:455
+#: cmd/incus/network_peer.go:465
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
-#: cmd/incus/network.go:354
+#: cmd/incus/network.go:361
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/network.go:1002
+#: cmd/incus/info.go:788 cmd/incus/network.go:1022
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:1204
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1505
+#: cmd/incus/network_zone.go:1539
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: cmd/incus/publish.go:37
+#: cmd/incus/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:674
+#: cmd/incus/image.go:162 cmd/incus/image.go:687
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:57 cmd/incus/move.go:57
+#: cmd/incus/copy.go:56 cmd/incus/create.go:59 cmd/incus/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:497
+#: cmd/incus/admin_init_interactive.go:499
 #, c-format
 msgid "No %s storage backends available"
 msgstr ""
 
-#: cmd/incus/config_trust.go:857
+#: cmd/incus/config_trust.go:873
 #, c-format
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:1315
+#: cmd/incus/cluster.go:1343
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
-#: cmd/incus/network.go:582 cmd/incus/network.go:679
+#: cmd/incus/network.go:594 cmd/incus/network.go:693
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:838 cmd/incus/storage_volume.go:935
+#: cmd/incus/storage_volume.go:852 cmd/incus/storage_volume.go:951
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1333
+#: cmd/incus/network_load_balancer.go:1361
 msgid "No load-balancer health information available"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1052
+#: cmd/incus/network_load_balancer.go:1075
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1107 cmd/incus/network_load_balancer.go:1266
+#: cmd/incus/network_forward.go:1130 cmd/incus/network_load_balancer.go:1294
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1139
+#: cmd/incus/network_acl.go:1167
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:494
+#: cmd/incus/admin_init_interactive.go:496
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1837
+#: cmd/incus/storage_volume.go:427 cmd/incus/storage_volume.go:1898
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1848
+#: cmd/incus/storage_volume.go:477 cmd/incus/storage_volume.go:1909
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:500
+#: cmd/incus/utils.go:514
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:222
+#: cmd/incus/admin_recover.go:218
 msgid "No unknown storage pools or volumes found. Nothing to do."
 msgstr ""
 
-#: cmd/incus/config_device.go:142 cmd/incus/config_device.go:456
+#: cmd/incus/config_device.go:146 cmd/incus/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:526
+#: cmd/incus/info.go:528
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5781,19 +5793,19 @@ msgid ""
 "be used with the 'dir' backend"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:632
+#: cmd/incus/admin_init_interactive.go:635
 msgid "Number of placement groups"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:681
 msgid "OS"
 msgstr ""
 
-#: cmd/incus/info.go:680
+#: cmd/incus/info.go:682
 msgid "OS Version"
 msgstr ""
 
-#: cmd/incus/network.go:1045
+#: cmd/incus/network.go:1065
 msgid "OVN:"
 msgstr ""
 
@@ -5801,31 +5813,31 @@ msgstr ""
 msgid "One or more provided address isn't currently in the set"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
+#: cmd/incus/storage_volume.go:227 cmd/incus/storage_volume.go:320
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3036
+#: cmd/incus/storage_volume.go:3120
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2410
+#: cmd/incus/storage_volume.go:2482
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:347
+#: cmd/incus/remote.go:348
 msgid "Only https URLs are supported for oci and simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:774
+#: cmd/incus/image.go:788
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1409
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: cmd/incus/network.go:789 cmd/incus/network.go:1560
+#: cmd/incus/network.go:805 cmd/incus/network.go:1588
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -5838,171 +5850,171 @@ msgstr ""
 msgid "Open the web interface"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:680
 msgid "Operating System:"
 msgstr ""
 
-#: cmd/incus/operation.go:93
+#: cmd/incus/operation.go:97
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:884 cmd/incus/storage_volume.go:1538
+#: cmd/incus/info.go:886 cmd/incus/storage_volume.go:1560
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:118
+#: cmd/incus/main.go:119
 msgid "Override the source project"
 msgstr ""
 
-#: cmd/incus/exec.go:60
+#: cmd/incus/exec.go:61
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: cmd/incus/info.go:129 cmd/incus/info.go:215
+#: cmd/incus/info.go:131 cmd/incus/info.go:217
 #, c-format
 msgid "PCI address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:594
+#: cmd/incus/info.go:596
 msgid "PCI device:"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:599
 msgid "PCI devices:"
 msgstr ""
 
-#: cmd/incus/network_peer.go:134
+#: cmd/incus/network_peer.go:137
 msgid "PEER"
 msgstr ""
 
-#: cmd/incus/list.go:591
+#: cmd/incus/list.go:513
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:660
+#: cmd/incus/info.go:662
 #, c-format
 msgid "PID: %d"
 msgstr ""
 
-#: cmd/incus/network_forward.go:139 cmd/incus/network_load_balancer.go:146
+#: cmd/incus/network_forward.go:142 cmd/incus/network_load_balancer.go:149
 msgid "PORTS"
 msgstr ""
 
-#: cmd/incus/list.go:590
+#: cmd/incus/list.go:512
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:592 cmd/incus/project.go:564
+#: cmd/incus/list.go:514 cmd/incus/project.go:575
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1123 cmd/incus/list.go:583 cmd/incus/network.go:1130
-#: cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:136 cmd/incus/profile.go:760
-#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_volume.go:1704
-#: cmd/incus/top.go:79 cmd/incus/warning.go:218
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
+#: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
+#: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/config_trust.go:446
+#: cmd/incus/config_trust.go:455
 msgid "PROJECTS"
 msgstr ""
 
-#: cmd/incus/remote.go:765
+#: cmd/incus/remote.go:766
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1128 cmd/incus/remote.go:767
+#: cmd/incus/image.go:1149 cmd/incus/remote.go:768
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:770 cmd/incus/network.go:1005
+#: cmd/incus/info.go:772 cmd/incus/network.go:1025
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:771 cmd/incus/network.go:1006
+#: cmd/incus/info.go:773 cmd/incus/network.go:1026
 msgid "Packets sent"
 msgstr ""
 
-#: cmd/incus/info.go:314
+#: cmd/incus/info.go:316
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:424
+#: cmd/incus/main.go:426
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1574
+#: cmd/incus/file.go:1587
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
 
-#: cmd/incus/admin_init.go:149
+#: cmd/incus/admin_init.go:152
 #, c-format
 msgid "Path %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:661
+#: cmd/incus/admin_init_interactive.go:667
 msgid "Path to the existing block device:"
 msgstr ""
 
-#: cmd/incus/action.go:56 cmd/incus/action.go:57
+#: cmd/incus/action.go:55 cmd/incus/action.go:56
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/network_peer.go:339
+#: cmd/incus/network_peer.go:346
 msgid "Peer description"
 msgstr ""
 
-#: cmd/incus/copy.go:64
+#: cmd/incus/copy.go:66
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:219
+#: cmd/incus/admin_recover.go:230
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:200
+#: cmd/incus/remote.go:201
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:188
+#: cmd/incus/admin_init_interactive.go:190
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:478
+#: cmd/incus/remote.go:479
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:101
+#: cmd/incus/admin_recover.go:104
 msgid "Pool name cannot be empty"
 msgstr ""
 
-#: cmd/incus/network_forward.go:928 cmd/incus/network_load_balancer.go:1099
+#: cmd/incus/network_forward.go:948 cmd/incus/network_load_balancer.go:1124
 msgid "Port description"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:819
+#: cmd/incus/admin_init_interactive.go:825
 msgid "Port to bind to"
 msgstr ""
 
-#: cmd/incus/admin_init.go:60
+#: cmd/incus/admin_init.go:62
 #, c-format
 msgid "Port to bind to (default: %d)"
 msgstr ""
 
-#: cmd/incus/info.go:241
+#: cmd/incus/info.go:243
 #, c-format
 msgid "Port type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:223
+#: cmd/incus/info.go:225
 msgid "Ports:"
 msgstr ""
 
-#: cmd/incus/admin_init.go:56
+#: cmd/incus/admin_init.go:58
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
@@ -6018,258 +6030,258 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1490
+#: cmd/incus/file.go:1503
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:967 cmd/incus/cluster_group.go:422
-#: cmd/incus/config.go:277 cmd/incus/config.go:352
-#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
-#: cmd/incus/config_trust.go:357 cmd/incus/image.go:465
-#: cmd/incus/network.go:814 cmd/incus/network_acl.go:727
-#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:802
-#: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:782
-#: cmd/incus/network_peer.go:815 cmd/incus/network_zone.go:723
-#: cmd/incus/network_zone.go:1430 cmd/incus/profile.go:609
-#: cmd/incus/project.go:410 cmd/incus/storage.go:376
-#: cmd/incus/storage_bucket.go:370 cmd/incus/storage_bucket.go:1323
-#: cmd/incus/storage_volume.go:1122 cmd/incus/storage_volume.go:1154
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423
+#: cmd/incus/config.go:278 cmd/incus/config.go:353
+#: cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262
+#: cmd/incus/config_trust.go:365 cmd/incus/image.go:475
+#: cmd/incus/network.go:830 cmd/incus/network_acl.go:745
+#: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
+#: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
+#: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/project.go:418 cmd/incus/storage.go:384
+#: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
+#: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: cmd/incus/monitor.go:49
+#: cmd/incus/monitor.go:51
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:116
+#: cmd/incus/main.go:117
 msgid "Print help"
 msgstr ""
 
-#: cmd/incus/query.go:43
+#: cmd/incus/query.go:44
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:115
+#: cmd/incus/main.go:116
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:496 cmd/incus/info.go:689
+#: cmd/incus/info.go:498 cmd/incus/info.go:691
 #, c-format
 msgid "Processes: %d"
 msgstr ""
 
-#: cmd/incus/main_aliases.go:236 cmd/incus/main_aliases.go:243
+#: cmd/incus/main_aliases.go:235 cmd/incus/main_aliases.go:242
 #, c-format
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:364 cmd/incus/info.go:377
+#: cmd/incus/info.go:366 cmd/incus/info.go:379
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:467
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:363 cmd/incus/info.go:376 cmd/incus/info.go:414
+#: cmd/incus/info.go:365 cmd/incus/info.go:378 cmd/incus/info.go:416
 #, c-format
 msgid "Product: %v"
 msgstr ""
 
-#: cmd/incus/info.go:125 cmd/incus/info.go:211
+#: cmd/incus/info.go:127 cmd/incus/info.go:213
 #, c-format
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:167
+#: cmd/incus/profile.go:171
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:431
+#: cmd/incus/profile.go:441
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:490
+#: cmd/incus/profile.go:502
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:928
+#: cmd/incus/profile.go:948
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:953
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1012
+#: cmd/incus/profile.go:1034
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:369
+#: cmd/incus/profile.go:378
 msgid "Profile description"
 msgstr ""
 
-#: cmd/incus/image.go:161
+#: cmd/incus/image.go:166
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:56
+#: cmd/incus/copy.go:57 cmd/incus/create.go:58
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:58
+#: cmd/incus/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:255
+#: cmd/incus/profile.go:261
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:1043
+#: cmd/incus/image.go:1063
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:1041
+#: cmd/incus/image.go:1061
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:190
+#: cmd/incus/project.go:194
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:283
+#: cmd/incus/project.go:289
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:784
+#: cmd/incus/project.go:798
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/project.go:114
+#: cmd/incus/project.go:117
 msgid "Project description"
 msgstr ""
 
-#: cmd/incus/remote.go:124
+#: cmd/incus/remote.go:125
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:1016
+#: cmd/incus/image.go:1036
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1623
+#: cmd/incus/image.go:1648
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:1036
+#: cmd/incus/image.go:1056
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:226
+#: cmd/incus/config_trust.go:231
 #, c-format
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:42
+#: cmd/incus/remote_unix.go:43
 msgid "Proxy timeout (exits when no connections)"
 msgstr ""
 
-#: cmd/incus/remote.go:123
+#: cmd/incus/remote.go:124
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:995
+#: cmd/incus/image.go:1015
 #, c-format
 msgid "Public: %s"
 msgstr ""
 
-#: cmd/incus/publish.go:31 cmd/incus/publish.go:32
+#: cmd/incus/publish.go:33 cmd/incus/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: cmd/incus/publish.go:264
+#: cmd/incus/publish.go:267
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:461 cmd/incus/file.go:462
+#: cmd/incus/file.go:469 cmd/incus/file.go:470
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:633 cmd/incus/file.go:1121
+#: cmd/incus/file.go:642 cmd/incus/file.go:1132
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:693 cmd/incus/file.go:694
+#: cmd/incus/file.go:703 cmd/incus/file.go:704
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:931 cmd/incus/file.go:1241
+#: cmd/incus/file.go:942 cmd/incus/file.go:1252
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
 
-#: cmd/incus/query.go:88
+#: cmd/incus/query.go:90
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:503 cmd/incus/image.go:927 cmd/incus/image.go:1511
+#: cmd/incus/image.go:514 cmd/incus/image.go:946 cmd/incus/image.go:1533
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1159
+#: cmd/incus/project.go:1183
 msgid "RESOURCE"
 msgstr ""
 
-#: cmd/incus/config_trust.go:445
+#: cmd/incus/config_trust.go:454
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:933
+#: cmd/incus/storage_bucket.go:953
 msgid "ROLE"
 msgstr ""
 
-#: cmd/incus/cluster.go:177
+#: cmd/incus/cluster.go:180
 msgid "ROLES"
 msgstr ""
 
-#: cmd/incus/info.go:310 cmd/incus/info.go:319
+#: cmd/incus/info.go:312 cmd/incus/info.go:321
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
 
-#: cmd/incus/rebuild.go:31
+#: cmd/incus/rebuild.go:33
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: cmd/incus/rebuild.go:26
+#: cmd/incus/rebuild.go:28
 msgid "Rebuild instances"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1100
+#: cmd/incus/network_zone.go:1125
 msgid "Record description"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:28
+#: cmd/incus/admin_recover.go:30
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_recover.go:31
 msgid ""
 "Recover missing instances and volumes from existing and unknown storage "
 "pools\n"
@@ -6282,24 +6294,24 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:700
+#: cmd/incus/file.go:477 cmd/incus/file.go:710
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:370
+#: cmd/incus/storage_volume.go:377
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
+#: cmd/incus/image.go:1443 cmd/incus/image.go:1444
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:409
+#: cmd/incus/copy.go:413
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1456
+#: cmd/incus/image.go:1477
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6309,13 +6321,13 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1029 cmd/incus/project.go:1199 cmd/incus/remote.go:931
+#: cmd/incus/project.go:1051 cmd/incus/project.go:1223 cmd/incus/remote.go:931
 #: cmd/incus/remote.go:1012 cmd/incus/remote.go:1077 cmd/incus/remote.go:1125
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:316
+#: cmd/incus/remote.go:317
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
@@ -6330,40 +6342,40 @@ msgstr ""
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:310
+#: cmd/incus/remote.go:311
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:120
+#: cmd/incus/remote.go:121
 msgid "Remote trust token"
 msgstr ""
 
-#: cmd/incus/info.go:311
+#: cmd/incus/info.go:313
 #, c-format
 msgid "Removable: %v"
 msgstr ""
 
-#: cmd/incus/delete.go:48
+#: cmd/incus/delete.go:50
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:229
+#: cmd/incus/project.go:234
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
 "networks, ...) (yes/no): "
 msgstr ""
 
-#: cmd/incus/cluster_group.go:621
+#: cmd/incus/cluster_group.go:622
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:692 cmd/incus/cluster.go:693
+#: cmd/incus/cluster.go:709 cmd/incus/cluster.go:710
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1595
+#: cmd/incus/network_zone.go:1633
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -6375,44 +6387,44 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1171
+#: cmd/incus/network_forward.go:1030 cmd/incus/network_load_balancer.go:1198
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1034
+#: cmd/incus/network_acl.go:1061
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:1003
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:1002
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1596
+#: cmd/incus/network_zone.go:1634
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: cmd/incus/config_device.go:501 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:512 cmd/incus/config_device.go:513
 msgid "Remove instance devices"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:621
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1006 cmd/incus/network_forward.go:1007
+#: cmd/incus/network_forward.go:1028 cmd/incus/network_forward.go:1029
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1169
-#: cmd/incus/network_load_balancer.go:1170
+#: cmd/incus/network_load_balancer.go:1196
+#: cmd/incus/network_load_balancer.go:1197
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:881 cmd/incus/profile.go:882
+#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6420,49 +6432,49 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:114 cmd/incus/cluster_role.go:115
+#: cmd/incus/cluster_role.go:115 cmd/incus/cluster_role.go:116
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1032 cmd/incus/network_acl.go:1033
+#: cmd/incus/network_acl.go:1059 cmd/incus/network_acl.go:1060
 msgid "Remove rules from an ACL"
 msgstr ""
 
-#: cmd/incus/snapshot.go:252
+#: cmd/incus/snapshot.go:258
 #, c-format
 msgid "Remove snapshot %s from %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/config_trust.go:753 cmd/incus/config_trust.go:754
+#: cmd/incus/config_trust.go:766 cmd/incus/config_trust.go:767
 msgid "Remove trusted client"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:705 cmd/incus/cluster_group.go:706
+#: cmd/incus/cluster_group.go:706 cmd/incus/cluster_group.go:707
 msgid "Rename a cluster group"
 msgstr ""
 
-#: cmd/incus/cluster.go:634 cmd/incus/cluster.go:635
+#: cmd/incus/cluster.go:649 cmd/incus/cluster.go:650
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:376
-#: cmd/incus/image_alias.go:377
+#: cmd/incus/alias.go:172 cmd/incus/alias.go:173 cmd/incus/image_alias.go:385
+#: cmd/incus/image_alias.go:386
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1880 cmd/incus/storage_volume.go:1881
+#: cmd/incus/storage_volume.go:1942 cmd/incus/storage_volume.go:1943
 msgid "Rename custom storage volumes"
 msgstr ""
 
-#: cmd/incus/snapshot.go:452 cmd/incus/snapshot.go:453
+#: cmd/incus/snapshot.go:461 cmd/incus/snapshot.go:462
 msgid "Rename instance snapshots"
 msgstr ""
 
-#: cmd/incus/rename.go:20 cmd/incus/rename.go:21
+#: cmd/incus/rename.go:22 cmd/incus/rename.go:23
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:758 cmd/incus/network_acl.go:759
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:778
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6470,19 +6482,19 @@ msgstr ""
 msgid "Rename network address sets"
 msgstr ""
 
-#: cmd/incus/network_integration.go:562 cmd/incus/network_integration.go:563
+#: cmd/incus/network_integration.go:563 cmd/incus/network_integration.go:564
 msgid "Rename network integrations"
 msgstr ""
 
-#: cmd/incus/network.go:1446 cmd/incus/network.go:1447
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1472
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:969 cmd/incus/profile.go:970
+#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:736 cmd/incus/project.go:737
+#: cmd/incus/project.go:749 cmd/incus/project.go:750
 msgid "Rename projects"
 msgstr ""
 
@@ -6490,281 +6502,281 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2727 cmd/incus/storage_volume.go:2728
+#: cmd/incus/storage_volume.go:2804 cmd/incus/storage_volume.go:2805
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:2005
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2799
+#: cmd/incus/storage_volume.go:2877
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/info.go:149
+#: cmd/incus/info.go:151
 #, c-format
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: cmd/incus/cluster.go:997 cmd/incus/cluster.go:998
+#: cmd/incus/cluster.go:1020 cmd/incus/cluster.go:1021
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: cmd/incus/delete.go:37 cmd/incus/snapshot.go:206
+#: cmd/incus/delete.go:39 cmd/incus/snapshot.go:211
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:689
 msgid "Resources:"
 msgstr ""
 
-#: cmd/incus/action.go:108 cmd/incus/action.go:109
+#: cmd/incus/action.go:105 cmd/incus/action.go:106
 msgid "Restart instances"
 msgstr ""
 
-#: cmd/incus/cluster.go:1481 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1513 cmd/incus/cluster.go:1514
 msgid "Restore cluster member"
 msgstr ""
 
-#: cmd/incus/snapshot.go:514
+#: cmd/incus/snapshot.go:525
 msgid ""
 "Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: cmd/incus/snapshot.go:513
+#: cmd/incus/snapshot.go:524
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2814 cmd/incus/storage_volume.go:2815
+#: cmd/incus/storage_volume.go:2893 cmd/incus/storage_volume.go:2894
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/cluster.go:1546
+#: cmd/incus/cluster.go:1580
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:97 cmd/incus/config_trust.go:180
+#: cmd/incus/config_trust.go:99 cmd/incus/config_trust.go:184
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: cmd/incus/action.go:82 cmd/incus/action.go:83
+#: cmd/incus/action.go:80 cmd/incus/action.go:81
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:46
+#: cmd/incus/console.go:48
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:402
+#: cmd/incus/create.go:405
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:799 cmd/incus/config_trust.go:800
+#: cmd/incus/config_trust.go:814 cmd/incus/config_trust.go:815
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: cmd/incus/cluster.go:1240
+#: cmd/incus/cluster.go:1267
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1054
+#: cmd/incus/storage_bucket.go:1076
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:152
+#: cmd/incus/admin_sql.go:155
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
 
-#: cmd/incus/network_acl.go:891
+#: cmd/incus/network_acl.go:915
 msgid "Rule description"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:36
+#: cmd/incus/remote_unix.go:37
 msgid "Run a local API proxy"
 msgstr ""
 
-#: cmd/incus/remote_unix.go:37
+#: cmd/incus/remote_unix.go:38
 msgid "Run a local API proxy for the remote"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:61
+#: cmd/incus/network_allocations.go:62
 msgid "Run again a specific project"
 msgstr ""
 
-#: cmd/incus/action.go:161
+#: cmd/incus/action.go:156
 msgid "Run against all instances"
 msgstr ""
 
-#: cmd/incus/network_allocations.go:62
+#: cmd/incus/network_allocations.go:63
 msgid "Run against all projects"
 msgstr ""
 
-#: cmd/incus/warning.go:219
+#: cmd/incus/warning.go:223
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1129
+#: cmd/incus/image.go:1150
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:428
 #, c-format
 msgid "SKU: %v"
 msgstr ""
 
-#: cmd/incus/list.go:593
+#: cmd/incus/list.go:515
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: cmd/incus/storage.go:722
+#: cmd/incus/storage.go:735
 msgid "SOURCE"
 msgstr ""
 
-#: cmd/incus/info.go:164 cmd/incus/info.go:273
+#: cmd/incus/info.go:166 cmd/incus/info.go:275
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1601
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1618
+#: cmd/incus/file.go:1631
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1619
+#: cmd/incus/file.go:1632
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: cmd/incus/list.go:597
+#: cmd/incus/list.go:519
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:594 cmd/incus/network.go:1138
-#: cmd/incus/network_peer.go:136 cmd/incus/operation.go:157
-#: cmd/incus/storage.go:724 cmd/incus/warning.go:220
+#: cmd/incus/list.go:516 cmd/incus/network.go:1159
+#: cmd/incus/network_peer.go:139 cmd/incus/operation.go:162
+#: cmd/incus/storage.go:737 cmd/incus/warning.go:224
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/snapshot.go:342
+#: cmd/incus/snapshot.go:349
 msgid "STATEFUL"
 msgstr ""
 
-#: cmd/incus/remote.go:768
+#: cmd/incus/remote.go:769
 msgid "STATIC"
 msgstr ""
 
-#: cmd/incus/cluster.go:181
+#: cmd/incus/cluster.go:184
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:566
+#: cmd/incus/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
-#: cmd/incus/list.go:579
+#: cmd/incus/list.go:501
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:565
+#: cmd/incus/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
-#: cmd/incus/network.go:1027
+#: cmd/incus/network.go:1047
 msgid "STP"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:169
+#: cmd/incus/admin_recover.go:172
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1056
+#: cmd/incus/storage_bucket.go:1078
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1139
+#: cmd/incus/storage_bucket.go:1162
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
 
-#: cmd/incus/query.go:33 cmd/incus/query.go:34
+#: cmd/incus/query.go:34 cmd/incus/query.go:35
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:368
+#: cmd/incus/info.go:370
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:453 cmd/incus/info.go:469
+#: cmd/incus/info.go:455 cmd/incus/info.go:471
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:430
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Serial: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:122
+#: cmd/incus/remote.go:123
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:476
+#: cmd/incus/remote.go:477
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:606
+#: cmd/incus/remote.go:607
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:276 cmd/incus/cluster.go:1180 cmd/incus/cluster.go:1277
-#: cmd/incus/cluster.go:1385 cmd/incus/cluster_group.go:575
+#: cmd/incus/cluster.go:280 cmd/incus/cluster.go:1206 cmd/incus/cluster.go:1305
+#: cmd/incus/cluster.go:1415 cmd/incus/cluster_group.go:576
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:121
+#: cmd/incus/remote.go:122
 msgid "Server protocol (incus, oci or simplestreams)"
 msgstr ""
 
-#: cmd/incus/version.go:58
+#: cmd/incus/version.go:60
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:1035
+#: cmd/incus/image.go:1055
 #, c-format
 msgid "Server: %s"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:974
+#: cmd/incus/cluster_group.go:977
 msgid "Set a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:510
+#: cmd/incus/cluster.go:521
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1369
+#: cmd/incus/file.go:1381
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: cmd/incus/config_device.go:615
+#: cmd/incus/config_device.go:628
 msgid "Set device configuration keys"
 msgstr ""
 
-#: cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:631
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6773,7 +6785,7 @@ msgid ""
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:638
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6782,15 +6794,15 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
+#: cmd/incus/image.go:1665 cmd/incus/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
-#: cmd/incus/config.go:524
+#: cmd/incus/config.go:525
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/config.go:525
+#: cmd/incus/config.go:526
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6799,11 +6811,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:488
+#: cmd/incus/network_acl.go:501
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:489
+#: cmd/incus/network_acl.go:502
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6816,11 +6828,11 @@ msgstr ""
 msgid "Set network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1506
+#: cmd/incus/network.go:1533
 msgid "Set network configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1507
+#: cmd/incus/network.go:1534
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6829,11 +6841,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:522
+#: cmd/incus/network_forward.go:533
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:523
+#: cmd/incus/network_forward.go:534
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6842,11 +6854,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:616
+#: cmd/incus/network_integration.go:617
 msgid "Set network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:617
+#: cmd/incus/network_integration.go:618
 msgid ""
 "Set network integration configuration keys\n"
 "\n"
@@ -6856,11 +6868,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:508
+#: cmd/incus/network_load_balancer.go:519
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:509
+#: cmd/incus/network_load_balancer.go:520
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6869,11 +6881,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:560
+#: cmd/incus/network_peer.go:573
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:561
+#: cmd/incus/network_peer.go:574
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6882,11 +6894,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:506
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:497
+#: cmd/incus/network_zone.go:507
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6895,15 +6907,15 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1195 cmd/incus/network_zone.go:1196
+#: cmd/incus/network_zone.go:1222 cmd/incus/network_zone.go:1223
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1029
+#: cmd/incus/profile.go:1052
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1030
+#: cmd/incus/profile.go:1053
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -6912,11 +6924,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:801
+#: cmd/incus/project.go:816
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:802
+#: cmd/incus/project.go:817
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6925,11 +6937,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:650
+#: cmd/incus/storage_bucket.go:663
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:651
+#: cmd/incus/storage_bucket.go:664
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6938,11 +6950,11 @@ msgid ""
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage.go:836
+#: cmd/incus/storage.go:851
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:837
+#: cmd/incus/storage.go:852
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -6951,11 +6963,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:2024
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1961
+#: cmd/incus/storage_volume.go:2025
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6973,39 +6985,39 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:115
+#: cmd/incus/file.go:116
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:703
+#: cmd/incus/file.go:713
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:118
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:704
+#: cmd/incus/file.go:714
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:116
+#: cmd/incus/file.go:117
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:702
+#: cmd/incus/file.go:712
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:977
+#: cmd/incus/cluster_group.go:980
 msgid "Set the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:513
+#: cmd/incus/cluster.go:524
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:495
+#: cmd/incus/network_acl.go:508
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7013,135 +7025,135 @@ msgstr ""
 msgid "Set the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:530
+#: cmd/incus/network_forward.go:541
 msgid "Set the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:624
+#: cmd/incus/network_integration.go:625
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:516
+#: cmd/incus/network_load_balancer.go:527
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:568
+#: cmd/incus/network_peer.go:581
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1514
+#: cmd/incus/network.go:1541
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:504
+#: cmd/incus/network_zone.go:514
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1201
+#: cmd/incus/network_zone.go:1228
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1037
+#: cmd/incus/profile.go:1060
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:809
+#: cmd/incus/project.go:824
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:658
+#: cmd/incus/storage_bucket.go:671
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:844
+#: cmd/incus/storage.go:859
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1977
+#: cmd/incus/storage_volume.go:2041
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:538
+#: cmd/incus/config.go:539
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1367
+#: cmd/incus/file.go:1379
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: cmd/incus/admin_init.go:62
+#: cmd/incus/admin_init.go:64
 msgid "Setup device based storage using DEVICE"
 msgstr ""
 
-#: cmd/incus/admin_init.go:63
+#: cmd/incus/admin_init.go:65
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:119
+#: cmd/incus/main.go:120
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:120
+#: cmd/incus/main.go:121
 msgid "Show all information messages"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:761 cmd/incus/cluster_group.go:762
+#: cmd/incus/cluster_group.go:762 cmd/incus/cluster_group.go:763
 msgid "Show cluster group configurations"
 msgstr ""
 
-#: cmd/incus/config_template.go:359 cmd/incus/config_template.go:360
+#: cmd/incus/config_template.go:370 cmd/incus/config_template.go:371
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: cmd/incus/cluster.go:321 cmd/incus/cluster.go:322
+#: cmd/incus/cluster.go:326 cmd/incus/cluster.go:327
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: cmd/incus/operation.go:292 cmd/incus/operation.go:293
+#: cmd/incus/operation.go:299 cmd/incus/operation.go:300
 msgid "Show details on a background operation"
 msgstr ""
 
-#: cmd/incus/monitor.go:50
+#: cmd/incus/monitor.go:52
 msgid "Show events from all projects"
 msgstr ""
 
-#: cmd/incus/config_device.go:757 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:772 cmd/incus/config_device.go:773
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1529 cmd/incus/image.go:1530
 msgid "Show image properties"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:186 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_metadata.go:191 cmd/incus/config_metadata.go:192
 msgid "Show instance metadata files"
 msgstr ""
 
-#: cmd/incus/config.go:750 cmd/incus/config.go:751
+#: cmd/incus/config.go:751 cmd/incus/config.go:752
 msgid "Show instance or server configurations"
 msgstr ""
 
-#: cmd/incus/info.go:35 cmd/incus/info.go:36
+#: cmd/incus/info.go:36 cmd/incus/info.go:37
 msgid "Show instance or server information"
 msgstr ""
 
-#: cmd/incus/snapshot.go:592 cmd/incus/snapshot.go:593
+#: cmd/incus/snapshot.go:603 cmd/incus/snapshot.go:604
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:303 cmd/incus/main.go:304
+#: cmd/incus/main.go:304 cmd/incus/main.go:305
 msgid "Show less common commands"
 msgstr ""
 
-#: cmd/incus/version.go:21 cmd/incus/version.go:22
+#: cmd/incus/version.go:22 cmd/incus/version.go:23
 msgid "Show local and remote versions"
 msgstr ""
 
-#: cmd/incus/network_acl.go:193 cmd/incus/network_acl.go:194
+#: cmd/incus/network_acl.go:198 cmd/incus/network_acl.go:199
 msgid "Show network ACL configurations"
 msgstr ""
 
-#: cmd/incus/network_acl.go:254 cmd/incus/network_acl.go:255
+#: cmd/incus/network_acl.go:261 cmd/incus/network_acl.go:262
 msgid "Show network ACL log"
 msgstr ""
 
@@ -7149,64 +7161,64 @@ msgstr ""
 msgid "Show network address set configuration"
 msgstr ""
 
-#: cmd/incus/network.go:1602 cmd/incus/network.go:1603
+#: cmd/incus/network.go:1631 cmd/incus/network.go:1632
 msgid "Show network configurations"
 msgstr ""
 
-#: cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:252
+#: cmd/incus/network_forward.go:256 cmd/incus/network_forward.go:257
 msgid "Show network forward configurations"
 msgstr ""
 
-#: cmd/incus/network_integration.go:730 cmd/incus/network_integration.go:731
+#: cmd/incus/network_integration.go:731 cmd/incus/network_integration.go:732
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:255
-#: cmd/incus/network_load_balancer.go:256
+#: cmd/incus/network_load_balancer.go:260
+#: cmd/incus/network_load_balancer.go:261
 msgid "Show network load balancer configurations"
 msgstr ""
 
-#: cmd/incus/network_peer.go:252 cmd/incus/network_peer.go:253
+#: cmd/incus/network_peer.go:257 cmd/incus/network_peer.go:258
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:257 cmd/incus/network_zone.go:258
+#: cmd/incus/network_zone.go:261 cmd/incus/network_zone.go:262
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:949
+#: cmd/incus/network_zone.go:970
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:950
+#: cmd/incus/network_zone.go:971
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1118 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:933 cmd/incus/project.go:934
+#: cmd/incus/project.go:952 cmd/incus/project.go:953
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:744 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:759 cmd/incus/storage_bucket.go:760
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1353 cmd/incus/storage_bucket.go:1354
+#: cmd/incus/storage_bucket.go:1381 cmd/incus/storage_bucket.go:1382
 msgid "Show storage bucket key configurations"
 msgstr ""
 
-#: cmd/incus/storage.go:940 cmd/incus/storage.go:941
+#: cmd/incus/storage.go:957 cmd/incus/storage.go:958
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2123
+#: cmd/incus/storage_volume.go:2189
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2124
+#: cmd/incus/storage_volume.go:2190
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7218,19 +7230,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2895
+#: cmd/incus/storage_volume.go:2976
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2894
+#: cmd/incus/storage_volume.go:2975
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1323
+#: cmd/incus/storage_volume.go:1344
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1324
+#: cmd/incus/storage_volume.go:1345
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7239,94 +7251,94 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/project.go:1177 cmd/incus/project.go:1178
+#: cmd/incus/project.go:1201 cmd/incus/project.go:1202
 msgid "Show the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:684 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:685 cmd/incus/remote.go:686
 msgid "Show the default remote"
 msgstr ""
 
-#: cmd/incus/config.go:754
+#: cmd/incus/config.go:755
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:46 cmd/incus/project.go:1065
+#: cmd/incus/info.go:47 cmd/incus/project.go:1088
 msgid "Show the instance's access list"
 msgstr ""
 
-#: cmd/incus/info.go:47
+#: cmd/incus/info.go:48
 msgid "Show the instance's recent log entries"
 msgstr ""
 
-#: cmd/incus/info.go:48
+#: cmd/incus/info.go:49
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: cmd/incus/storage.go:944
+#: cmd/incus/storage.go:961
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: cmd/incus/storage.go:494
+#: cmd/incus/storage.go:505
 msgid "Show the used and free space in bytes"
 msgstr ""
 
-#: cmd/incus/config_trust.go:870 cmd/incus/config_trust.go:871
+#: cmd/incus/config_trust.go:887 cmd/incus/config_trust.go:888
 msgid "Show trust configurations"
 msgstr ""
 
-#: cmd/incus/cluster.go:378 cmd/incus/cluster.go:379
+#: cmd/incus/cluster.go:385 cmd/incus/cluster.go:386
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:923 cmd/incus/image.go:924
+#: cmd/incus/image.go:942 cmd/incus/image.go:943
 msgid "Show useful information about images"
 msgstr ""
 
-#: cmd/incus/storage.go:490 cmd/incus/storage.go:491
+#: cmd/incus/storage.go:501 cmd/incus/storage.go:502
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: cmd/incus/warning.go:308 cmd/incus/warning.go:309
+#: cmd/incus/warning.go:315 cmd/incus/warning.go:316
 msgid "Show warning"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:689
+#: cmd/incus/admin_init_interactive.go:695
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: cmd/incus/info.go:304 cmd/incus/info.go:320
+#: cmd/incus/info.go:306 cmd/incus/info.go:322
 #, c-format
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2348
+#: cmd/incus/storage_volume.go:2419
 msgid "Snapshot description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2336 cmd/incus/storage_volume.go:2337
+#: cmd/incus/storage_volume.go:2407 cmd/incus/storage_volume.go:2408
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2064
+#: cmd/incus/storage_volume.go:2129
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1463
+#: cmd/incus/info.go:800 cmd/incus/storage_volume.go:1485
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:511
 #, c-format
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:468
+#: cmd/incus/action.go:462
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7335,13 +7347,13 @@ msgstr ""
 msgid "Sorting Method:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:121
+#: cmd/incus/admin_recover.go:124
 msgid ""
 "Source of the storage pool (block device, volume group, dataset, path, ... "
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:1034
+#: cmd/incus/image.go:1054
 msgid "Source:"
 msgstr ""
 
@@ -7349,75 +7361,75 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, c-format
 msgid "Started: %s"
 msgstr ""
 
-#: cmd/incus/launch.go:117
+#: cmd/incus/launch.go:119
 #, c-format
 msgid "Starting %s"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:239
+#: cmd/incus/admin_recover.go:242
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:755
+#: cmd/incus/info.go:757
 msgid "State"
 msgstr ""
 
-#: cmd/incus/network.go:987
+#: cmd/incus/network.go:1007
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:832
+#: cmd/incus/info.go:834
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Status: %s"
 msgstr ""
 
-#: cmd/incus/action.go:133 cmd/incus/action.go:134
+#: cmd/incus/action.go:129 cmd/incus/action.go:130
 msgid "Stop instances"
 msgstr ""
 
-#: cmd/incus/publish.go:38
+#: cmd/incus/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: cmd/incus/publish.go:153
+#: cmd/incus/publish.go:156
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: cmd/incus/delete.go:125
+#: cmd/incus/delete.go:128
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: cmd/incus/admin_init.go:61
+#: cmd/incus/admin_init.go:63
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:187
+#: cmd/incus/storage_bucket.go:191
 #, c-format
 msgid "Storage bucket %q created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:254
+#: cmd/incus/storage_bucket.go:260
 #, c-format
 msgid "Storage bucket %q deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1160
 #, c-format
 msgid "Storage bucket key %q added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1203
+#: cmd/incus/storage_bucket.go:1228
 #, c-format
 msgid "Storage bucket key %q removed"
 msgstr ""
@@ -7426,94 +7438,94 @@ msgstr ""
 msgid "Storage has already been configured"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:106
+#: cmd/incus/admin_recover.go:109
 #, c-format
 msgid "Storage pool %q is already on recover list"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:202
+#: cmd/incus/admin_recover.go:205
 #, c-format
 msgid "Storage pool %q of type %q"
 msgstr ""
 
-#: cmd/incus/storage.go:201
+#: cmd/incus/storage.go:205
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: cmd/incus/storage.go:261
+#: cmd/incus/storage.go:267
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: cmd/incus/storage.go:199
+#: cmd/incus/storage.go:203
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/storage.go:111
+#: cmd/incus/storage.go:114
 msgid "Storage pool description"
 msgstr ""
 
-#: cmd/incus/copy.go:60 cmd/incus/create.go:61 cmd/incus/import.go:34
-#: cmd/incus/move.go:63
+#: cmd/incus/copy.go:62 cmd/incus/create.go:63 cmd/incus/import.go:35
+#: cmd/incus/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
-#: cmd/incus/admin_init.go:64
+#: cmd/incus/admin_init.go:66
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:678
+#: cmd/incus/storage_volume.go:688
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:752
+#: cmd/incus/storage_volume.go:764
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:490
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:486
+#: cmd/incus/storage_volume.go:494
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2537
+#: cmd/incus/storage_volume.go:2611
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
 
-#: cmd/incus/action.go:164
+#: cmd/incus/action.go:160
 msgid "Store the instance state"
 msgstr ""
 
-#: cmd/incus/cluster.go:1425
+#: cmd/incus/cluster.go:1455
 msgid "Successfully updated cluster certificates"
 msgstr ""
 
-#: cmd/incus/info.go:233
+#: cmd/incus/info.go:235
 #, c-format
 msgid "Supported modes: %s"
 msgstr ""
 
-#: cmd/incus/info.go:237
+#: cmd/incus/info.go:239
 #, c-format
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:728
+#: cmd/incus/info.go:730
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:732
+#: cmd/incus/info.go:734
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:994 cmd/incus/project.go:995
+#: cmd/incus/project.go:1015 cmd/incus/project.go:1016
 msgid "Switch the current project"
 msgstr ""
 
@@ -7521,15 +7533,15 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:146
+#: cmd/incus/file.go:147
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:404
+#: cmd/incus/info.go:406
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:340 cmd/incus/storage_volume.go:2670
+#: cmd/incus/snapshot.go:347 cmd/incus/storage_volume.go:2746
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7537,36 +7549,36 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: cmd/incus/cluster.go:1116 cmd/incus/config_trust.go:633
+#: cmd/incus/cluster.go:1141 cmd/incus/config_trust.go:644
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:439 cmd/incus/image.go:1130
-#: cmd/incus/image_alias.go:250 cmd/incus/list.go:595 cmd/incus/network.go:1132
-#: cmd/incus/network.go:1337 cmd/incus/network_allocations.go:78
-#: cmd/incus/network_integration.go:455 cmd/incus/network_peer.go:135
-#: cmd/incus/operation.go:155 cmd/incus/storage_volume.go:1684
-#: cmd/incus/warning.go:221
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1151
+#: cmd/incus/image_alias.go:257 cmd/incus/list.go:517 cmd/incus/network.go:1153
+#: cmd/incus/network.go:1360 cmd/incus/network_allocations.go:79
+#: cmd/incus/network_integration.go:456 cmd/incus/network_peer.go:138
+#: cmd/incus/operation.go:160 cmd/incus/storage_volume.go:1719
+#: cmd/incus/warning.go:225
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1535
+#: cmd/incus/info.go:832 cmd/incus/info.go:883 cmd/incus/storage_volume.go:1557
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1433
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1414
+#: cmd/incus/file.go:1427
 msgid "Target path must be a directory"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:29
+#: cmd/incus/admin_shutdown.go:31
 msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
-#: cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_shutdown.go:32
 msgid ""
 "Tell the daemon to shutdown all instances and exit\n"
 "\n"
@@ -7577,20 +7589,20 @@ msgid ""
 "  shutdown, especially if a non-standard timeout was configured for them."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:535
+#: cmd/incus/admin_init_interactive.go:537
 #, c-format
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:136
+#: cmd/incus/console.go:139
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:754
+#: cmd/incus/admin_init_interactive.go:760
 msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:742
+#: cmd/incus/admin_init_interactive.go:748
 msgid ""
 "The LVM thin provisioning tools couldn't be found.\n"
 "LVM can still be used without thin provisioning but this will disable over-"
@@ -7604,7 +7616,7 @@ msgid ""
 "before running \"init\" again."
 msgstr ""
 
-#: cmd/incus/admin_cluster.go:47
+#: cmd/incus/admin_cluster.go:49
 msgid ""
 "The \"cluster\" subcommand requires access to internal server data.\n"
 "To do so, it's actually part of the \"incusd\" binary rather than "
@@ -7613,62 +7625,62 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:392
+#: cmd/incus/console.go:399
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
-#: cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:167 cmd/incus/config_device.go:184
+#: cmd/incus/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1023 cmd/incus/network_acl.go:1161
+#: cmd/incus/network_acl.go:1049 cmd/incus/network_acl.go:1190
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:200
+#: cmd/incus/admin_recover.go:203
 msgid "The following unknown storage pools have been found:"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:207
+#: cmd/incus/admin_recover.go:210
 msgid "The following unknown volumes have been found:"
 msgstr ""
 
-#: cmd/incus/delete.go:109
+#: cmd/incus/delete.go:112
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: cmd/incus/publish.go:122
+#: cmd/incus/publish.go:125
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:476
+#: cmd/incus/create.go:479
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: cmd/incus/config.go:652
+#: cmd/incus/config.go:654
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:955
+#: cmd/incus/cluster_group.go:958
 #, c-format
 msgid "The key %q does not exist on cluster group %q"
 msgstr ""
 
-#: cmd/incus/cluster.go:492
+#: cmd/incus/cluster.go:502
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:436
+#: cmd/incus/utils.go:450
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:432
+#: cmd/incus/utils.go:446
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7677,107 +7689,107 @@ msgstr ""
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
-#: cmd/incus/config_device.go:449
+#: cmd/incus/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:946
+#: cmd/incus/cluster_group.go:949
 #, c-format
 msgid "The property %q does not exist on the cluster group %q: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:483
+#: cmd/incus/cluster.go:493
 #, c-format
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:474
+#: cmd/incus/config.go:475
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: cmd/incus/config.go:450
+#: cmd/incus/config.go:451
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:482
+#: cmd/incus/network_load_balancer.go:492
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
 
-#: cmd/incus/network.go:903
+#: cmd/incus/network.go:921
 #, c-format
 msgid "The property %q does not exist on the network %q: %v"
 msgstr ""
 
-#: cmd/incus/network_acl.go:359
+#: cmd/incus/network_acl.go:369
 #, c-format
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:496
+#: cmd/incus/network_forward.go:506
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
 
-#: cmd/incus/network_integration.go:390
+#: cmd/incus/network_integration.go:391
 #, c-format
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:534
+#: cmd/incus/network_peer.go:546
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:369
+#: cmd/incus/network_zone.go:376
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1065
+#: cmd/incus/network_zone.go:1089
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:693
+#: cmd/incus/profile.go:709
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:493
+#: cmd/incus/project.go:503
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:452
+#: cmd/incus/storage_bucket.go:462
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
 
-#: cmd/incus/storage.go:465
+#: cmd/incus/storage.go:475
 #, c-format
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1299
+#: cmd/incus/storage_volume.go:1319
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1271
+#: cmd/incus/storage_volume.go:1291
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/utils_properties.go:100
+#: cmd/incus/utils_properties.go:117
 #, c-format
 msgid "The property with tag %q does not exist"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:151
+#: cmd/incus/admin_recover.go:154
 msgid "The recovery process will be scanning the following storage pools:"
 msgstr ""
 
@@ -7792,18 +7804,18 @@ msgstr ""
 msgid "The requested backend '%s' isn't supported by init"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:319
+#: cmd/incus/admin_init_interactive.go:321
 msgid "The requested interface doesn't exist. Please choose another one."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:356
+#: cmd/incus/admin_init_interactive.go:358
 #, c-format
 msgid ""
 "The requested network bridge \"%s\" already exists. Please choose another "
 "name."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:531
+#: cmd/incus/admin_init_interactive.go:533
 #, c-format
 msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
@@ -7813,28 +7825,28 @@ msgstr ""
 msgid "The server doesn't have a web UI installed"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:397
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:587 cmd/incus/network.go:684
-#: cmd/incus/storage_volume.go:843 cmd/incus/storage_volume.go:940
+#: cmd/incus/network.go:599 cmd/incus/network.go:698
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:956
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: cmd/incus/network.go:591 cmd/incus/network.go:688
+#: cmd/incus/network.go:603 cmd/incus/network.go:702
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:118
+#: cmd/incus/file.go:119
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
-#: cmd/incus/publish.go:95
+#: cmd/incus/publish.go:98
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:343
+#: cmd/incus/main.go:344
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7848,265 +7860,265 @@ msgstr ""
 msgid "This command isn't supported on Windows"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:63
+#: cmd/incus/admin_recover.go:66
 msgid "This server currently has the following storage pools:"
 msgstr ""
 
-#: cmd/incus/cluster.go:846
+#: cmd/incus/cluster.go:866
 msgid "This server is already clustered"
 msgstr ""
 
-#: cmd/incus/cluster.go:836
+#: cmd/incus/cluster.go:856
 msgid "This server is not available on the network"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:347
 msgid "Threads:"
 msgstr ""
 
-#: cmd/incus/action.go:176
+#: cmd/incus/action.go:172
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1016
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:478
+#: cmd/incus/create.go:481
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:477
+#: cmd/incus/create.go:480
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:229
+#: cmd/incus/console.go:232
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:468
+#: cmd/incus/main.go:470
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:387
-#: cmd/incus/network.go:968 cmd/incus/storage.go:531
+#: cmd/incus/config.go:302 cmd/incus/config.go:495 cmd/incus/config.go:703
+#: cmd/incus/config.go:803 cmd/incus/copy.go:146 cmd/incus/info.go:389
+#: cmd/incus/network.go:988 cmd/incus/storage.go:543
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1448
+#: cmd/incus/storage_volume.go:1470
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:520 cmd/incus/info.go:531 cmd/incus/info.go:536
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:522 cmd/incus/info.go:533 cmd/incus/info.go:538
+#: cmd/incus/info.go:544
 #, c-format
 msgid "Total: %v"
 msgstr ""
 
-#: cmd/incus/info.go:245
+#: cmd/incus/info.go:247
 #, c-format
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1791
+#: cmd/incus/storage_volume.go:1851
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/image.go:159
+#: cmd/incus/image.go:164
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365
+#: cmd/incus/storage_volume.go:372
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:59
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:796
+#: cmd/incus/image.go:810
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:365 cmd/incus/move.go:343
+#: cmd/incus/copy.go:369 cmd/incus/move.go:346
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1014
+#: cmd/incus/network.go:1034
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:578
+#: cmd/incus/remote.go:579
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:339 cmd/incus/launch.go:154
+#: cmd/incus/action.go:333 cmd/incus/launch.go:156
 #, c-format
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:754
+#: cmd/incus/info.go:756
 msgid "Type"
 msgstr ""
 
-#: cmd/incus/config_trust.go:183
+#: cmd/incus/config_trust.go:187
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:47
+#: cmd/incus/console.go:49
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:338
+#: cmd/incus/network_peer.go:345
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:301 cmd/incus/info.go:434
-#: cmd/incus/info.go:445 cmd/incus/info.go:651 cmd/incus/network.go:988
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/image.go:1014 cmd/incus/info.go:303 cmd/incus/info.go:436
+#: cmd/incus/info.go:447 cmd/incus/info.go:653 cmd/incus/network.go:1008
+#: cmd/incus/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1131
+#: cmd/incus/project.go:1155
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1131
+#: cmd/incus/image.go:1152
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/remote.go:764
+#: cmd/incus/cluster.go:179 cmd/incus/remote.go:765
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1161 cmd/incus/storage_volume.go:1689
+#: cmd/incus/project.go:1185 cmd/incus/storage_volume.go:1724
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:582
+#: cmd/incus/info.go:584
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:587
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1137 cmd/incus/network_acl.go:174
-#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:76
-#: cmd/incus/network_integration.go:456 cmd/incus/network_zone.go:139
-#: cmd/incus/profile.go:762 cmd/incus/project.go:570 cmd/incus/storage.go:723
-#: cmd/incus/storage_volume.go:1688
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
+#: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
+#: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
+#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
 
-#: cmd/incus/warning.go:222
+#: cmd/incus/warning.go:226
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:160 cmd/incus/info.go:406
+#: cmd/incus/info.go:162 cmd/incus/info.go:408
 #, c-format
 msgid "UUID: %v"
 msgstr ""
 
-#: cmd/incus/admin_init.go:194 cmd/incus/admin_init_interactive.go:219
+#: cmd/incus/admin_init.go:197 cmd/incus/admin_init_interactive.go:221
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:417
+#: cmd/incus/file.go:424
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:232 cmd/incus/remote.go:266
+#: cmd/incus/remote.go:233 cmd/incus/remote.go:267
 msgid "Unavailable remote server"
 msgstr ""
 
-#: cmd/incus/config_trust.go:200
+#: cmd/incus/config_trust.go:205
 #, c-format
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1641
+#: cmd/incus/file.go:1654
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster.go:1131
-#: cmd/incus/cluster_group.go:525 cmd/incus/config_trust.go:462
-#: cmd/incus/config_trust.go:648 cmd/incus/image.go:1148
-#: cmd/incus/image_alias.go:266 cmd/incus/list.go:655 cmd/incus/network.go:1157
-#: cmd/incus/network.go:1355 cmd/incus/network_allocations.go:94
-#: cmd/incus/network_forward.go:157 cmd/incus/network_integration.go:470
-#: cmd/incus/network_load_balancer.go:164 cmd/incus/network_peer.go:150
-#: cmd/incus/network_zone.go:157 cmd/incus/operation.go:177
-#: cmd/incus/profile.go:783 cmd/incus/project.go:585 cmd/incus/remote.go:783
-#: cmd/incus/snapshot.go:356 cmd/incus/storage.go:739
-#: cmd/incus/storage_bucket.go:550 cmd/incus/storage_bucket.go:947
-#: cmd/incus/storage_volume.go:1722 cmd/incus/storage_volume.go:2685
-#: cmd/incus/top.go:98 cmd/incus/warning.go:249
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156
+#: cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469
+#: cmd/incus/config_trust.go:659 cmd/incus/image.go:1167
+#: cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178
+#: cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95
+#: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
+#: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
+#: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
+#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
+#: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
+#: cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:166
+#: cmd/incus/console.go:169
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1175
+#: cmd/incus/file.go:1186
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:956 cmd/incus/network_acl.go:1095
+#: cmd/incus/network_acl.go:980 cmd/incus/network_acl.go:1123
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:115
+#: cmd/incus/console.go:118
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1056
+#: cmd/incus/cluster_group.go:1059
 msgid "Unset a cluster group's configuration keys"
 msgstr ""
 
-#: cmd/incus/cluster.go:590
+#: cmd/incus/cluster.go:603
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: cmd/incus/config_device.go:842 cmd/incus/config_device.go:843
+#: cmd/incus/config_device.go:859 cmd/incus/config_device.go:860
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
+#: cmd/incus/image.go:1731 cmd/incus/image.go:1732
 msgid "Unset image properties"
 msgstr ""
 
-#: cmd/incus/config.go:882 cmd/incus/config.go:883
+#: cmd/incus/config.go:883 cmd/incus/config.go:884
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:576 cmd/incus/network_acl.go:577
+#: cmd/incus/network_acl.go:591 cmd/incus/network_acl.go:592
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -8114,67 +8126,67 @@ msgstr ""
 msgid "Unset network address set configuration keys"
 msgstr ""
 
-#: cmd/incus/network.go:1674 cmd/incus/network.go:1675
+#: cmd/incus/network.go:1705 cmd/incus/network.go:1706
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:632
+#: cmd/incus/network_forward.go:645
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:633
+#: cmd/incus/network_forward.go:646
 msgid "Unset network forward keys"
 msgstr ""
 
-#: cmd/incus/network_integration.go:697 cmd/incus/network_integration.go:698
+#: cmd/incus/network_integration.go:698 cmd/incus/network_integration.go:699
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:618
+#: cmd/incus/network_load_balancer.go:631
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:619
+#: cmd/incus/network_load_balancer.go:632
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:662
+#: cmd/incus/network_peer.go:677
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:663
+#: cmd/incus/network_peer.go:678
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:584 cmd/incus/network_zone.go:585
+#: cmd/incus/network_zone.go:596 cmd/incus/network_zone.go:597
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1284 cmd/incus/network_zone.go:1285
+#: cmd/incus/network_zone.go:1313 cmd/incus/network_zone.go:1314
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1182 cmd/incus/profile.go:1183
+#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:889 cmd/incus/project.go:890
+#: cmd/incus/project.go:906 cmd/incus/project.go:907
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:813 cmd/incus/storage_bucket.go:814
+#: cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:831
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage.go:1034 cmd/incus/storage.go:1035
+#: cmd/incus/storage.go:1053 cmd/incus/storage.go:1054
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2228
+#: cmd/incus/storage_volume.go:2296
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2229
+#: cmd/incus/storage_volume.go:2297
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8183,15 +8195,15 @@ msgid ""
 "machine\"."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:1059
+#: cmd/incus/cluster_group.go:1062
 msgid "Unset the key as a cluster group property"
 msgstr ""
 
-#: cmd/incus/cluster.go:593
+#: cmd/incus/cluster.go:606
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:580
+#: cmd/incus/network_acl.go:595
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8199,78 +8211,78 @@ msgstr ""
 msgid "Unset the key as a network address set property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:636
+#: cmd/incus/network_forward.go:649
 msgid "Unset the key as a network forward property"
 msgstr ""
 
-#: cmd/incus/network_integration.go:702
+#: cmd/incus/network_integration.go:703
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:622
+#: cmd/incus/network_load_balancer.go:635
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:666
+#: cmd/incus/network_peer.go:681
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: cmd/incus/network.go:1679
+#: cmd/incus/network.go:1710
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:588
+#: cmd/incus/network_zone.go:600
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1288
+#: cmd/incus/network_zone.go:1317
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1187
+#: cmd/incus/profile.go:1214
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:894
+#: cmd/incus/project.go:911
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:817
+#: cmd/incus/storage_bucket.go:834
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
-#: cmd/incus/storage.go:1039
+#: cmd/incus/storage.go:1058
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2241
+#: cmd/incus/storage_volume.go:2309
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: cmd/incus/config.go:887
+#: cmd/incus/config.go:888
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:903
+#: cmd/incus/info.go:908
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1015
+#: cmd/incus/network.go:1035
 msgid "Up delay"
 msgstr ""
 
-#: cmd/incus/cluster.go:1328
+#: cmd/incus/cluster.go:1357
 msgid "Update cluster certificate"
 msgstr ""
 
-#: cmd/incus/cluster.go:1330
+#: cmd/incus/cluster.go:1359
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:278
+#: cmd/incus/profile.go:285
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8279,119 +8291,119 @@ msgstr ""
 msgid "Updated interval to %v"
 msgstr ""
 
-#: cmd/incus/image.go:1002
+#: cmd/incus/image.go:1022
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
 
-#: cmd/incus/network.go:1031
+#: cmd/incus/network.go:1051
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1446
+#: cmd/incus/storage_volume.go:1468
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2987
+#: cmd/incus/export.go:43 cmd/incus/storage_volume.go:3070
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:521 cmd/incus/info.go:532 cmd/incus/info.go:537
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Used: %v"
 msgstr ""
 
-#: cmd/incus/exec.go:64
+#: cmd/incus/exec.go:65
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:232
+#: cmd/incus/admin_init_interactive.go:234
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:732 cmd/incus/delete.go:53 cmd/incus/project.go:234
-#: cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:749 cmd/incus/delete.go:55 cmd/incus/project.go:239
+#: cmd/incus/snapshot.go:263
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/info.go:168 cmd/incus/info.go:277
+#: cmd/incus/info.go:170 cmd/incus/info.go:279
 #, c-format
 msgid "VFs: %d"
 msgstr ""
 
-#: cmd/incus/network.go:1039
+#: cmd/incus/network.go:1059
 msgid "VLAN ID"
 msgstr ""
 
-#: cmd/incus/network.go:1030
+#: cmd/incus/network.go:1050
 msgid "VLAN filtering"
 msgstr ""
 
-#: cmd/incus/network.go:1037
+#: cmd/incus/network.go:1057
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:362 cmd/incus/info.go:375
+#: cmd/incus/info.go:364 cmd/incus/info.go:377
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:441 cmd/incus/info.go:461 cmd/incus/info.go:481
+#: cmd/incus/info.go:443 cmd/incus/info.go:463 cmd/incus/info.go:483
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:327 cmd/incus/info.go:361 cmd/incus/info.go:374
-#: cmd/incus/info.go:410
+#: cmd/incus/info.go:329 cmd/incus/info.go:363 cmd/incus/info.go:376
+#: cmd/incus/info.go:412
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
 
-#: cmd/incus/info.go:121 cmd/incus/info.go:207
+#: cmd/incus/info.go:123 cmd/incus/info.go:209
 #, c-format
 msgid "Vendor: %v (%v)"
 msgstr ""
 
-#: cmd/incus/info.go:266
+#: cmd/incus/info.go:268
 #, c-format
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:449 cmd/incus/info.go:473 cmd/incus/info.go:485
+#: cmd/incus/info.go:451 cmd/incus/info.go:475 cmd/incus/info.go:487
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:422
+#: cmd/incus/info.go:424
 #, c-format
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1537
+#: cmd/incus/storage_volume.go:1559
 msgid "Volume Only"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:590
+#: cmd/incus/storage_volume.go:599
 msgid "Volume description"
 msgstr ""
 
-#: cmd/incus/info.go:307
+#: cmd/incus/info.go:309
 #, c-format
 msgid "WWN: %s"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:26
+#: cmd/incus/admin_waitready.go:27
 msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
-#: cmd/incus/admin_waitready.go:27
+#: cmd/incus/admin_waitready.go:28
 msgid ""
 "Wait for the daemon to be ready to process requests\n"
 "\n"
@@ -8401,11 +8413,11 @@ msgid ""
 "  containers."
 msgstr ""
 
-#: cmd/incus/query.go:42
+#: cmd/incus/query.go:43
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:771
+#: cmd/incus/admin_init_interactive.go:777
 msgid ""
 "We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
@@ -8422,235 +8434,235 @@ msgstr ""
 msgid "Web server running at: %s"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:154
+#: cmd/incus/admin_init_interactive.go:156
 msgid "What IP address or DNS name should be used to reach this server?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:368
+#: cmd/incus/admin_init_interactive.go:370
 msgid "What IPv4 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:389
+#: cmd/incus/admin_init_interactive.go:391
 msgid "What IPv6 address should be used?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:120
+#: cmd/incus/admin_init_interactive.go:122
 msgid "What member name should be used to identify this server in the cluster?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:349
+#: cmd/incus/admin_init_interactive.go:351
 msgid "What should the new bridge be called?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:568
+#: cmd/incus/admin_init_interactive.go:570
 msgid "Where should this storage pool store its data?"
 msgstr ""
 
-#: cmd/incus/export.go:40
+#: cmd/incus/export.go:41
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:522
+#: cmd/incus/snapshot.go:533
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
 msgstr ""
 
-#: cmd/incus/snapshot.go:89
+#: cmd/incus/snapshot.go:92
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: cmd/incus/rebuild.go:27
+#: cmd/incus/rebuild.go:29
 msgid ""
 "Wipe the instance root disk and re-initialize with a new image (or empty "
 "volume)."
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:80
+#: cmd/incus/admin_init_interactive.go:82
 msgid "Would you like a YAML \"init\" preseed to be printed?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:846
+#: cmd/incus/admin_init_interactive.go:852
 msgid "Would you like stale cached images to be updated automatically?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:792
+#: cmd/incus/admin_init_interactive.go:798
 msgid "Would you like the server to be available over the network?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:230
+#: cmd/incus/admin_recover.go:233
 msgid "Would you like those to be recovered?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:380
+#: cmd/incus/admin_init_interactive.go:382
 msgid "Would you like to NAT IPv4 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:401
+#: cmd/incus/admin_init_interactive.go:403
 msgid "Would you like to NAT IPv6 traffic on your bridge?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:160
+#: cmd/incus/admin_recover.go:163
 msgid "Would you like to continue with scanning for lost volumes?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:583
+#: cmd/incus/admin_init_interactive.go:585
 #, c-format
 msgid "Would you like to create a new btrfs subvolume under %s?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:299
+#: cmd/incus/admin_init_interactive.go:301
 msgid "Would you like to create a new local network bridge?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:599
+#: cmd/incus/admin_init_interactive.go:601
 msgid "Would you like to create a new zfs dataset under rpool/incus?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:780
+#: cmd/incus/admin_init_interactive.go:786
 msgid "Would you like to have your containers share their parent's allocation?"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:77
+#: cmd/incus/admin_recover.go:80
 msgid "Would you like to recover another storage pool?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:306
+#: cmd/incus/admin_init_interactive.go:308
 msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:655
+#: cmd/incus/admin_init_interactive.go:661
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:110
+#: cmd/incus/admin_init_interactive.go:112
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1177 cmd/incus/operation.go:207
-#: cmd/incus/project.go:602 cmd/incus/project.go:611 cmd/incus/project.go:620
-#: cmd/incus/project.go:629 cmd/incus/project.go:638 cmd/incus/project.go:647
-#: cmd/incus/remote.go:829 cmd/incus/remote.go:838 cmd/incus/remote.go:847
+#: cmd/incus/network.go:1198 cmd/incus/operation.go:212
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:640 cmd/incus/project.go:649 cmd/incus/project.go:658
+#: cmd/incus/remote.go:830 cmd/incus/remote.go:839 cmd/incus/remote.go:848
 msgid "YES"
 msgstr ""
 
-#: cmd/incus/admin_recover.go:214
+#: cmd/incus/admin_recover.go:225
 msgid "You are currently missing the following:"
 msgstr ""
 
-#: cmd/incus/exec.go:106
+#: cmd/incus/exec.go:108
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: cmd/incus/exec.go:110
+#: cmd/incus/exec.go:112
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:115
+#: cmd/incus/copy.go:117
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:98 cmd/incus/move.go:250
+#: cmd/incus/copy.go:100 cmd/incus/move.go:253
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: cmd/incus/rebuild.go:120
+#: cmd/incus/rebuild.go:122
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/network_zone.go:404
+#: cmd/incus/network_zone.go:412
 msgid "Zone description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:865
+#: cmd/incus/storage_volume.go:880
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252
+#: cmd/incus/storage_volume.go:257
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1074
-#: cmd/incus/cluster_group.go:462 cmd/incus/config_trust.go:400
-#: cmd/incus/config_trust.go:595 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1083 cmd/incus/network_acl.go:91
-#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:413
-#: cmd/incus/network_zone.go:88 cmd/incus/operation.go:111
-#: cmd/incus/profile.go:715 cmd/incus/project.go:515 cmd/incus/storage.go:669
-#: cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:70
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099
+#: cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409
+#: cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33
+#: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
+#: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
+#: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
+#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
+#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
 #: cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
-#: cmd/incus/import.go:25
+#: cmd/incus/import.go:26
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:1326
+#: cmd/incus/cluster.go:1355
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:170
+#: cmd/incus/config_trust.go:174
 msgid "[<remote>:] <cert>"
 msgstr ""
 
-#: cmd/incus/cluster.go:782 cmd/incus/config_trust.go:798
+#: cmd/incus/cluster.go:801 cmd/incus/config_trust.go:813
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1064 cmd/incus/list.go:47
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:186
+#: cmd/incus/image_alias.go:193
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:192 cmd/incus/network_acl.go:253
-#: cmd/incus/network_acl.go:618 cmd/incus/network_acl.go:813
+#: cmd/incus/network_acl.go:197 cmd/incus/network_acl.go:260
+#: cmd/incus/network_acl.go:635 cmd/incus/network_acl.go:834
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:887 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:911 cmd/incus/network_acl.go:1058
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:309 cmd/incus/network_acl.go:575
+#: cmd/incus/network_acl.go:318 cmd/incus/network_acl.go:590
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:487
+#: cmd/incus/network_acl.go:500
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:756
+#: cmd/incus/network_acl.go:775
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:384
+#: cmd/incus/network_acl.go:395
 msgid "[<remote>:]<ACL> [key=value...]"
 msgstr ""
 
-#: cmd/incus/query.go:32
+#: cmd/incus/query.go:33
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:256 cmd/incus/network_zone.go:626
-#: cmd/incus/network_zone.go:752
+#: cmd/incus/network_zone.go:260 cmd/incus/network_zone.go:640
+#: cmd/incus/network_zone.go:768
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:319 cmd/incus/network_zone.go:583
+#: cmd/incus/network_zone.go:325 cmd/incus/network_zone.go:595
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495
+#: cmd/incus/network_zone.go:505
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:394
+#: cmd/incus/network_zone.go:402
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8679,142 +8691,142 @@ msgstr ""
 msgid "[<remote>:]<address-set> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:132
+#: cmd/incus/image_alias.go:137
 msgid "[<remote>:]<alias>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:66
+#: cmd/incus/image_alias.go:69
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:374
+#: cmd/incus/image_alias.go:383
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:276 cmd/incus/config_trust.go:751
-#: cmd/incus/config_trust.go:869
+#: cmd/incus/config_trust.go:283 cmd/incus/config_trust.go:764
+#: cmd/incus/config_trust.go:886
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:277
-#: cmd/incus/cluster_group.go:338 cmd/incus/cluster_group.go:760
+#: cmd/incus/cluster_group.go:187 cmd/incus/cluster_group.go:278
+#: cmd/incus/cluster_group.go:339 cmd/incus/cluster_group.go:761
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:898 cmd/incus/cluster_group.go:1055
+#: cmd/incus/cluster_group.go:901 cmd/incus/cluster_group.go:1058
 msgid "[<remote>:]<group> <key>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:973
+#: cmd/incus/cluster_group.go:976
 msgid "[<remote>:]<group> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:703
+#: cmd/incus/cluster_group.go:704
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:361 cmd/incus/image.go:922 cmd/incus/image.go:1506
+#: cmd/incus/image.go:370 cmd/incus/image.go:941 cmd/incus/image.go:1528
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
+#: cmd/incus/image.go:1597 cmd/incus/image.go:1730
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1638
+#: cmd/incus/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:145
+#: cmd/incus/image.go:150
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: cmd/incus/rebuild.go:25
+#: cmd/incus/rebuild.go:27
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:42 cmd/incus/launch.go:22
+#: cmd/incus/create.go:44 cmd/incus/launch.go:23
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:496
+#: cmd/incus/image.go:507
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:305 cmd/incus/image.go:1422
+#: cmd/incus/image.go:312 cmd/incus/image.go:1442
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
-#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
-#: cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:327 cmd/incus/config_device.go:767
+#: cmd/incus/config_metadata.go:55 cmd/incus/config_metadata.go:190
+#: cmd/incus/config_template.go:295 cmd/incus/console.go:38
+#: cmd/incus/snapshot.go:299
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:214 cmd/incus/config_device.go:837
+#: cmd/incus/config_device.go:219 cmd/incus/config_device.go:854
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:617
+#: cmd/incus/config_device.go:630
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:81
+#: cmd/incus/config_device.go:84
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:398
+#: cmd/incus/config_device.go:407
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: cmd/incus/rename.go:19
+#: cmd/incus/rename.go:21
 msgid "[<remote>:]<instance> <instance>"
 msgstr ""
 
-#: cmd/incus/config_device.go:495
+#: cmd/incus/config_device.go:506
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: cmd/incus/snapshot.go:451
+#: cmd/incus/snapshot.go:460
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:107 cmd/incus/profile.go:880
+#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:181
+#: cmd/incus/profile.go:186
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:200 cmd/incus/snapshot.go:512
+#: cmd/incus/snapshot.go:205 cmd/incus/snapshot.go:523
 msgid "[<remote>:]<instance> <snapshot name>"
 msgstr ""
 
-#: cmd/incus/snapshot.go:591
+#: cmd/incus/snapshot.go:602
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
-#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:358
+#: cmd/incus/config_template.go:67 cmd/incus/config_template.go:136
+#: cmd/incus/config_template.go:193 cmd/incus/config_template.go:369
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:32
+#: cmd/incus/move.go:34
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/snapshot.go:76
+#: cmd/incus/snapshot.go:79
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
-#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:54 cmd/incus/action.go:79
+#: cmd/incus/action.go:104 cmd/incus/action.go:128 cmd/incus/delete.go:31
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
-#: cmd/incus/exec.go:39
+#: cmd/incus/exec.go:40
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
@@ -8822,458 +8834,458 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--format]"
 msgstr ""
 
-#: cmd/incus/export.go:30
+#: cmd/incus/export.go:31
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:382
+#: cmd/incus/file.go:388
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:103
+#: cmd/incus/file.go:104
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:299
+#: cmd/incus/file.go:303
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:468
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1359
+#: cmd/incus/file.go:1371
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
-#: cmd/incus/publish.go:30
+#: cmd/incus/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:320 cmd/incus/cluster.go:377 cmd/incus/cluster.go:690
-#: cmd/incus/cluster.go:875 cmd/incus/cluster.go:1239 cmd/incus/cluster.go:1451
-#: cmd/incus/cluster.go:1480
+#: cmd/incus/cluster.go:325 cmd/incus/cluster.go:384 cmd/incus/cluster.go:707
+#: cmd/incus/cluster.go:896 cmd/incus/cluster.go:1266 cmd/incus/cluster.go:1482
+#: cmd/incus/cluster.go:1512
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:619
-#: cmd/incus/cluster_group.go:822
+#: cmd/incus/cluster_group.go:99 cmd/incus/cluster_group.go:620
+#: cmd/incus/cluster_group.go:824
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: cmd/incus/cluster.go:436 cmd/incus/cluster.go:589
+#: cmd/incus/cluster.go:445 cmd/incus/cluster.go:602
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: cmd/incus/cluster.go:509
+#: cmd/incus/cluster.go:520
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/cluster.go:632
+#: cmd/incus/cluster.go:647
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: cmd/incus/cluster_role.go:49 cmd/incus/cluster_role.go:113
+#: cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:114
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:89
+#: cmd/incus/config_trust.go:91
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
-#: cmd/incus/network_integration.go:729
+#: cmd/incus/network_integration.go:176 cmd/incus/network_integration.go:229
+#: cmd/incus/network_integration.go:730
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:350 cmd/incus/network_integration.go:696
+#: cmd/incus/network_integration.go:351 cmd/incus/network_integration.go:697
 msgid "[<remote>:]<network integration> <key>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:615
+#: cmd/incus/network_integration.go:616
 msgid "[<remote>:]<network integration> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_integration.go:560
+#: cmd/incus/network_integration.go:561
 msgid "[<remote>:]<network integration> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:83
+#: cmd/incus/network_integration.go:84
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:456 cmd/incus/network.go:709 cmd/incus/network.go:926
-#: cmd/incus/network.go:1287 cmd/incus/network.go:1601
-#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:97
-#: cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:465 cmd/incus/network.go:724 cmd/incus/network.go:945
+#: cmd/incus/network.go:1310 cmd/incus/network.go:1630
+#: cmd/incus/network_forward.go:91 cmd/incus/network_load_balancer.go:100
+#: cmd/incus/network_peer.go:87
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: cmd/incus/network.go:515
+#: cmd/incus/network.go:526
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:145
+#: cmd/incus/network.go:148
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:845 cmd/incus/network.go:1673
+#: cmd/incus/network.go:862 cmd/incus/network.go:1704
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: cmd/incus/network.go:1505
+#: cmd/incus/network.go:1532
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:678
-#: cmd/incus/network_forward.go:831 cmd/incus/network_load_balancer.go:254
-#: cmd/incus/network_load_balancer.go:647
-#: cmd/incus/network_load_balancer.go:811
-#: cmd/incus/network_load_balancer.go:1291
+#: cmd/incus/network_forward.go:255 cmd/incus/network_forward.go:693
+#: cmd/incus/network_forward.go:848 cmd/incus/network_load_balancer.go:259
+#: cmd/incus/network_load_balancer.go:662
+#: cmd/incus/network_load_balancer.go:828
+#: cmd/incus/network_load_balancer.go:1319
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:979
+#: cmd/incus/network_load_balancer.go:1001
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:901
+#: cmd/incus/network_load_balancer.go:921
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_forward.go:631
-#: cmd/incus/network_load_balancer.go:439
-#: cmd/incus/network_load_balancer.go:617
+#: cmd/incus/network_forward.go:445 cmd/incus/network_forward.go:644
+#: cmd/incus/network_load_balancer.go:448
+#: cmd/incus/network_load_balancer.go:630
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:521 cmd/incus/network_load_balancer.go:507
+#: cmd/incus/network_forward.go:532 cmd/incus/network_load_balancer.go:518
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1093
+#: cmd/incus/network_load_balancer.go:1118
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:922
+#: cmd/incus/network_forward.go:942
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1005 cmd/incus/network_load_balancer.go:1168
+#: cmd/incus/network_forward.go:1027 cmd/incus/network_load_balancer.go:1195
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:328 cmd/incus/network_load_balancer.go:331
+#: cmd/incus/network_forward.go:335 cmd/incus/network_load_balancer.go:338
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network.go:1444
+#: cmd/incus/network.go:1469
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:251
+#: cmd/incus/network_peer.go:256
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:708 cmd/incus/network_peer.go:844
+#: cmd/incus/network_peer.go:725 cmd/incus/network_peer.go:863
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:323
+#: cmd/incus/network_peer.go:330
 msgid ""
 "[<remote>:]<network> <peer_name> <[target project/]<target network or "
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:474 cmd/incus/network_peer.go:661
+#: cmd/incus/network_peer.go:485 cmd/incus/network_peer.go:676
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:559
+#: cmd/incus/network_peer.go:572
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network.go:612
+#: cmd/incus/network.go:625
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/network.go:242
+#: cmd/incus/network.go:247
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: cmd/incus/network.go:341
+#: cmd/incus/network.go:348
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: cmd/incus/operation.go:60 cmd/incus/operation.go:291
+#: cmd/incus/operation.go:63 cmd/incus/operation.go:298
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:216 cmd/incus/storage.go:275 cmd/incus/storage.go:489
-#: cmd/incus/storage.go:939 cmd/incus/storage_bucket.go:483
+#: cmd/incus/storage.go:221 cmd/incus/storage.go:282 cmd/incus/storage.go:500
+#: cmd/incus/storage.go:956 cmd/incus/storage_bucket.go:494
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1575
+#: cmd/incus/storage_bucket.go:1604
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3146
+#: cmd/incus/storage_volume.go:3231
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:206 cmd/incus/storage_bucket.go:268
-#: cmd/incus/storage_bucket.go:743 cmd/incus/storage_bucket.go:891
+#: cmd/incus/storage_bucket.go:211 cmd/incus/storage_bucket.go:275
+#: cmd/incus/storage_bucket.go:758 cmd/incus/storage_bucket.go:911
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:401 cmd/incus/storage_bucket.go:812
-#: cmd/incus/storage_bucket.go:1042 cmd/incus/storage_bucket.go:1153
-#: cmd/incus/storage_bucket.go:1217 cmd/incus/storage_bucket.go:1352
+#: cmd/incus/storage_bucket.go:410 cmd/incus/storage_bucket.go:829
+#: cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1177
+#: cmd/incus/storage_bucket.go:1243 cmd/incus/storage_bucket.go:1380
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:649
+#: cmd/incus/storage_bucket.go:662
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1424
+#: cmd/incus/storage_bucket.go:1453
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:99
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:100
+#: cmd/incus/storage.go:103
 msgid "[<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage.go:407 cmd/incus/storage.go:1033
+#: cmd/incus/storage.go:416 cmd/incus/storage.go:1052
 msgid "[<remote>:]<pool> <key>"
 msgstr ""
 
-#: cmd/incus/storage.go:835
+#: cmd/incus/storage.go:850
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1879
+#: cmd/incus/storage_volume.go:1941
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:693 cmd/incus/storage_volume.go:2559
+#: cmd/incus/storage_volume.go:704 cmd/incus/storage_volume.go:2634
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:767
+#: cmd/incus/storage_volume.go:780
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161
+#: cmd/incus/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2726
+#: cmd/incus/storage_volume.go:2803
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2469 cmd/incus/storage_volume.go:2813
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2892
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2980
+#: cmd/incus/storage_volume.go:3063
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2406
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:587
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2893
+#: cmd/incus/storage_volume.go:2974
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1585
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:2122
+#: cmd/incus/storage_volume.go:979 cmd/incus/storage_volume.go:1343
+#: cmd/incus/storage_volume.go:2188
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2295
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1959
+#: cmd/incus/storage_volume.go:2023
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1186
+#: cmd/incus/storage_volume.go:1205
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1785
+#: cmd/incus/storage_volume.go:1845
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359
+#: cmd/incus/storage_volume.go:366
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
-#: cmd/incus/profile.go:357 cmd/incus/profile.go:445 cmd/incus/profile.go:504
-#: cmd/incus/profile.go:1117
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
+#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
+#: cmd/incus/profile.go:1142
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/config_device.go:216 cmd/incus/config_device.go:839
+#: cmd/incus/config_device.go:221 cmd/incus/config_device.go:856
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: cmd/incus/config_device.go:624
+#: cmd/incus/config_device.go:637
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:89
+#: cmd/incus/config_device.go:92
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:640 cmd/incus/profile.go:1181
+#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1028
+#: cmd/incus/profile.go:1051
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: cmd/incus/config_device.go:497
+#: cmd/incus/config_device.go:508
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:967
+#: cmd/incus/profile.go:988
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:272
+#: cmd/incus/profile.go:279
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:103 cmd/incus/project.go:206 cmd/incus/project.go:305
-#: cmd/incus/project.go:932 cmd/incus/project.go:993 cmd/incus/project.go:1061
+#: cmd/incus/project.go:106 cmd/incus/project.go:211 cmd/incus/project.go:312
+#: cmd/incus/project.go:951 cmd/incus/project.go:1014 cmd/incus/project.go:1084
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:441 cmd/incus/project.go:888
+#: cmd/incus/project.go:450 cmd/incus/project.go:905
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:800
+#: cmd/incus/project.go:815
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:734
+#: cmd/incus/project.go:747
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:38
+#: cmd/incus/copy.go:40
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: cmd/incus/warning.go:265 cmd/incus/warning.go:307 cmd/incus/warning.go:360
+#: cmd/incus/warning.go:270 cmd/incus/warning.go:314 cmd/incus/warning.go:369
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:865
+#: cmd/incus/network_zone.go:884
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:948 cmd/incus/network_zone.go:1330
-#: cmd/incus/network_zone.go:1459
+#: cmd/incus/network_zone.go:969 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1492
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1012 cmd/incus/network_zone.go:1283
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1312
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1194
+#: cmd/incus/network_zone.go:1221
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1536 cmd/incus/network_zone.go:1594
+#: cmd/incus/network_zone.go:1572 cmd/incus/network_zone.go:1632
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090
+#: cmd/incus/network_zone.go:1115
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: cmd/incus/config.go:93 cmd/incus/config.go:749
+#: cmd/incus/config.go:94 cmd/incus/config.go:750
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
-#: cmd/incus/info.go:34
+#: cmd/incus/info.go:35
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: cmd/incus/config.go:386 cmd/incus/config.go:881
+#: cmd/incus/config.go:387 cmd/incus/config.go:882
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: cmd/incus/config.go:523
+#: cmd/incus/config.go:524
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:107
+#: cmd/incus/remote.go:108
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: cmd/incus/cluster.go:996
+#: cmd/incus/cluster.go:1019
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:646
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:706 cmd/incus/remote.go:798
+#: cmd/incus/project.go:718 cmd/incus/remote.go:799
 msgid "current"
 msgstr ""
 
-#: cmd/incus/storage.go:557
+#: cmd/incus/storage.go:569
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:981
+#: cmd/incus/image.go:1001
 msgid "disabled"
 msgstr ""
 
-#: cmd/incus/storage.go:556
+#: cmd/incus/storage.go:568
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:983
+#: cmd/incus/image.go:1003
 msgid "enabled"
 msgstr ""
 
-#: cmd/incus/info.go:648
+#: cmd/incus/info.go:650
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:460
+#: cmd/incus/action.go:454
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9296,13 +9308,13 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: cmd/incus/cluster.go:879
+#: cmd/incus/cluster.go:900
 msgid ""
 "incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:103
+#: cmd/incus/cluster_group.go:104
 msgid ""
 "incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -9311,7 +9323,7 @@ msgid ""
 "    Reset \"foo\" to only using the \"default\" cluster group."
 msgstr ""
 
-#: cmd/incus/cluster_group.go:191
+#: cmd/incus/cluster_group.go:192
 msgid ""
 "incus cluster group create g1\n"
 "\n"
@@ -9319,7 +9331,7 @@ msgid ""
 "\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:82
+#: cmd/incus/config_device.go:85
 msgid ""
 "incus config device add [<remote>:]instance1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9330,13 +9342,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/config.go:97
+#: cmd/incus/config.go:98
 msgid ""
 "incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: cmd/incus/config.go:530
+#: cmd/incus/config.go:531
 msgid ""
 "incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -9345,7 +9357,7 @@ msgid ""
 "    Will have the server listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: cmd/incus/config_template.go:68
+#: cmd/incus/config_template.go:71
 msgid ""
 "incus config template create u1 t1\n"
 "\n"
@@ -9353,15 +9365,15 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:45
+#: cmd/incus/create.go:47
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9371,7 +9383,7 @@ msgid ""
 "    Creates an ELF format memory dump of the vm1 instance."
 msgstr ""
 
-#: cmd/incus/exec.go:52
+#: cmd/incus/exec.go:53
 msgid ""
 "incus exec c1 bash\n"
 "\tRun the \"bash\" command in instance \"c1\"\n"
@@ -9380,13 +9392,13 @@ msgid ""
 "\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
-#: cmd/incus/export.go:34
+#: cmd/incus/export.go:35
 msgid ""
 "incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:107
+#: cmd/incus/file.go:108
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9394,26 +9406,26 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1363
+#: cmd/incus/file.go:1375
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:464
+#: cmd/incus/file.go:472
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:696
+#: cmd/incus/file.go:706
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:365
+#: cmd/incus/image.go:374
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9422,13 +9434,13 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: cmd/incus/import.go:29
+#: cmd/incus/import.go:30
 msgid ""
 "incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/info.go:38
+#: cmd/incus/info.go:39
 msgid ""
 "incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
@@ -9437,7 +9449,7 @@ msgid ""
 "    For server information."
 msgstr ""
 
-#: cmd/incus/launch.go:26
+#: cmd/incus/launch.go:27
 msgid ""
 "incus launch images:ubuntu/22.04 u1\n"
 "\n"
@@ -9448,19 +9460,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
-#: cmd/incus/list.go:124
+#: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9471,7 +9483,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: cmd/incus/monitor.go:37
+#: cmd/incus/monitor.go:39
 msgid ""
 "incus monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -9483,7 +9495,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:45
+#: cmd/incus/move.go:47
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9497,7 +9509,7 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: cmd/incus/network_acl.go:387
+#: cmd/incus/network_acl.go:398
 msgid ""
 "incus network acl create a1\n"
 "\n"
@@ -9513,7 +9525,7 @@ msgid ""
 "    Create network address set with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network.go:344
+#: cmd/incus/network.go:351
 msgid ""
 "incus network create foo\n"
 "    Create a new network called foo\n"
@@ -9525,7 +9537,7 @@ msgid ""
 "    Create a new OVN network called bar using baz as its uplink network"
 msgstr ""
 
-#: cmd/incus/network_forward.go:331
+#: cmd/incus/network_forward.go:338
 msgid ""
 "incus network forward create n1 127.0.0.1\n"
 "\n"
@@ -9533,24 +9545,24 @@ msgid ""
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:87
+#: cmd/incus/network_integration.go:88
 msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_integration.go:232
+#: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:334
+#: cmd/incus/network_load_balancer.go:341
 msgid ""
 "incus network load-balancer create n1 127.0.0.1\n"
 "\n"
@@ -9559,7 +9571,7 @@ msgid ""
 "config.yaml"
 msgstr ""
 
-#: cmd/incus/network_peer.go:326
+#: cmd/incus/network_peer.go:333
 msgid ""
 "incus network peer create default peer1 web/default\n"
 "    Create a new peering between network \"default\" in the current project "
@@ -9575,7 +9587,7 @@ msgid ""
 "\tin the file config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:405
 msgid ""
 "incus network zone create z1\n"
 "\n"
@@ -9583,7 +9595,7 @@ msgid ""
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1093
+#: cmd/incus/network_zone.go:1118
 msgid ""
 "incus network zone record create z1 r1\n"
 "\n"
@@ -9591,13 +9603,13 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/operation.go:295
+#: cmd/incus/operation.go:302
 msgid ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:191
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9609,7 +9621,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:361
+#: cmd/incus/profile.go:370
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9618,7 +9630,7 @@ msgid ""
 "    Create a profile named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/config_device.go:90
+#: cmd/incus/config_device.go:93
 msgid ""
 "incus profile device add [<remote>:]profile1 <device-name> disk source=/"
 "share/c1 path=/opt\n"
@@ -9629,13 +9641,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:508
+#: cmd/incus/profile.go:521
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:107
+#: cmd/incus/project.go:110
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9644,19 +9656,19 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:309
+#: cmd/incus/project.go:316
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: cmd/incus/query.go:36
+#: cmd/incus/query.go:37
 msgid ""
 "incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:83
+#: cmd/incus/snapshot.go:86
 msgid ""
 "incus snapshot create u1 snap0\n"
 "\tCreate a snapshot of \"u1\" called \"snap0\".\n"
@@ -9666,13 +9678,13 @@ msgid ""
 "\"config.yaml\"."
 msgstr ""
 
-#: cmd/incus/snapshot.go:518
+#: cmd/incus/snapshot.go:529
 msgid ""
 "incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:99
+#: cmd/incus/storage_bucket.go:102
 msgid ""
 "incus storage bucket create p1 b01\n"
 "\tCreate a new storage bucket named b01 in storage pool p1\n"
@@ -9682,31 +9694,31 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:271
+#: cmd/incus/storage_bucket.go:278
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1220
+#: cmd/incus/storage_bucket.go:1246
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1428
+#: cmd/incus/storage_bucket.go:1457
 msgid ""
 "incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1579
+#: cmd/incus/storage_bucket.go:1608
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1045
+#: cmd/incus/storage_bucket.go:1067
 msgid ""
 "incus storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9716,21 +9728,21 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1355
+#: cmd/incus/storage_bucket.go:1383
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:746
+#: cmd/incus/storage_bucket.go:761
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
 "pool."
 msgstr ""
 
-#: cmd/incus/storage.go:104
+#: cmd/incus/storage.go:107
 msgid ""
 "incus storage create s1 dir\n"
 "\n"
@@ -9739,13 +9751,13 @@ msgid ""
 "\t"
 msgstr ""
 
-#: cmd/incus/storage.go:279
+#: cmd/incus/storage.go:286
 msgid ""
 "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:582
+#: cmd/incus/storage_volume.go:591
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9755,7 +9767,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:986
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9765,7 +9777,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1195
+#: cmd/incus/storage_volume.go:1214
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9775,7 +9787,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3150
+#: cmd/incus/storage_volume.go:3235
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9785,7 +9797,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1329
+#: cmd/incus/storage_volume.go:1350
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9795,7 +9807,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1969
+#: cmd/incus/storage_volume.go:2033
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9805,7 +9817,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2131
+#: cmd/incus/storage_volume.go:2197
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9819,7 +9831,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2339
+#: cmd/incus/storage_volume.go:2410
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9829,7 +9841,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2234
+#: cmd/incus/storage_volume.go:2302
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
@@ -9839,66 +9851,66 @@ msgid ""
 "in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage.go:554
+#: cmd/incus/storage.go:566
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:475
+#: cmd/incus/remote.go:476
 msgid "n"
 msgstr ""
 
-#: cmd/incus/storage.go:555
+#: cmd/incus/storage.go:567
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:503 cmd/incus/image.go:971 cmd/incus/image.go:976
-#: cmd/incus/image.go:1188
+#: cmd/incus/config_trust.go:512 cmd/incus/image.go:991 cmd/incus/image.go:996
+#: cmd/incus/image.go:1209
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:467
+#: cmd/incus/remote.go:468
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
-#: cmd/incus/config.go:55
+#: cmd/incus/config.go:56
 msgid "please use `incus profile`"
 msgstr ""
 
-#: cmd/incus/storage.go:559
+#: cmd/incus/storage.go:571
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1530
+#: cmd/incus/file.go:1543
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1489
+#: cmd/incus/file.go:1502
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1442
+#: cmd/incus/file.go:1455
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
-#: cmd/incus/storage.go:558
+#: cmd/incus/storage.go:570
 msgid "total space"
 msgstr ""
 
-#: cmd/incus/version.go:48
+#: cmd/incus/version.go:50
 msgid "unreachable"
 msgstr ""
 
-#: cmd/incus/storage.go:553
+#: cmd/incus/storage.go:565
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:478
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:731 cmd/incus/config_trust.go:500
-#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1185 cmd/incus/project.go:233 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:748 cmd/incus/config_trust.go:509
+#: cmd/incus/delete.go:54 cmd/incus/image.go:993 cmd/incus/image.go:998
+#: cmd/incus/image.go:1206 cmd/incus/project.go:238 cmd/incus/snapshot.go:262
 msgid "yes"
 msgstr ""


### PR DESCRIPTION
This change adds support for filtering storage volumes using a single keyword.

Example:
`storage volumes ls default vol` will return all volumes from the "default" storage that start with `vol`.

Regular expressions are also supported, e.g., `vol.*`.