### PR TITLE
Memory hotplug support for VMs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2791,3 +2791,7 @@ Adds a `snat` configuration option for network forwards which will cause any DNA
 So new connections from the target will appear as coming from the network forward address.
 
 This is limited to bridged networks as OVN doesn't support flexible enough SNAT for this.
+
+## `memory_hotplug`
+
+This adds memory hotplugging for VMs, allowing them to add memory at runtime without rebooting.

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -102,12 +102,16 @@ func TestQemuConfigTemplates(t *testing.T) {
 			qemuMemoryOpts{4096},
 			`# Memory
 			[memory]
-			size = "4096M"`,
+			size = "4096M"
+			slots = "16"
+			maxmem = "1T"`,
 		}, {
 			qemuMemoryOpts{8192},
 			`# Memory
 			[memory]
-			size = "8192M"`,
+			size = "8192M"
+			slots = "16"
+			maxmem = "1T"`,
 		}}
 		for _, tc := range testCases {
 			runTest(tc.expected, qemuMemory(&tc.opts))

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -119,10 +119,15 @@ type qemuMemoryOpts struct {
 }
 
 func qemuMemory(opts *qemuMemoryOpts) []cfg.Section {
+	// Sets fixed values for slots and maxmem to support memory hotplug.
 	return []cfg.Section{{
 		Name:    "memory",
 		Comment: "Memory",
-		Entries: []cfg.Entry{{Key: "size", Value: fmt.Sprintf("%dM", opts.memSizeMB)}},
+		Entries: []cfg.Entry{
+			{Key: "size", Value: fmt.Sprintf("%dM", opts.memSizeMB)},
+			{Key: "slots", Value: "16"},
+			{Key: "maxmem", Value: "1T"},
+		},
 	}}
 }
 

--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/internal/server/db"
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/cfg"
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/qmp"
 	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v6/internal/server/state"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
@@ -130,4 +132,117 @@ func ParseMemoryStr(memory string) (valueInt int64, err error) {
 
 func qemuEscapeCmdline(value string) string {
 	return strings.ReplaceAll(value, ",", ",,")
+}
+
+// roundDownToBlockSize returns the largest multiple of blockSize less than or equal to the input value.
+func roundDownToBlockSize(value int64, blockSize int64) int64 {
+	if value%blockSize == 0 {
+		return value
+	}
+
+	return ((value / blockSize) - 1) * blockSize
+}
+
+// memoryConfigSectionToMap converts a memory object of type cfg.Section to type map[string]any.
+func memoryConfigSectionToMap(section *cfg.Section) map[string]any {
+	const blockSize = 128 * 1024 * 1024 // 128MiB
+	obj := map[string]any{}
+	hostNodes := []int{}
+
+	for _, entry := range section.Entries {
+		if strings.HasPrefix(entry.Key, "host-nodes") {
+			hostNode, err := strconv.Atoi(entry.Value)
+			if err != nil {
+				continue
+			}
+
+			hostNodes = append(hostNodes, hostNode)
+		} else if entry.Key == "size" {
+			// Size in the config is specified in the format: 1024M, so the last character needs to be removed before parsing.
+			memSizeMB, err := strconv.Atoi(entry.Value[:len(entry.Value)-1])
+			if err != nil {
+				continue
+			}
+
+			obj["size"] = roundDownToBlockSize(int64(memSizeMB)*1024*1024, blockSize)
+		} else if entry.Key == "merge" || entry.Key == "dump" || entry.Key == "prealloc" || entry.Key == "share" || entry.Key == "reserve" {
+			val := false
+			if entry.Value == "on" {
+				val = true
+			}
+
+			obj[entry.Key] = val
+		} else {
+			obj[entry.Key] = entry.Value
+		}
+	}
+
+	if len(hostNodes) > 0 {
+		obj["host-nodes"] = hostNodes
+	}
+
+	return obj
+}
+
+// extractTrailingNumber extracts the trailing number from a string.
+// For example, given "dimm1", it returns 1.
+func extractTrailingNumber(s string, prefix string) (int, error) {
+	if !strings.HasPrefix(s, prefix) {
+		return -1, fmt.Errorf("Prefix %s not found in %s", prefix, s)
+	}
+
+	trimmed := strings.TrimPrefix(s, prefix)
+	num, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return -1, err
+	}
+
+	return num, nil
+}
+
+// findNextDimmIndex finds the next available index for a pc-dimm device
+// whose ID starts with the prefix "dimm".
+func findNextDimmIndex(monitor *qmp.Monitor) (int, error) {
+	devices, err := monitor.GetDimmDevices()
+	if err != nil {
+		return -1, err
+	}
+
+	index := -1
+	for _, dev := range devices {
+		i, err := extractTrailingNumber(dev.ID, "dimm")
+		if err != nil {
+			continue
+		}
+
+		if i > index {
+			index = i
+		}
+	}
+
+	return index + 1, nil
+}
+
+// findNextMemoryIndex finds the next available index for a memory object
+// whose ID starts with the prefix "mem".
+func findNextMemoryIndex(monitor *qmp.Monitor) (int, error) {
+	memDevs, err := monitor.GetMemdev()
+	if err != nil {
+		return -1, err
+	}
+
+	memIndex := -1
+	for _, mem := range memDevs {
+		var index int
+		index, err := extractTrailingNumber(mem.ID, "mem")
+		if err != nil {
+			continue
+		}
+
+		if index > memIndex {
+			memIndex = index
+		}
+	}
+
+	return memIndex + 1, nil
 }

--- a/internal/server/instance/drivers/util_test.go
+++ b/internal/server/instance/drivers/util_test.go
@@ -1,0 +1,63 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/cfg"
+)
+
+// Test roundDownToBlockSize.
+func TestRoundDownToBlockSize(t *testing.T) {
+	const blockSize = 128 * 1024 * 1024
+
+	value := roundDownToBlockSize(1073741824, blockSize)
+	assert.Equal(t, int64(1073741824), value)
+
+	value = roundDownToBlockSize(1000000000, blockSize)
+	assert.Equal(t, int64(805306368), value)
+}
+
+// Test memoryConfigSectionToMap.
+func TestMemoryConfigSectionToMap(t *testing.T) {
+	result := memoryConfigSectionToMap(
+		&cfg.Section{
+			Name: "object \"mem0\"",
+			Entries: []cfg.Entry{
+				{Key: "size", Value: "1024M"},
+				{Key: "host-nodes.0", Value: "0"},
+				{Key: "host-nodes.1", Value: "1"},
+				{Key: "policy", Value: "bind"},
+				{Key: "share", Value: "on"},
+			},
+		},
+	)
+
+	expected := map[string]any{
+		"size":       int64(1073741824),
+		"host-nodes": []int{0, 1},
+		"policy":     "bind",
+		"share":      true,
+	}
+
+	assert.Equal(t, expected, result)
+}
+
+// Test extractTraiingNumber.
+func TestExtractTrailingNumber(t *testing.T) {
+	value, _ := extractTrailingNumber("mem0", "mem")
+	assert.Equal(t, 0, value)
+
+	value, _ = extractTrailingNumber("mem34", "mem")
+	assert.Equal(t, 34, value)
+
+	value, _ = extractTrailingNumber("dimm1", "dimm")
+	assert.Equal(t, 1, value)
+
+	expectedErr := "Prefix mem not found in dimm1"
+	_, err := extractTrailingNumber("dimm1", "mem")
+	if err.Error() != expectedErr {
+		t.Errorf("unexpected error message: got %q, want %q", err.Error(), expectedErr)
+	}
+}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -479,6 +479,7 @@ var APIExtensions = []string{
 	"network_address_set",
 	"server_logging",
 	"network_forward_snat",
+	"memory_hotplug",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for hot-plugging memory during VM runtime.
It reuses the same approach and set of functions that are used for generating QEMU CPU and memory configurations. The generated configuration is then translated into a format compatible with QMP. This approach respects both hugepages and NUMA node topology.

Closes: #986