### PR TITLE
feat: support access_token query parameter as JWT fallback

### DIFF
--- a/test/suites/tls2jwt.sh
+++ b/test/suites/tls2jwt.sh
@@ -15,18 +15,22 @@ test_tls_jwt() {
   # Ensure invalid token is not accepted
   JWT="1234567"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.error_code')" -eq 403 ]
+  [ "$(curl -k -s "https://${INCUS_ADDR}/1.0/networks?access_token=${JWT}" | jq '.error_code')" -eq 403 ]
 
   # Ensure valid token is accepted
   JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.crt" "${INCUS_CONF}/jwt-client.key" now 60)"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.status_code')" -eq 200 ]
+  [ "$(curl -k -s "https://${INCUS_ADDR}/1.0/networks?access_token=${JWT}" | jq '.status_code')" -eq 200 ]
 
   # Ensure token not valid yet is not accepted
   JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.crt" "${INCUS_CONF}/jwt-client.key" "2100-01-01T12:00:00Z" 60)"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.error_code')" -eq 403 ]
+  [ "$(curl -k -s "https://${INCUS_ADDR}/1.0/networks?access_token=${JWT}" | jq '.error_code')" -eq 403 ]
 
   # Ensure token no longer valid is not accepted
   JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.crt" "${INCUS_CONF}/jwt-client.key" now -60)"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.error_code')" -eq 403 ]
+  [ "$(curl -k -s "https://${INCUS_ADDR}/1.0/networks?access_token=${JWT}" | jq '.error_code')" -eq 403 ]
 
   # Cleanup
   incus config trust remove "${FINGERPRINT}"


### PR DESCRIPTION
This update enhances the `CheckJwtToken` function to support scenarios where the JWT token is provided via the `access_token` query parameter instead of the Authorization header.

🔧 Fixes: #1932 

Changes:

- Attempts to extract the token from the Authorization header first (Bearer <token>)
- Falls back to `access_token` query parameter if the header is missing or invalid
- Maintains existing JWT validation: expiration, not-before, and signature verification
- This fix provides compatibility for clients that cannot set headers, such as certain browser-based tools or embedded clients.