### PR TITLE
shared/archive: Prevent xattr errors from crashing unsquashfs

### DIFF
--- a/shared/archive/archive.go
+++ b/shared/archive/archive.go
@@ -189,6 +189,7 @@ func Unpack(file string, path string, blockBackend bool, maxMemory int64, tracke
 		// so ProgressTracker is not possible.
 		command = "unsquashfs"
 		args = append(args, "-f", "-d", path, "-n")
+		args = append(args, "-user-xattrs")
 
 		if maxMemory != 0 {
 			// If maximum memory consumption is less than 256MiB, restrict unsquashfs and limit to a single thread.


### PR DESCRIPTION
When unpacking a SquashFS containing `security.selinux` xattrs, the AppArmor archive profile blocks access to writing these to the FS which crashes unsquashfs (but not tar).

Errors seen:
* unsquashfs: `FATAL ERROR: write_xattr: failed to write xattr security.selinux for file squashfs-root/etc/selinux/targeted/contexts/files/file_contexts because Operation not permitted`
* AA denials: `apparmor="DENIED" operation="capable" class="cap" profile="incus_archive-cf1435b8-7543-419a-87a1-f656442c6e2f" pid=928 comm="unsquashfs" capability=21  capname="sys_admin"` (similar for tar)

I'm not sure my changes are the correct solution for this behavior. I can think of several more:
* Use the `-xattrs-exclude ^security.` to narrow down xattr exclusion (but only works for unsquashfs v4.6+)
* Ignore errors that look like `FATAL ERROR: write_xattr: failed to write xattr security.` along with char/block device errors (but unsure whether the rest of the archive would be extracted)
* Add `sys_admin` capability to archive AA profile to allow writing of `security.*` xattrs (this gives a lot of permissions but it is just a humble unpacking process after all)

Also, tar is similarly blocked by AA from writing these xattrs, but it fails with only an AA denial in syslog and a zero exit code, more or less silently stripping away the xattrs it cannot write. Perhaps it should also explicitly exclude `security.*` xattrs from unpacking? Or benefit from the addition of `cap_sys_admin` to the archive AA profile?

If some xattrs are to be excluded, that should probably be reflected in the documentation.