### PR TITLE
Remove gocapability dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
-	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/vishvananda/netlink v1.3.0
 	github.com/zitadel/oidc/v3 v3.37.0
 	go.starlark.net v0.0.0-20250417143717-f57e51f710eb

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,6 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
-github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tailscale/depaware v0.0.0-20210622194025-720c4b409502/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=

--- a/internal/server/sys/apparmor_test.go
+++ b/internal/server/sys/apparmor_test.go
@@ -1,0 +1,19 @@
+//go:build linux && cgo && !agent
+
+package sys
+
+import (
+	"os"
+	"testing"
+)
+
+func TestHaveMacAdmin(t *testing.T) {
+	macAdmin := haveMacAdmin()
+
+	uid := os.Getuid()
+	t.Log(macAdmin, uid)
+
+	if macAdmin != (uid == 0) {
+		t.Fatal(uid, macAdmin)
+	}
+}


### PR DESCRIPTION
package `github.com/syndtr/gocapability` has stayed for long time without update or bug fix, and incus use little function it provides.