### PR TITLE
Add common aliases for add/create remove/delete/rm in the CLI

### DIFF
--- a/cmd/incus/alias.go
+++ b/cmd/incus/alias.go
@@ -224,7 +224,7 @@ type cmdAliasRemove struct {
 func (c *cmdAliasRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("<alias>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove aliases")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove aliases`))

--- a/cmd/incus/alias.go
+++ b/cmd/incus/alias.go
@@ -58,6 +58,7 @@ type cmdAliasAdd struct {
 func (c *cmdAliasAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("<alias> <target>"))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add new aliases")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Add new aliases`))

--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -705,7 +705,7 @@ type cmdClusterRemove struct {
 func (c *cmdClusterRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<member>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove a member from the cluster")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove a member from the cluster`))

--- a/cmd/incus/cluster_role.go
+++ b/cmd/incus/cluster_role.go
@@ -113,6 +113,7 @@ type cmdClusterRoleRemove struct {
 func (c *cmdClusterRoleRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<member> <role[,role...]>"))
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove roles from a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove roles from a cluster member`))

--- a/cmd/incus/cluster_role.go
+++ b/cmd/incus/cluster_role.go
@@ -48,6 +48,7 @@ type cmdClusterRoleAdd struct {
 func (c *cmdClusterRoleAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<member> <role[,role...]>"))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add roles to a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Add roles to a cluster member`))

--- a/cmd/incus/config_device.go
+++ b/cmd/incus/config_device.go
@@ -509,7 +509,7 @@ func (c *cmdConfigDeviceRemove) Command() *cobra.Command {
 		cmd.Use = usage("remove", i18n.G("[<remote>:]<profile> <name>..."))
 	}
 
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove instance devices")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove instance devices`))

--- a/cmd/incus/config_device.go
+++ b/cmd/incus/config_device.go
@@ -77,6 +77,7 @@ type cmdConfigDeviceAdd struct {
 // Command returns a cobra.Command for use with (*cobra.Command).AddCommand.
 func (c *cmdConfigDeviceAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add instance devices")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Add instance devices`))

--- a/cmd/incus/config_template.go
+++ b/cmd/incus/config_template.go
@@ -65,6 +65,7 @@ type cmdConfigTemplateCreate struct {
 func (c *cmdConfigTemplateCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<instance> <template>"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new instance file templates")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create new instance file templates`))

--- a/cmd/incus/config_template.go
+++ b/cmd/incus/config_template.go
@@ -135,7 +135,7 @@ type cmdConfigTemplateDelete struct {
 func (c *cmdConfigTemplateDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance> <template>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete instance file templates")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete instance file templates`))

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -770,7 +770,7 @@ type cmdConfigTrustRemove struct {
 func (c *cmdConfigTrustRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<fingerprint>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove trusted client")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove trusted client`))

--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -295,7 +295,7 @@ type cmdFileDelete struct {
 func (c *cmdFileDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete files in instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete files in instances`))

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -310,7 +310,7 @@ type cmdImageDelete struct {
 func (c *cmdImageDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<image> [[<remote>:]<image>...]"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete images`))

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -67,6 +67,7 @@ type cmdImageAliasCreate struct {
 func (c *cmdImageAliasCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<alias> <fingerprint>"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create aliases for existing images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create aliases for existing images`))

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -136,7 +136,7 @@ type cmdImageAliasDelete struct {
 func (c *cmdImageAliasDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<alias>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete image aliases")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete image aliases`))

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -348,6 +348,7 @@ type cmdNetworkCreate struct {
 func (c *cmdNetworkCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new networks")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create new networks`))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network create foo

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -466,7 +466,7 @@ type cmdNetworkDelete struct {
 func (c *cmdNetworkDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete networks")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete networks`))

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -393,6 +393,7 @@ type cmdNetworkACLCreate struct {
 func (c *cmdNetworkACLCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<ACL> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new network ACLs")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network ACLs"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network acl create a1

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -910,6 +910,7 @@ func (c *cmdNetworkACLRule) Command() *cobra.Command {
 func (c *cmdNetworkACLRule) CommandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<ACL> <direction> <key>=<value>..."))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add rules to an ACL")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add rules to an ACL"))
 

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -1058,6 +1058,7 @@ func (c *cmdNetworkACLRule) RunAdd(cmd *cobra.Command, args []string) error {
 func (c *cmdNetworkACLRule) CommandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<ACL> <direction> <key>=<value>..."))
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove rules from an ACL")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove rules from an ACL"))
 	cmd.Flags().BoolVar(&c.flagRemoveForce, "force", false, i18n.G("Remove all rules that match"))

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -833,7 +833,7 @@ type cmdNetworkACLDelete struct {
 func (c *cmdNetworkACLDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<ACL>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network ACLs")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network ACLs"))
 	cmd.RunE = c.Run

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -941,6 +941,7 @@ func (c *cmdNetworkForwardPort) Command() *cobra.Command {
 func (c *cmdNetworkForwardPort) CommandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add ports to a forward")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add ports to a forward"))
 	cmd.RunE = c.RunAdd

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -847,7 +847,7 @@ type cmdNetworkForwardDelete struct {
 func (c *cmdNetworkForwardDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network> <listen_address>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network forwards")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network forwards"))
 	cmd.RunE = c.Run

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -1027,6 +1027,7 @@ func (c *cmdNetworkForwardPort) RunAdd(cmd *cobra.Command, args []string) error 
 func (c *cmdNetworkForwardPort) CommandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"))
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove ports from a forward")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove ports from a forward"))
 	cmd.Flags().BoolVar(&c.flagRemoveForce, "force", false, i18n.G("Remove all ports that match"))

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -333,6 +333,7 @@ type cmdNetworkForwardCreate struct {
 func (c *cmdNetworkForwardCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> <listen_address> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new network forwards")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network forwards"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network forward create n1 127.0.0.1

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -82,6 +82,7 @@ type cmdNetworkIntegrationCreate struct {
 func (c *cmdNetworkIntegrationCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network integration> <type>"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create network integrations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create network integrations`))

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -175,7 +175,7 @@ type cmdNetworkIntegrationDelete struct {
 func (c *cmdNetworkIntegrationDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network integration>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network integrations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete network integrations`))

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -827,7 +827,7 @@ type cmdNetworkLoadBalancerDelete struct {
 func (c *cmdNetworkLoadBalancerDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network> <listen_address>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network load balancers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network load balancers"))
 	cmd.RunE = c.Run

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -920,6 +920,7 @@ func (c *cmdNetworkLoadBalancerBackend) Command() *cobra.Command {
 func (c *cmdNetworkLoadBalancerBackend) CommandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add backends to a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add backend to a load balancer"))
 	cmd.RunE = c.RunAdd
@@ -1117,6 +1118,7 @@ func (c *cmdNetworkLoadBalancerPort) Command() *cobra.Command {
 func (c *cmdNetworkLoadBalancerPort) CommandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add ports to a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add ports to a load balancer"))
 	cmd.RunE = c.RunAdd

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -336,6 +336,7 @@ type cmdNetworkLoadBalancerCreate struct {
 func (c *cmdNetworkLoadBalancerCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> <listen_address> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new network load balancers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network load balancers"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network load-balancer create n1 127.0.0.1

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -1001,6 +1001,7 @@ func (c *cmdNetworkLoadBalancerBackend) RunAdd(cmd *cobra.Command, args []string
 func (c *cmdNetworkLoadBalancerBackend) CommandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<network> <listen_address> <backend_name>"))
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove backends from a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove backend from a load balancer"))
 	cmd.RunE = c.RunRemove
@@ -1196,6 +1197,7 @@ func (c *cmdNetworkLoadBalancerPort) RunAdd(cmd *cobra.Command, args []string) e
 func (c *cmdNetworkLoadBalancerPort) CommandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"))
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove ports from a load balancer")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove ports from a load balancer"))
 	cmd.Flags().BoolVar(&c.flagRemoveForce, "force", false, i18n.G("Remove all ports that match"))

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -862,7 +862,7 @@ type cmdNetworkPeerDelete struct {
 func (c *cmdNetworkPeerDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<network> <peer_name>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network peerings")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network peerings"))
 	cmd.RunE = c.Run

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -328,6 +328,7 @@ type cmdNetworkPeerCreate struct {
 func (c *cmdNetworkPeerCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> <peer_name> <[target project/]<target network or integration> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new network peering")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network peering"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network peer create default peer1 web/default

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -1633,6 +1633,7 @@ func (c *cmdNetworkZoneRecordEntry) RunAdd(cmd *cobra.Command, args []string) er
 func (c *cmdNetworkZoneRecordEntry) CommandRemove() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("[<remote>:]<zone> <record> <type> <value>"))
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove a network zone record entry")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Remove entries from a network zone record"))
 	cmd.RunE = c.RunRemove

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -767,7 +767,7 @@ type cmdNetworkZoneDelete struct {
 func (c *cmdNetworkZoneDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<Zone>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network zones")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network zones"))
 	cmd.RunE = c.Run
@@ -1492,7 +1492,7 @@ type cmdNetworkZoneRecordDelete struct {
 func (c *cmdNetworkZoneRecordDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<zone> <record>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete network zone record")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete network zone record"))
 	cmd.RunE = c.Run

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -400,6 +400,7 @@ type cmdNetworkZoneCreate struct {
 func (c *cmdNetworkZoneCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<Zone> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new network zones")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network zones"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network zone create z1
@@ -1113,6 +1114,7 @@ type cmdNetworkZoneRecordCreate struct {
 func (c *cmdNetworkZoneRecordCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<zone> <record> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new network zone record")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network zone record"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus network zone record create z1 r1

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -1572,6 +1572,7 @@ func (c *cmdNetworkZoneRecordEntry) Command() *cobra.Command {
 func (c *cmdNetworkZoneRecordEntry) CommandAdd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<zone> <record> <type> <value>"))
+	cmd.Aliases = []string{"create"}
 	cmd.Short = i18n.G("Add a network zone record entry")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Add entries to a network zone record"))
 	cmd.RunE = c.RunAdd

--- a/cmd/incus/operation.go
+++ b/cmd/incus/operation.go
@@ -61,7 +61,7 @@ type cmdOperationDelete struct {
 func (c *cmdOperationDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<operation>"))
-	cmd.Aliases = []string{"cancel", "rm"}
+	cmd.Aliases = []string{"cancel", "rm", "remove"}
 	cmd.Short = i18n.G("Delete a background operation (will attempt to cancel)")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete a background operation (will attempt to cancel)`))

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -105,6 +105,7 @@ type cmdProjectCreate struct {
 func (c *cmdProjectCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<project>"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create projects")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create projects`))

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -211,7 +211,7 @@ type cmdProjectDelete struct {
 func (c *cmdProjectDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<project>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete projects")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete projects`))

--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -1125,7 +1125,7 @@ type cmdRemoteRemove struct {
 func (c *cmdRemoteRemove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("remove", i18n.G("<remote>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"delete", "rm"}
 	cmd.Short = i18n.G("Remove remotes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Remove remotes`))

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -204,7 +204,7 @@ type cmdSnapshotDelete struct {
 func (c *cmdSnapshotDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<instance> <snapshot name>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete instance snapshots")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete instance snapshots`))

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -77,6 +77,7 @@ type cmdSnapshotCreate struct {
 func (c *cmdSnapshotCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<instance> [<snapshot name>]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create instance snapshot")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create instance snapshots

--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -220,7 +220,7 @@ type cmdStorageDelete struct {
 func (c *cmdStorageDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete storage pools")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete storage pools`))

--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -101,6 +101,7 @@ type cmdStorageCreate struct {
 func (c *cmdStorageCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <driver> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create storage pools")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create storage pools`))

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -210,7 +210,7 @@ type cmdStorageBucketDelete struct {
 func (c *cmdStorageBucketDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete storage buckets")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Delete storage buckets`))
 
@@ -1209,6 +1209,7 @@ type cmdStorageBucketKeyDelete struct {
 func (c *cmdStorageBucketKeyDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <bucket> <key>"))
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete key from a storage bucket")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Delete key from a storage bucket"))
 	cmd.RunE = c.RunRemove

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -97,6 +97,7 @@ type cmdStorageBucketCreate struct {
 func (c *cmdStorageBucketCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new custom storage buckets")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create new custom storage buckets`))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus storage bucket create p1 b01
@@ -1094,6 +1095,7 @@ type cmdStorageBucketKeyCreate struct {
 func (c *cmdStorageBucketKeyCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> <key>"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create key for a storage bucket")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create key for a storage bucket"))
 	cmd.Example = cli.FormatSection("", i18n.G(`incus storage bucket key create p1 b01 k1

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -709,7 +709,7 @@ type cmdStorageVolumeDelete struct {
 func (c *cmdStorageVolumeDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <volume>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete custom storage volumes`))
@@ -2678,7 +2678,7 @@ type cmdStorageVolumeSnapshotDelete struct {
 func (c *cmdStorageVolumeSnapshotDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <volume> <snapshot>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete storage volume snapshots")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete storage volume snapshots`))

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -591,6 +591,7 @@ type cmdStorageVolumeCreate struct {
 func (c *cmdStorageVolumeCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <volume> [key=value...]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Create new custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create new custom storage volumes`))
@@ -2540,6 +2541,7 @@ type cmdStorageVolumeSnapshotCreate struct {
 func (c *cmdStorageVolumeSnapshotCreate) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <volume> [<snapshot>]"))
+	cmd.Aliases = []string{"add"}
 	cmd.Short = i18n.G("Snapshot storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Snapshot storage volumes`))

--- a/cmd/incus/warning.go
+++ b/cmd/incus/warning.go
@@ -367,7 +367,7 @@ type cmdWarningDelete struct {
 func (c *cmdWarningDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<warning-uuid>"))
-	cmd.Aliases = []string{"rm"}
+	cmd.Aliases = []string{"rm", "remove"}
 	cmd.Short = i18n.G("Delete warning")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete warning`))


### PR DESCRIPTION
Finishes adding all aliases for add / create and remove/delete/rm in the incus CLI

closes #1797 