### PR TITLE
Add generated documentation for network bridge

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1600,6 +1600,432 @@ User keys can be used in search.
 ```
 
 <!-- config group network_address_set-common end -->
+<!-- config group network_bridge-common start -->
+```{config:option} bgp.ipv4.nexthop network_bridge-common
+:condition: "BGP server"
+:default: "local address"
+:shortdesc: "Override the next-hop for advertised prefixes"
+:type: "string"
+
+```
+
+```{config:option} bgp.ipv6.nexthop network_bridge-common
+:condition: "BGP server"
+:default: "local address"
+:shortdesc: "Override the next-hop for advertised prefixes"
+:type: "string"
+
+```
+
+```{config:option} bridge.driver network_bridge-common
+:condition: "-"
+:default: "`native`"
+:shortdesc: "Bridge driver: `native` or `openvswitch`"
+:type: "string"
+
+```
+
+```{config:option} bridge.external_interfaces network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "Comma-separated list of unconfigured network interfaces to include in the bridge"
+:type: "string"
+
+```
+
+```{config:option} bridge.hwaddr network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "MAC address for the bridge"
+:type: "string"
+
+```
+
+```{config:option} bridge.mtu network_bridge-common
+:condition: "-"
+:default: "`1500`"
+:shortdesc: "Bridge MTU (default varies if tunnel in use)"
+:type: "integer"
+
+```
+
+```{config:option} dns.domain network_bridge-common
+:condition: "-"
+:default: "`incus`"
+:shortdesc: "Domain to advertise to DHCP clients and use for DNS resolution"
+:type: "string"
+
+```
+
+```{config:option} dns.mode network_bridge-common
+:condition: "-"
+:default: "`managed`"
+:shortdesc: "DNS registration mode: none for no DNS record, managed for Incus-generated static records or dynamic for client-generated records"
+:type: "string"
+
+```
+
+```{config:option} dns.nameservers network_bridge-common
+:condition: "-"
+:default: "IPv4 and IPv6 address"
+:shortdesc: "DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and IPv6 addresses are also advertised as RDNSS via RA."
+:type: "string"
+
+```
+
+```{config:option} dns.search network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "Full comma-separated domain search list, defaulting to `dns.domain` value"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.forward network_bridge-common
+:condition: "-"
+:default: "`managed`"
+:shortdesc: "Comma-separated list of DNS zone names for forward DNS records"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.reverse.ipv4 network_bridge-common
+:condition: "-"
+:default: "`managed`"
+:shortdesc: "DNS zone name for IPv4 reverse DNS records"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.reverse.ipv6 network_bridge-common
+:condition: "-"
+:default: "`managed`"
+:shortdesc: "DNS zone name for IPv6 reverse DNS records"
+:type: "string"
+
+```
+
+```{config:option} ipv4.address network_bridge-common
+:condition: "standard mode"
+:default: "- (initial value on creation: `auto`)"
+:shortdesc: "IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp network_bridge-common
+:condition: "IPv4 address"
+:default: "`true`"
+:shortdesc: "Whether to allocate addresses using DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.dhcp.expiry network_bridge-common
+:condition: "IPv4 DHCP"
+:default: "`1h`"
+:shortdesc: "When to expire DHCP leases"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.gateway network_bridge-common
+:condition: "IPv4 DHCP"
+:default: "all addresses"
+:shortdesc: "Address of the gateway for the subnet"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.ranges network_bridge-common
+:condition: "IPv4 DHCP"
+:default: "all addresses"
+:shortdesc: "Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.routes network_bridge-common
+:condition: "IPv4 DHCP"
+:default: "-"
+:shortdesc: "Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.firewall network_bridge-common
+:condition: "IPv4 address"
+:default: "`true`"
+:shortdesc: "Whether to generate filtering firewall rules for this network"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.nat network_bridge-common
+:condition: "IPv4 address"
+:default: "`false`(initial value on creation if `ipv4.address` is set to `auto`: `true`)"
+:shortdesc: "Whether to NAT"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.nat.address network_bridge-common
+:condition: "IPv4 address"
+:default: "-"
+:shortdesc: "The source address used for outbound traffic from the bridge"
+:type: "string"
+
+```
+
+```{config:option} ipv4.nat.order network_bridge-common
+:condition: "IPv4 address"
+:default: "`before`"
+:shortdesc: "Whether to add the required NAT rules before or after any pre-existing rules"
+:type: "string"
+
+```
+
+```{config:option} ipv4.ovn.ranges network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.routes network_bridge-common
+:condition: "IPv4 address"
+:default: "-"
+:shortdesc: "Comma-separated list of additional IPv4 CIDR subnets to route to the bridge"
+:type: "string"
+
+```
+
+```{config:option} ipv4.routing network_bridge-common
+:condition: "IPv4 DHCP"
+:default: "`true`"
+:shortdesc: "Whether to route traffic in and out of the bridge"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.address network_bridge-common
+:condition: "standard mode"
+:default: "- (initial value on creation: `auto`)"
+:shortdesc: "IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)"
+:type: "string"
+
+```
+
+```{config:option} ipv6.dhcp network_bridge-common
+:condition: "IPv6 DHCP"
+:default: "`true`"
+:shortdesc: "Whether to provide additional network configuration over DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.dhcp.expiry network_bridge-common
+:condition: "IPv6 DHCP"
+:default: "`1h`"
+:shortdesc: "When to expire DHCP leases"
+:type: "string"
+
+```
+
+```{config:option} ipv6.dhcp.ranges network_bridge-common
+:condition: "IPv6 stateful DHCP"
+:default: "all addresses"
+:shortdesc: "Comma-separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)"
+:type: "string"
+
+```
+
+```{config:option} ipv6.dhcp.stateful network_bridge-common
+:condition: "IPv6 DHCP"
+:default: "`false`"
+:shortdesc: "Whether to allocate addresses using DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.firewall network_bridge-common
+:condition: "IPv6 address"
+:default: "`true`"
+:shortdesc: "Whether to generate filtering firewall rules for this network"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.nat network_bridge-common
+:condition: "IPv6 address"
+:default: "`false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)"
+:shortdesc: "Whether to NAT"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.nat.address network_bridge-common
+:condition: "IPv6 address"
+:default: "-"
+:shortdesc: "The source address used for outbound traffic from the bridge"
+:type: "string"
+
+```
+
+```{config:option} ipv6.nat.order network_bridge-common
+:condition: "IPv6 address"
+:default: "`before`"
+:shortdesc: "Whether to add the required NAT rules before or after any pre-existing rules"
+:type: "string"
+
+```
+
+```{config:option} ipv6.ovn.ranges network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)"
+:type: "string"
+
+```
+
+```{config:option} ipv6.routes network_bridge-common
+:condition: "IPv6"
+:default: "-"
+:shortdesc: "Comma-separated list of additional IPv6 CIDR subnets to route to the bridge"
+:type: "string"
+
+```
+
+```{config:option} ipv6.routing network_bridge-common
+:condition: "IPv6 address"
+:default: "`true`"
+:shortdesc: "Whether to route traffic in and out of the bridge"
+:type: "bool"
+
+```
+
+```{config:option} raw.dnsmasq network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "Additional dnsmasq configuration to append to the configuration file"
+:type: "string"
+
+```
+
+```{config:option} security.acls network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "Comma-separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)"
+:type: "string"
+
+```
+
+```{config:option} security.acls.default.egress.action network_bridge-common
+:condition: "`security.acls`"
+:default: "`reject`"
+:shortdesc: "Action to use for egress traffic that doesn't match any ACL rule"
+:type: "string"
+
+```
+
+```{config:option} security.acls.default.egress.logged network_bridge-common
+:condition: "`security.acls`"
+:default: "`false`"
+:shortdesc: "Whether to log egress traffic that doesn't match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} security.acls.default.ingress.action network_bridge-common
+:condition: "`security.acls`"
+:default: "`reject`"
+:shortdesc: "Action to use for ingress traffic that doesn't match any ACL rule"
+:type: "string"
+
+```
+
+```{config:option} security.acls.default.ingress.logged network_bridge-common
+:condition: "`security.acls`"
+:default: "`false`"
+:shortdesc: "Whether to log ingress traffic that doesn't match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} tunnel.NAME.group network_bridge-common
+:condition: "`vxlan`"
+:default: "`239.0.0.1`"
+:shortdesc: "Multicast address for `vxlan` (used if local and remote aren't set)"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.id network_bridge-common
+:condition: "`vxlan`"
+:default: "`0`"
+:shortdesc: "Specific tunnel ID to use for the `vxlan` tunnel"
+:type: "integer"
+
+```
+
+```{config:option} tunnel.NAME.interface network_bridge-common
+:condition: "`vxlan`"
+:default: "-"
+:shortdesc: "Specific host interface to use for the tunnel"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.local network_bridge-common
+:condition: "`gre` or `vxlan`"
+:default: "-"
+:shortdesc: "Local address for the tunnel (not necessary for multicast `vxlan`)"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.port network_bridge-common
+:condition: "`vxlan`"
+:default: "`0`"
+:shortdesc: "Specific port to use for the `vxlan` tunnel"
+:type: "integer"
+
+```
+
+```{config:option} tunnel.NAME.protocol network_bridge-common
+:condition: "standard mode"
+:default: "-"
+:shortdesc: "Tunneling protocol: `vxlan` or `gre`"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.remote network_bridge-common
+:condition: "`gre` or `vxlan`"
+:default: "-"
+:shortdesc: "Remote address for the tunnel (not necessary for multicast `vxlan`)"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.ttl network_bridge-common
+:condition: "`vxlan`"
+:default: "`1`"
+:shortdesc: "Specific TTL to use for multicast routing topologies"
+:type: "integer"
+
+```
+
+```{config:option} user.* network_bridge-common
+:condition: "-"
+:default: "-"
+:shortdesc: "User-provided free-form key/value pairs"
+:type: "string"
+
+```
+
+<!-- config group network_bridge-common end -->
 <!-- config group network_integration-common start -->
 ```{config:option} user.* network_integration-common
 :shortdesc: "Free form user key/value storage"

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -52,65 +52,11 @@ The following configuration key namespaces are currently supported for the `brid
 
 The following configuration options are available for the `bridge` network type:
 
-Key                                  | Type      | Condition             | Default                   | Description
-:--                                  | :--       | :--                   | :--                       | :--
-`bgp.peers.NAME.address`             | string    | BGP server            | -                         | Peer address (IPv4 or IPv6)
-`bgp.peers.NAME.asn`                 | integer   | BGP server            | -                         | Peer AS number
-`bgp.peers.NAME.password`            | string    | BGP server            | - (no password)           | Peer session password (optional)
-`bgp.peers.NAME.holdtime`            | integer   | BGP server            | `180`                     | Peer session hold time (in seconds; optional)
-`bgp.ipv4.nexthop`                   | string    | BGP server            | local address             | Override the next-hop for advertised prefixes
-`bgp.ipv6.nexthop`                   | string    | BGP server            | local address             | Override the next-hop for advertised prefixes
-`bridge.driver`                      | string    | -                     | `native`                  | Bridge driver: `native` or `openvswitch`
-`bridge.external_interfaces`         | string    | -                     | -                         | Comma-separated list of unconfigured network interfaces to include in the bridge
-`bridge.hwaddr`                      | string    | -                     | -                         | MAC address for the bridge
-`bridge.mtu`                         | integer   | -                     | `1500`                    | Bridge MTU (default varies if tunnel in use)
-`dns.nameservers`                    | string    | -                     | IPv4 and IPv6 address     | DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and IPv6 addresses are also advertised as RDNSS via RA.
-`dns.domain`                         | string    | -                     | `incus`                   | Domain to advertise to DHCP clients and use for DNS resolution
-`dns.mode`                           | string    | -                     | `managed`                 | DNS registration mode: `none` for no DNS record, `managed` for Incus-generated static records or `dynamic` for client-generated records
-`dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value
-`dns.zone.forward`                   | string    | -                     | `managed`                 | Comma-separated list of DNS zone names for forward DNS records
-`dns.zone.reverse.ipv4`              | string    | -                     | `managed`                 | DNS zone name for IPv4 reverse DNS records
-`dns.zone.reverse.ipv6`              | string    | -                     | `managed`                 | DNS zone name for IPv6 reverse DNS records
-`ipv4.address`                       | string    | standard mode         | - (initial value on creation: `auto`) | IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)
-`ipv4.dhcp`                          | bool      | IPv4 address          | `true`                    | Whether to allocate addresses using DHCP
-`ipv4.dhcp.expiry`                   | string    | IPv4 DHCP             | `1h`                      | When to expire DHCP leases
-`ipv4.dhcp.gateway`                  | string    | IPv4 DHCP             | IPv4 address              | Address of the gateway for the subnet
-`ipv4.dhcp.ranges`                   | string    | IPv4 DHCP             | all addresses             | Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)
-`ipv4.dhcp.routes`                   | string    | IPv4 DHCP             | -                         | Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq)
-`ipv4.firewall`                      | bool      | IPv4 address          | `true`                    | Whether to generate filtering firewall rules for this network
-`ipv4.nat`                           | bool      | IPv4 address          | `false` (initial value on creation if `ipv4.address` is set to `auto`: `true`) | Whether to NAT
-`ipv4.nat.address`                   | string    | IPv4 address          | -                         | The source address used for outbound traffic from the bridge
-`ipv4.nat.order`                     | string    | IPv4 address          | `before`                  | Whether to add the required NAT rules before or after any pre-existing rules
-`ipv4.ovn.ranges`                    | string    | -                     | -                         | Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
-`ipv4.routes`                        | string    | IPv4 address          | -                         | Comma-separated list of additional IPv4 CIDR subnets to route to the bridge
-`ipv4.routing`                       | bool      | IPv4 address          | `true`                    | Whether to route traffic in and out of the bridge
-`ipv6.address`                       | string    | standard mode         | - (initial value on creation: `auto`) | IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)
-`ipv6.dhcp`                          | bool      | IPv6 address          | `true`                    | Whether to provide additional network configuration over DHCP
-`ipv6.dhcp.expiry`                   | string    | IPv6 DHCP             | `1h`                      | When to expire DHCP leases
-`ipv6.dhcp.ranges`                   | string    | IPv6 stateful DHCP    | all addresses             | Comma-separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)
-`ipv6.dhcp.stateful`                 | bool      | IPv6 DHCP             | `false`                   | Whether to allocate addresses using DHCP
-`ipv6.firewall`                      | bool      | IPv6 address          | `true`                    | Whether to generate filtering firewall rules for this network
-`ipv6.nat`                           | bool      | IPv6 address          | `false` (initial value on creation if `ipv6.address` is set to `auto`: `true`) | Whether to NAT
-`ipv6.nat.address`                   | string    | IPv6 address          | -                         | The source address used for outbound traffic from the bridge
-`ipv6.nat.order`                     | string    | IPv6 address          | `before`                  | Whether to add the required NAT rules before or after any pre-existing rules
-`ipv6.ovn.ranges`                    | string    | -                     | -                         | Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
-`ipv6.routes`                        | string    | IPv6 address          | -                         | Comma-separated list of additional IPv6 CIDR subnets to route to the bridge
-`ipv6.routing`                       | bool      | IPv6 address          | `true`                    | Whether to route traffic in and out of the bridge
-`raw.dnsmasq`                        | string    | -                     | -                         | Additional `dnsmasq` configuration to append to the configuration file
-`security.acls`                      | string    | -                     | -                         | Comma-separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)
-`security.acls.default.egress.action`| string    | `security.acls`       | `reject`                  | Action to use for egress traffic that doesn't match any ACL rule
-`security.acls.default.egress.logged`| bool      | `security.acls`       | `false`                   | Whether to log egress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.action`| string    | `security.acls`      | `reject`                  | Action to use for ingress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.logged`| bool      | `security.acls`      | `false`                   | Whether to log ingress traffic that doesn't match any ACL rule
-`tunnel.NAME.group`                  | string    | `vxlan`               | `239.0.0.1`               | Multicast address for `vxlan` (used if local and remote aren't set)
-`tunnel.NAME.id`                     | integer   | `vxlan`               | `0`                       | Specific tunnel ID to use for the `vxlan` tunnel
-`tunnel.NAME.interface`              | string    | `vxlan`               | -                         | Specific host interface to use for the tunnel
-`tunnel.NAME.local`                  | string    | `gre` or `vxlan`      | -                         | Local address for the tunnel (not necessary for multicast `vxlan`)
-`tunnel.NAME.port`                   | integer   | `vxlan`               | `0`                       | Specific port to use for the `vxlan` tunnel
-`tunnel.NAME.protocol`               | string    | standard mode         | -                         | Tunneling protocol: `vxlan` or `gre`
-`tunnel.NAME.remote`                 | string    | `gre` or `vxlan`      | -                         | Remote address for the tunnel (not necessary for multicast `vxlan`)
-`tunnel.NAME.ttl`                    | integer   | `vxlan`               | `1`                       | Specific TTL to use for multicast routing topologies
-`user.*`                             | string    | -                     | -                         | User-provided free-form key/value pairs
+% Include content from [config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group network_bridge-common start -->
+    :end-before: <!-- config group network_bridge-common end -->
+```
 
 ```{note}
 The `bridge.external_interfaces` option supports an extended format allowing the creation of missing VLAN interfaces.

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1761,6 +1761,489 @@
 				]
 			}
 		},
+		"network_bridge": {
+			"common": {
+				"keys": [
+					{
+						"bgp.ipv4.nexthop": {
+							"condition": "BGP server",
+							"default": "local address",
+							"longdesc": "",
+							"shortdesc": "Override the next-hop for advertised prefixes",
+							"type": "string"
+						}
+					},
+					{
+						"bgp.ipv6.nexthop": {
+							"condition": "BGP server",
+							"default": "local address",
+							"longdesc": "",
+							"shortdesc": "Override the next-hop for advertised prefixes",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.driver": {
+							"condition": "-",
+							"default": "`native`",
+							"longdesc": "",
+							"shortdesc": "Bridge driver: `native` or `openvswitch`",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.external_interfaces": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of unconfigured network interfaces to include in the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.hwaddr": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "MAC address for the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.mtu": {
+							"condition": "-",
+							"default": "`1500`",
+							"longdesc": "",
+							"shortdesc": "Bridge MTU (default varies if tunnel in use)",
+							"type": "integer"
+						}
+					},
+					{
+						"dns.domain": {
+							"condition": "-",
+							"default": "`incus`",
+							"longdesc": "",
+							"shortdesc": "Domain to advertise to DHCP clients and use for DNS resolution",
+							"type": "string"
+						}
+					},
+					{
+						"dns.mode": {
+							"condition": "-",
+							"default": "`managed`",
+							"longdesc": "",
+							"shortdesc": "DNS registration mode: none for no DNS record, managed for Incus-generated static records or dynamic for client-generated records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.nameservers": {
+							"condition": "-",
+							"default": "IPv4 and IPv6 address",
+							"longdesc": "",
+							"shortdesc": "DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and IPv6 addresses are also advertised as RDNSS via RA.",
+							"type": "string"
+						}
+					},
+					{
+						"dns.search": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Full comma-separated domain search list, defaulting to `dns.domain` value",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.forward": {
+							"condition": "-",
+							"default": "`managed`",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of DNS zone names for forward DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.reverse.ipv4": {
+							"condition": "-",
+							"default": "`managed`",
+							"longdesc": "",
+							"shortdesc": "DNS zone name for IPv4 reverse DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.reverse.ipv6": {
+							"condition": "-",
+							"default": "`managed`",
+							"longdesc": "",
+							"shortdesc": "DNS zone name for IPv6 reverse DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"condition": "standard mode",
+							"default": "- (initial value on creation: `auto`)",
+							"longdesc": "",
+							"shortdesc": "IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp": {
+							"condition": "IPv4 address",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to allocate addresses using DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.dhcp.expiry": {
+							"condition": "IPv4 DHCP",
+							"default": "`1h`",
+							"longdesc": "",
+							"shortdesc": "When to expire DHCP leases",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.gateway": {
+							"condition": "IPv4 DHCP",
+							"default": "all addresses",
+							"longdesc": "",
+							"shortdesc": "Address of the gateway for the subnet",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.ranges": {
+							"condition": "IPv4 DHCP",
+							"default": "all addresses",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.routes": {
+							"condition": "IPv4 DHCP",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.firewall": {
+							"condition": "IPv4 address",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to generate filtering firewall rules for this network",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.nat": {
+							"condition": "IPv4 address",
+							"default": "`false`(initial value on creation if `ipv4.address` is set to `auto`: `true`)",
+							"longdesc": "",
+							"shortdesc": "Whether to NAT",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.nat.address": {
+							"condition": "IPv4 address",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "The source address used for outbound traffic from the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.nat.order": {
+							"condition": "IPv4 address",
+							"default": "`before`",
+							"longdesc": "",
+							"shortdesc": "Whether to add the required NAT rules before or after any pre-existing rules",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.ovn.ranges": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes": {
+							"condition": "IPv4 address",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of additional IPv4 CIDR subnets to route to the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routing": {
+							"condition": "IPv4 DHCP",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to route traffic in and out of the bridge",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.address": {
+							"condition": "standard mode",
+							"default": "- (initial value on creation: `auto`)",
+							"longdesc": "",
+							"shortdesc": "IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp": {
+							"condition": "IPv6 DHCP",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to provide additional network configuration over DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.dhcp.expiry": {
+							"condition": "IPv6 DHCP",
+							"default": "`1h`",
+							"longdesc": "",
+							"shortdesc": "When to expire DHCP leases",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp.ranges": {
+							"condition": "IPv6 stateful DHCP",
+							"default": "all addresses",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp.stateful": {
+							"condition": "IPv6 DHCP",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to allocate addresses using DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.firewall": {
+							"condition": "IPv6 address",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to generate filtering firewall rules for this network",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.nat": {
+							"condition": "IPv6 address",
+							"default": "`false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)",
+							"longdesc": "",
+							"shortdesc": "Whether to NAT",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.nat.address": {
+							"condition": "IPv6 address",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "The source address used for outbound traffic from the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.nat.order": {
+							"condition": "IPv6 address",
+							"default": "`before`",
+							"longdesc": "",
+							"shortdesc": "Whether to add the required NAT rules before or after any pre-existing rules",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.ovn.ranges": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes": {
+							"condition": "IPv6",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of additional IPv6 CIDR subnets to route to the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routing": {
+							"condition": "IPv6 address",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to route traffic in and out of the bridge",
+							"type": "bool"
+						}
+					},
+					{
+						"raw.dnsmasq": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Additional dnsmasq configuration to append to the configuration file",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.action": {
+							"condition": "`security.acls`",
+							"default": "`reject`",
+							"longdesc": "",
+							"shortdesc": "Action to use for egress traffic that doesn't match any ACL rule",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.logged": {
+							"condition": "`security.acls`",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to log egress traffic that doesn't match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"security.acls.default.ingress.action": {
+							"condition": "`security.acls`",
+							"default": "`reject`",
+							"longdesc": "",
+							"shortdesc": "Action to use for ingress traffic that doesn't match any ACL rule",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.ingress.logged": {
+							"condition": "`security.acls`",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to log ingress traffic that doesn't match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"tunnel.NAME.group": {
+							"condition": "`vxlan`",
+							"default": "`239.0.0.1`",
+							"longdesc": "",
+							"shortdesc": "Multicast address for `vxlan` (used if local and remote aren't set)",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.id": {
+							"condition": "`vxlan`",
+							"default": "`0`",
+							"longdesc": "",
+							"shortdesc": "Specific tunnel ID to use for the `vxlan` tunnel",
+							"type": "integer"
+						}
+					},
+					{
+						"tunnel.NAME.interface": {
+							"condition": "`vxlan`",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Specific host interface to use for the tunnel",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.local": {
+							"condition": "`gre` or `vxlan`",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Local address for the tunnel (not necessary for multicast `vxlan`)",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.port": {
+							"condition": "`vxlan`",
+							"default": "`0`",
+							"longdesc": "",
+							"shortdesc": "Specific port to use for the `vxlan` tunnel",
+							"type": "integer"
+						}
+					},
+					{
+						"tunnel.NAME.protocol": {
+							"condition": "standard mode",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Tunneling protocol: `vxlan` or `gre`",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.remote": {
+							"condition": "`gre` or `vxlan`",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "Remote address for the tunnel (not necessary for multicast `vxlan`)",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.ttl": {
+							"condition": "`vxlan`",
+							"default": "`1`",
+							"longdesc": "",
+							"shortdesc": "Specific TTL to use for multicast routing topologies",
+							"type": "integer"
+						}
+					},
+					{
+						"user.*": {
+							"condition": "-",
+							"default": "-",
+							"longdesc": "",
+							"shortdesc": "User-provided free-form key/value pairs",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"network_integration": {
 			"common": {
 				"keys": [

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -161,14 +161,63 @@ func (n *bridge) ValidateName(name string) error {
 func (n *bridge) Validate(config map[string]string) error {
 	// Build driver specific rules dynamically.
 	rules := map[string]func(value string) error{
+		// gendoc:generate(entity=network_bridge, group=common, key=bgp.ipv4.nexthop)
+		//
+		// ---
+		//  type: string
+		//  condition: BGP server
+		//  default: local address
+		//  shortdesc: Override the next-hop for advertised prefixes
 		"bgp.ipv4.nexthop": validate.Optional(validate.IsNetworkAddressV4),
+		// gendoc:generate(entity=network_bridge, group=common, key=bgp.ipv6.nexthop)
+		//
+		// ---
+		//  type: string
+		//  condition: BGP server
+		//  default: local address
+		//  shortdesc: Override the next-hop for advertised prefixes
 		"bgp.ipv6.nexthop": validate.Optional(validate.IsNetworkAddressV6),
 
-		"bridge.driver":              validate.Optional(validate.IsOneOf("native", "openvswitch")),
+		// gendoc:generate(entity=network_bridge, group=common, key=bridge.driver)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: `native`
+		//  shortdesc: Bridge driver: `native` or `openvswitch`
+		"bridge.driver": validate.Optional(validate.IsOneOf("native", "openvswitch")),
+		// gendoc:generate(entity=network_bridge, group=common, key=bridge.external_interfaces)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: Comma-separated list of unconfigured network interfaces to include in the bridge
 		"bridge.external_interfaces": validate.Optional(validateExternalInterfaces),
-		"bridge.hwaddr":              validate.Optional(validate.IsNetworkMAC),
-		"bridge.mtu":                 validate.Optional(validate.IsNetworkMTU),
+		// gendoc:generate(entity=network_bridge, group=common, key=bridge.hwaddr)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: MAC address for the bridge
+		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
+		// gendoc:generate(entity=network_bridge, group=common, key=bridge.mtu)
+		//
+		// ---
+		//  type: integer
+		//  condition: -
+		//  default: `1500`
+		//  shortdesc: Bridge MTU (default varies if tunnel in use)
+		"bridge.mtu": validate.Optional(validate.IsNetworkMTU),
 
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.address)
+		//
+		// ---
+		//  type: string
+		//  condition: standard mode
+		//  default: - (initial value on creation: `auto`)
+		//  shortdesc: IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)
 		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -176,19 +225,110 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			return validate.IsNetworkAddressCIDRV4(value)
 		}),
-		"ipv4.firewall":     validate.Optional(validate.IsBool),
-		"ipv4.nat":          validate.Optional(validate.IsBool),
-		"ipv4.nat.order":    validate.Optional(validate.IsOneOf("before", "after")),
-		"ipv4.nat.address":  validate.Optional(validate.IsNetworkAddressV4),
-		"ipv4.dhcp":         validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.firewall)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv4 address
+		//  default: `true`
+		//  shortdesc: Whether to generate filtering firewall rules for this network
+		"ipv4.firewall": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.nat)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv4 address
+		//  default: `false`(initial value on creation if `ipv4.address` is set to `auto`: `true`)
+		//  shortdesc: Whether to NAT
+		"ipv4.nat": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.nat.order)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 address
+		//  default: `before`
+		//  shortdesc: Whether to add the required NAT rules before or after any pre-existing rules
+		"ipv4.nat.order": validate.Optional(validate.IsOneOf("before", "after")),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.nat.address)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 address
+		//  default: -
+		//  shortdesc: The source address used for outbound traffic from the bridge
+		"ipv4.nat.address": validate.Optional(validate.IsNetworkAddressV4),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.dhcp)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv4 address
+		//  default: `true`
+		//  shortdesc: Whether to allocate addresses using DHCP
+		"ipv4.dhcp": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.dhcp.gateway)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 DHCP
+		//  default: all addresses
+		//  shortdesc: Address of the gateway for the subnet
 		"ipv4.dhcp.gateway": validate.Optional(validate.IsNetworkAddressV4),
-		"ipv4.dhcp.expiry":  validate.IsAny,
-		"ipv4.dhcp.ranges":  validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
-		"ipv4.dhcp.routes":  validate.Optional(validate.IsDHCPRouteList),
-		"ipv4.routes":       validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
-		"ipv4.routing":      validate.Optional(validate.IsBool),
-		"ipv4.ovn.ranges":   validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.dhcp.expiry)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 DHCP
+		//  default: `1h`
+		//  shortdesc: When to expire DHCP leases
+		"ipv4.dhcp.expiry": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.dhcp.ranges)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 DHCP
+		//  default: all addresses
+		//  shortdesc: Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)
+		"ipv4.dhcp.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.dhcp.routes)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 DHCP
+		//  default: -
+		//  shortdesc: Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq)
+		"ipv4.dhcp.routes": validate.Optional(validate.IsDHCPRouteList),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.routes)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 address
+		//  default: -
+		//  shortdesc: Comma-separated list of additional IPv4 CIDR subnets to route to the bridge
+		"ipv4.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.routing)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv4 DHCP
+		//  default: `true`
+		//  shortdesc: Whether to route traffic in and out of the bridge
+		"ipv4.routing": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.ovn.ranges)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
+		"ipv4.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
 
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.address)
+		//
+		// ---
+		//  type: string
+		//  condition: standard mode
+		//  default: - (initial value on creation: `auto`)
+		//  shortdesc: IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)
 		"ipv6.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -196,30 +336,201 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			return validate.IsNetworkAddressCIDRV6(value)
 		}),
-		"ipv6.firewall":                        validate.Optional(validate.IsBool),
-		"ipv6.nat":                             validate.Optional(validate.IsBool),
-		"ipv6.nat.order":                       validate.Optional(validate.IsOneOf("before", "after")),
-		"ipv6.nat.address":                     validate.Optional(validate.IsNetworkAddressV6),
-		"ipv6.dhcp":                            validate.Optional(validate.IsBool),
-		"ipv6.dhcp.expiry":                     validate.IsAny,
-		"ipv6.dhcp.stateful":                   validate.Optional(validate.IsBool),
-		"ipv6.dhcp.ranges":                     validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
-		"ipv6.routes":                          validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
-		"ipv6.routing":                         validate.Optional(validate.IsBool),
-		"ipv6.ovn.ranges":                      validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
-		"dns.nameservers":                      validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
-		"dns.domain":                           validate.IsAny,
-		"dns.mode":                             validate.Optional(validate.IsOneOf("dynamic", "managed", "none")),
-		"dns.search":                           validate.IsAny,
-		"dns.zone.forward":                     validate.IsAny,
-		"dns.zone.reverse.ipv4":                validate.IsAny,
-		"dns.zone.reverse.ipv6":                validate.IsAny,
-		"raw.dnsmasq":                          validate.IsAny,
-		"security.acls":                        validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.firewall)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 address
+		//  default: `true`
+		//  shortdesc: Whether to generate filtering firewall rules for this network
+		"ipv6.firewall": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.nat)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 address
+		//  default: `false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)
+		//  shortdesc: Whether to NAT
+		"ipv6.nat": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.nat.order)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv6 address
+		//  default: `before`
+		//  shortdesc: Whether to add the required NAT rules before or after any pre-existing rules
+		"ipv6.nat.order": validate.Optional(validate.IsOneOf("before", "after")),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.nat.address)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv6 address
+		//  default: -
+		//  shortdesc: The source address used for outbound traffic from the bridge
+		"ipv6.nat.address": validate.Optional(validate.IsNetworkAddressV6),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.dhcp)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 DHCP
+		//  default: `true`
+		//  shortdesc: Whether to provide additional network configuration over DHCP
+		"ipv6.dhcp": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.dhcp.expiry)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv6 DHCP
+		//  default: `1h`
+		//  shortdesc: When to expire DHCP leases
+		"ipv6.dhcp.expiry": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.dhcp.stateful)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 DHCP
+		//  default: `false`
+		//  shortdesc: Whether to allocate addresses using DHCP
+		"ipv6.dhcp.stateful": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.dhcp.ranges)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv6 stateful DHCP
+		//  default: all addresses
+		//  shortdesc: Comma-separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)
+		"ipv6.dhcp.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.routes)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv6
+		//  default: -
+		//  shortdesc: Comma-separated list of additional IPv6 CIDR subnets to route to the bridge
+		"ipv6.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.routing)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 address
+		//  default: `true`
+		//  shortdesc: Whether to route traffic in and out of the bridge
+		"ipv6.routing": validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=ipv6.ovn.ranges)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
+		"ipv6.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
+
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.nameservers)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: IPv4 and IPv6 address
+		//  shortdesc: DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and IPv6 addresses are also advertised as RDNSS via RA.
+		"dns.nameservers": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.domain)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: `incus`
+		//  shortdesc: Domain to advertise to DHCP clients and use for DNS resolution
+		"dns.domain": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.mode)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: `managed`
+		//  shortdesc: DNS registration mode: none for no DNS record, managed for Incus-generated static records or dynamic for client-generated records
+		"dns.mode": validate.Optional(validate.IsOneOf("dynamic", "managed", "none")),
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.search)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: Full comma-separated domain search list, defaulting to `dns.domain` value
+		"dns.search": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.zone.forward)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: `managed`
+		//  shortdesc: Comma-separated list of DNS zone names for forward DNS records
+		"dns.zone.forward": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.zone.reverse.ipv4)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: `managed`
+		//  shortdesc: DNS zone name for IPv4 reverse DNS records
+		"dns.zone.reverse.ipv4": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=dns.zone.reverse.ipv6)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: `managed`
+		//  shortdesc: DNS zone name for IPv6 reverse DNS records
+		"dns.zone.reverse.ipv6": validate.IsAny,
+
+		// gendoc:generate(entity=network_bridge, group=common, key=raw.dnsmasq)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: Additional dnsmasq configuration to append to the configuration file
+		"raw.dnsmasq": validate.IsAny,
+
+		// gendoc:generate(entity=network_bridge, group=common, key=security.acls)
+		//
+		// ---
+		//  type: string
+		//  condition: -
+		//  default: -
+		//  shortdesc: Comma-separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)
+		"security.acls": validate.IsAny,
+		// gendoc:generate(entity=network_bridge, group=common, key=security.acls.default.ingress.action)
+		//
+		// ---
+		//  type: string
+		//  condition: `security.acls`
+		//  default: `reject`
+		//  shortdesc: Action to use for ingress traffic that doesn't match any ACL rule
 		"security.acls.default.ingress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
-		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+		// gendoc:generate(entity=network_bridge, group=common, key=security.acls.default.egress.action)
+		//
+		// ---
+		//  type: string
+		//  condition: `security.acls`
+		//  default: `reject`
+		//  shortdesc: Action to use for egress traffic that doesn't match any ACL rule
+		"security.acls.default.egress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+		// gendoc:generate(entity=network_bridge, group=common, key=security.acls.default.ingress.logged)
+		//
+		// ---
+		//  type: bool
+		//  condition: `security.acls`
+		//  default: `false`
+		//  shortdesc: Whether to log ingress traffic that doesn't match any ACL rule
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
-		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
+		// gendoc:generate(entity=network_bridge, group=common, key=security.acls.default.egress.logged)
+		//
+		// ---
+		//  type: bool
+		//  condition: `security.acls`
+		//  default: `false`
+		//  shortdesc: Whether to log egress traffic that doesn't match any ACL rule
+		"security.acls.default.egress.logged": validate.Optional(validate.IsBool),
 	}
 
 	// Add dynamic validation rules.
@@ -241,20 +552,76 @@ func (n *bridge) Validate(config map[string]string) error {
 			// Add the correct validation rule for the dynamic field based on last part of key.
 			switch tunnelKey {
 			case "protocol":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.protocol)
+				//
+				// ---
+				//  type: string
+				//  condition: standard mode
+				//  default: -
+				//  shortdesc: Tunneling protocol: `vxlan` or `gre`
 				rules[k] = validate.Optional(validate.IsOneOf("gre", "vxlan"))
 			case "local":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.local)
+				//
+				// ---
+				//  type: string
+				//  condition: `gre` or `vxlan`
+				//  default: -
+				//  shortdesc: Local address for the tunnel (not necessary for multicast `vxlan`)
 				rules[k] = validate.Optional(validate.IsNetworkAddress)
 			case "remote":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.remote)
+				//
+				// ---
+				//  type: string
+				//  condition: `gre` or `vxlan`
+				//  default: -
+				//  shortdesc: Remote address for the tunnel (not necessary for multicast `vxlan`)
 				rules[k] = validate.Optional(validate.IsNetworkAddress)
 			case "port":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.port)
+				//
+				// ---
+				//  type: integer
+				//  condition: `vxlan`
+				//  default: `0`
+				//  shortdesc: Specific port to use for the `vxlan` tunnel
 				rules[k] = networkValidPort
 			case "group":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.group)
+				//
+				// ---
+				//  type: string
+				//  condition: `vxlan`
+				//  default: `239.0.0.1`
+				//  shortdesc: Multicast address for `vxlan` (used if local and remote aren't set)
 				rules[k] = validate.Optional(validate.IsNetworkAddress)
 			case "id":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.id)
+				//
+				// ---
+				//  type: integer
+				//  condition: `vxlan`
+				//  default: `0`
+				//  shortdesc: Specific tunnel ID to use for the `vxlan` tunnel
 				rules[k] = validate.Optional(validate.IsInt64)
 			case "interface":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.interface)
+				//
+				// ---
+				//  type: string
+				//  condition: `vxlan`
+				//  default: -
+				//  shortdesc: Specific host interface to use for the tunnel
 				rules[k] = validate.IsInterfaceName
 			case "ttl":
+				// gendoc:generate(entity=network_bridge, group=common, key=tunnel.NAME.ttl)
+				//
+				// ---
+				//  type: integer
+				//  condition: `vxlan`
+				//  default: `1`
+				//  shortdesc: Specific TTL to use for multicast routing topologies
 				rules[k] = validate.Optional(validate.IsUint8)
 			}
 		}
@@ -269,6 +636,14 @@ func (n *bridge) Validate(config map[string]string) error {
 	for k, v := range bgpRules {
 		rules[k] = v
 	}
+
+	// gendoc:generate(entity=network_bridge, group=common, key=user.*)
+	//
+	// ---
+	//  type: string
+	//  condition: -
+	//  default: -
+	//  shortdesc: User-provided free-form key/value pairs
 
 	// Validate the configuration.
 	err = n.validate(config, rules)


### PR DESCRIPTION
Resolves #1792 

Ran `make doc-spellcheck` and it dinged me for having "vxlan", "dns", and "openvswitch". However I assume this is okay given that these words are also found in the documentation on the site.

Signed-off-by: Nathan Chase <ntc477@utexas.edu> & Noor Ali <noorali05@utexas.edu>
