### PR TITLE
Add common aliases for add/create remove/delete/rm in the CLI

### DIFF
--- a/cmd/incus-simplestreams/main_add.go
+++ b/cmd/incus-simplestreams/main_add.go
@@ -35,6 +35,7 @@ type cmdAdd struct {
 func (c *cmdAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "add <metadata tarball> [<data file>]"
+	cmd.Aliases = []string{"import"}
 	cmd.Short = "Add an image"
 	cmd.Long = cli.FormatSection("Description",
 		`Add an image to the server

--- a/cmd/incus-simplestreams/main_remove.go
+++ b/cmd/incus-simplestreams/main_remove.go
@@ -23,6 +23,7 @@ type cmdRemove struct {
 func (c *cmdRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "remove <fingerprint>"
+	cmd.Aliases = []string{"rm", "delete"}
 	cmd.Short = "Remove an image"
 	cmd.Long = cli.FormatSection("Description",
 		`Remove an image from the server

--- a/cmd/incus/delete.go
+++ b/cmd/incus/delete.go
@@ -29,7 +29,7 @@ type cmdDelete struct {
 func (c *cmdDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance> [[<remote>:]<instance>...]"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete instances`))


### PR DESCRIPTION
Add `import` and `delete` aliases to `incus-simplestream add/remove` and `remove` alias to `incus delete`