### PR TITLE
Implement SNAT as part of network forwards

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -67,6 +67,7 @@ Distrobuilder
 diskful
 Diskless
 diskless
+DNAT
 DNS
 dnsmasq
 DNSSEC
@@ -264,6 +265,7 @@ SIGTERM
 simplestreams
 SLAAC
 SMTP
+SNAT
 Snapcraft
 Solaris
 SPAs

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2784,3 +2784,10 @@ This adds the concept of network address sets to API under the API endpoint pref
 
 This implements a new set of `logging` configuration keys on the server, allowing for multiple logging targets.
 The former `loki` configuration keys are being transitioned over as part of this.
+
+## `network_forward_snat`
+
+Adds a `snat` configuration option for network forwards which will cause any DNAT to get a matching SNAT applied.
+So new connections from the target will appear as coming from the network forward address.
+
+This is limited to bridged networks as OVN doesn't support flexible enough SNAT for this.

--- a/doc/howto/network_forwards.md
+++ b/doc/howto/network_forwards.md
@@ -96,6 +96,12 @@ Property          | Type       | Required | Description
 `target_address`  | string     | yes      | IP address to forward to
 `target_port`     | string     | no       | Target port(s) (e.g. `70,80-90` or `90`), same as `listen_port` if empty
 `description`     | string     | no       | Description of port(s)
+`snat`            | bool       | no       | Whether to place a matching SNAT rule to rewrite any new traffic coming from the target
+
+```{note}
+The `snat` property is currently only supported on managed `bridge` networks and with the `nftables` firewall driver.
+You also need to ensure that the target instance's port(s) aren't covered by multiple forwards to guarantee a consistent external address.
+```
 
 ## Edit a network forward
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -3168,6 +3168,11 @@ definitions:
                 example: tcp
                 type: string
                 x-go-name: Protocol
+            snat:
+                description: SNAT controls whether to apply a matching SNAT rule to new outgoing traffic from the target
+                example: false
+                type: boolean
+                x-go-name: SNAT
             target_address:
                 description: TargetAddress to forward ListenPorts to
                 example: 198.51.100.2

--- a/internal/server/firewall/drivers/drivers_consts.go
+++ b/internal/server/firewall/drivers/drivers_consts.go
@@ -51,6 +51,7 @@ type AddressForward struct {
 	Protocol      string
 	ListenPorts   []uint64
 	TargetPorts   []uint64
+	SNAT          bool
 }
 
 // AddressSet represent an address set.

--- a/internal/server/firewall/drivers/drivers_nftables.go
+++ b/internal/server/firewall/drivers/drivers_nftables.go
@@ -1358,7 +1358,6 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 			targetAddressStr := rule.TargetAddress.String()
 
 			if rule.Protocol != "" {
-
 				targetPortRanges := portRangesFromSlice(rule.TargetPorts)
 
 				for _, targetPortRange := range targetPortRanges {
@@ -1372,7 +1371,6 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 				}
 
 				dnatRanges := getOptimisedDNATRanges(&rule)
-
 				for listenPortRange, targetPortRange := range dnatRanges {
 					// Format the destination host/port as appropriate
 					targetDest := targetAddressStr
@@ -1393,6 +1391,17 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 						"listenPorts":   portRangeStr(listenPortRange, "-"),
 						"targetDest":    targetDest,
 					})
+
+					if rule.SNAT {
+						snatRules = append(snatRules, map[string]any{
+							"ipFamily":      ipFamily,
+							"protocol":      rule.Protocol,
+							"listenAddress": listenAddressStr,
+							"listenPorts":   portRangeStr(listenPortRange, "-"),
+							"targetAddress": targetAddressStr,
+							"targetPorts":   portRangeStr(targetPortRange, "-"),
+						})
+					}
 				}
 			} else {
 				// Format the destination host/port as appropriate.

--- a/internal/server/firewall/drivers/drivers_nftables_templates.go
+++ b/internal/server/firewall/drivers/drivers_nftables_templates.go
@@ -103,7 +103,11 @@ table {{.family}} {{.namespace}} {
 	chain {{.chainPrefix}}pstrt{{.chainSeparator}}{{.label}} {
 		type nat hook postrouting priority 100; policy accept;
 		{{ range .snatRules }}
+		{{ if .targetHost }}
 		{{.ipFamily}} saddr {{.targetHost}} {{.ipFamily}} daddr {{.targetHost}} {{ if .protocol }}{{.protocol}} dport {{.targetPorts}}{{ end }} masquerade
+		{{ else }}
+		{{.ipFamily}} saddr {{.targetAddress}} {{.protocol}} sport {{.targetPorts}} snat to {{.listenAddress}}:{{.listenPorts}}
+		{{ end }}
 		{{ end }}
 	}
 }

--- a/internal/server/firewall/drivers/drivers_xtables.go
+++ b/internal/server/firewall/drivers/drivers_xtables.go
@@ -1580,6 +1580,11 @@ func (d Xtables) NetworkApplyForwards(networkName string, rules []AddressForward
 			targetAddressStr := rule.TargetAddress.String()
 
 			if rule.Protocol != "" {
+				// We don't support SNAT here yet.
+				if rule.SNAT {
+					return fmt.Errorf("SNAT port rules are not supported under xtables")
+				}
+
 				if len(rule.TargetPorts) == 0 {
 					rule.TargetPorts = rule.ListenPorts
 				}

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -2248,6 +2248,7 @@ func (n *bridge) forwardConvertToFirewallForwards(listenAddress net.IP, defaultT
 			TargetAddress: portMap.target.address,
 			ListenPorts:   portMap.listenPorts,
 			TargetPorts:   portMap.target.ports,
+			SNAT:          portMap.snat,
 		})
 	}
 

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -50,6 +50,7 @@ type forwardPortMap struct {
 	listenPorts []uint64
 	protocol    string
 	target      forwardTarget
+	snat        bool
 }
 
 type loadBalancerPortMap struct {
@@ -981,6 +982,7 @@ func (n *common) forwardValidate(listenAddress net.IP, forward *api.NetworkForwa
 				address: targetAddress,
 			},
 			protocol: portSpec.Protocol,
+			snat:     portSpec.SNAT,
 		}
 
 		for _, pr := range listenPortRanges {

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -1001,6 +1001,11 @@ func (n *common) forwardValidate(listenAddress net.IP, forward *api.NetworkForwa
 			}
 		}
 
+		// Check that SNAT is only used with bridges.
+		if portSpec.SNAT && n.netType != "bridge" {
+			return nil, fmt.Errorf("SNAT can only be used with bridge networks")
+		}
+
 		// Check valid target port(s) supplied.
 		targetPortRanges := util.SplitNTrimSpace(portSpec.TargetPort, ",", -1, true)
 

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -478,6 +478,7 @@ var APIExtensions = []string{
 	"instance_oci_entrypoint",
 	"network_address_set",
 	"server_logging",
+	"network_forward_snat",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -30,6 +30,12 @@ type NetworkForwardPort struct {
 	// TargetAddress to forward ListenPorts to
 	// Example: 198.51.100.2
 	TargetAddress string `json:"target_address" yaml:"target_address"`
+
+	// SNAT controls whether to apply a matching SNAT rule to new outgoing traffic from the target
+	// Example: false
+	//
+	// API extension: network_forward_snat
+	SNAT bool `json:"snat" yaml:"snat"`
 }
 
 // Normalise normalises the fields in the rule so that they are comparable with ones stored.


### PR DESCRIPTION
This is primarily meant for environments where a single IP address is mapped to multiple instances using large port ranges with differing source and target ranges.

In that scenario, if the target is to initiate an outgoing connection, the desired behavior is for the external address to be that of the forward and for the external port to be mapped according to the mapping in the forward rule.