### PR TITLE
incusd/apparmor/lxc: Allow write access to /proc/sys/user

### DIFF
--- a/internal/server/apparmor/instance_lxc.profile.go
+++ b/internal/server/apparmor/instance_lxc.profile.go
@@ -330,7 +330,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(rw,move) /sys?*{,/**},
 
   # Block dangerous paths under /proc/sys
-  deny /proc/sys/[^fkn]*{,/**} wklx,
+  deny /proc/sys/[^fknu]*{,/**} wklx,
   deny /proc/sys/f[^s]*{,/**} wklx,
   deny /proc/sys/fs/[^b]*{,/**} wklx,
   deny /proc/sys/fs/b[^i]*{,/**} wklx,
@@ -381,6 +381,10 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny /proc/sys/n[^e]*{,/**} wklx,
   deny /proc/sys/ne[^t]*{,/**} wklx,
   deny /proc/sys/net?*{,/**} wklx,
+  deny /proc/sys/u[^s]*{,/**} wklx,
+  deny /proc/sys/us[^e]*{,/**} wklx,
+  deny /proc/sys/use[^r]*{,/**} wklx,
+  deny /proc/sys/user?*{,/**} wklx,
 
   # Block dangerous paths under /sys
   deny /sys/[^fdck]*{,/**} wklx,


### PR DESCRIPTION
Bubblewrap [2], used by Flatpak [3], attempts to disable further userns creation by writing 1 to `/proc/sys/user/max_user_namespaces` in a new userns, but this fails in a fresh unprivileged Incus container. This is safe even outside Bubblewrap's new userns because the files in `/proc/sys/user` are "the limits for the user namespace in which the opening process resides," [1] which is the Incus-created userns for the unprivileged container.

Reproduce:
```bash
incus launch -c security.nesting=true images:ubuntu/24.04 ubu
incus shell ubu
apt install bubblewrap

 # before changes
bwrap --unshare-user --disable-userns nothing
 #=> bwrap: cannot open /proc/sys/user/max_user_namespaces: Permission denied

 # after changes
bwrap --unshare-user --disable-userns nothing
 #=> bwrap: execvp nothing: No such file or directory
```

See:
[1] `namespaces(7)`: The /proc/sys/user directory
[2] <https://github.com/containers/bubblewrap/blob/main/bubblewrap.c#L3465>
[3] <https://github.com/flatpak/flatpak/blob/main/common/flatpak-run.c#L2238>