### PR TITLE
Infiniband Device Documentation Ported to GenDoc

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -402,6 +402,46 @@ For file systems (shared directories or custom volumes), this is one of:
 ```
 
 <!-- config group image-requirements end -->
+<!-- config group infiniband-common start -->
+```{config:option}  infiniband-commonhwaddr
+:defaultdesc: "randomly assigned"
+:required: "no"
+:shortdesc: "The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)"
+:type: "string"
+
+```
+
+```{config:option} mtu infiniband-common
+:defaultdesc: "parent MTU"
+:required: "no"
+:shortdesc: "The MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name infiniband-common
+:defaultdesc: "kernel assigned"
+:required: "no"
+:shortdesc: "The name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} nictype infiniband-common
+:required: "yes"
+:shortdesc: "The device type (one of `physical` or `sriov`)"
+:type: "string"
+
+```
+
+```{config:option} parent infiniband-common
+:required: "yes"
+:shortdesc: "The name of the host device or bridge"
+:type: "string"
+
+```
+
+<!-- config group infiniband-common end -->
 <!-- config group instance-boot start -->
 ```{config:option} boot.autorestart instance-boot
 :liveupdate: "no"

--- a/doc/reference/devices_infiniband.md
+++ b/doc/reference/devices_infiniband.md
@@ -29,10 +29,8 @@ To create an `sriov` `infiniband` device, use the following command:
 
 `infiniband` devices have the following device options:
 
-Key                     | Type      | Default           | Required  | Description
-:--                     | :--       | :--               | :--       | :--
-`hwaddr`                | string    | randomly assigned | no        | The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)
-`mtu`                   | integer   | parent MTU        | no        | The MTU of the new interface
-`name`                  | string    | kernel assigned   | no        | The name of the interface inside the instance
-`nictype`               | string    | -                 | yes       | The device type (one of `physical` or `sriov`)
-`parent`                | string    | -                 | yes       | The name of the host device or bridge
+% Include content from [config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group infiniband-common start -->
+    :end-before: <!-- config group infiniband-common end -->
+```

--- a/internal/server/device/infiniband_physical.go
+++ b/internal/server/device/infiniband_physical.go
@@ -30,41 +30,41 @@ func (d *infinibandPhysical) validateConfig(instConf instance.ConfigReader) erro
 	// gendoc:generate(entity=infiniband, group=common, key=name)
 	//
 	// ---
-	// type: string
-	// required: no
-	// defaultdesc: kernel assigned
-	// shortdesc: The name of the interface inside the instance
+	//  type: string
+	//  required: no
+	//  defaultdesc: kernel assigned
+	//  shortdesc: The name of the interface inside the instance
 
 	
 	// gendoc:generate(entity=infiniband, group=common, key=mtu)
 	//
 	// ---
-	// type: integer
-	// required: no
-	// defaultdesc: parent MTU
-	// shortdesc: The MTU of the new interface
+	//  type: integer
+	//  required: no
+	//  defaultdesc: parent MTU
+	//  shortdesc: The MTU of the new interface
 
 	// gendoc:generate(entity=infiniband, group=common, key=hwaddr)
 	//
 	// ---
-	// type: string
-	// required: no
-	// defaultdesc: randomly assigned
-	// shortdesc: The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)
+	//  type: string
+	//  required: no
+	//  defaultdesc: randomly assigned
+	//  shortdesc: The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)
 
 	// gendoc:generate(entity=infiniband, group=common, key=nictype)
 	//
 	// ---
-	// type: string
-	// required: yes
-	// shortdesc: The device type (one of `physical` or `sriov`)
+	//  type: string
+	//  required: yes
+	//  shortdesc: The device type (one of `physical` or `sriov`)
 
 	// gendoc:generate(entity=infiniband, group=common, key=parent)
 	//
 	// ---
-	// type: string
-	// required: yes
-	// shortdesc: The name of the host device or bridge
+	//  type: string
+	//  required: yes
+	//  shortdesc: The name of the host device or bridge
 
 
 	rules := nicValidationRules(requiredFields, optionalFields, instConf)

--- a/internal/server/device/infiniband_physical.go
+++ b/internal/server/device/infiniband_physical.go
@@ -27,7 +27,49 @@ func (d *infinibandPhysical) validateConfig(instConf instance.ConfigReader) erro
 		"hwaddr",
 	}
 
+	// gendoc:generate(entity=infiniband, group=common, key=name)
+	//
+	// ---
+	// type: string
+	// required: no
+	// defaultdesc: kernel assigned
+	// shortdesc: The name of the interface inside the instance
+
+	
+	// gendoc:generate(entity=infiniband, group=common, key=mtu)
+	//
+	// ---
+	// type: integer
+	// required: no
+	// defaultdesc: parent MTU
+	// shortdesc: The MTU of the new interface
+
+	// gendoc:generate(entity=infiniband, group=common, key=hwaddr)
+	//
+	// ---
+	// type: string
+	// required: no
+	// defaultdesc: randomly assigned
+	// shortdesc: The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)
+
+	// gendoc:generate(entity=infiniband, group=common, key=nictype)
+	//
+	// ---
+	// type: string
+	// required: yes
+	// shortdesc: The device type (one of `physical` or `sriov`)
+
+	// gendoc:generate(entity=infiniband, group=common, key=parent)
+	//
+	// ---
+	// type: string
+	// required: yes
+	// shortdesc: The name of the host device or bridge
+
+
 	rules := nicValidationRules(requiredFields, optionalFields, instConf)
+
+	
 	rules["hwaddr"] = func(value string) error {
 		if value == "" {
 			return nil

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -450,6 +450,55 @@
 				]
 			}
 		},
+		"infiniband": {
+			"common": {
+				"keys": [
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"nictype": {
+							"longdesc": "",
+							"required": "yes",
+							"shortdesc": "The device type (one of `physical` or `sriov`)",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"required": "yes",
+							"shortdesc": "The name of the host device or bridge",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"instance": {
 			"boot": {
 				"keys": [


### PR DESCRIPTION
The previous Infiniband device documentation used a static table of valid options. This was moved to an auto-generated table using gendoc.

#1787 
