### PR TITLE
Infiniband Device Documentation Ported to GenDoc

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1575,6 +1575,47 @@ For file systems (shared directories or custom volumes), this is one of:
 ```
 
 <!-- config group image-requirements end -->
+<!-- config group infiniband-common start -->
+```{config:option} hwaddr infiniband-common
+:defaultdesc: "randomly assigned"
+:required: "no"
+:shortdesc: "The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)"
+:type: "string"
+
+```
+
+```{config:option} mtu infiniband-common
+:defaultdesc: "parent MTU"
+:required: "no"
+:shortdesc: "The MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name infiniband-common
+:defaultdesc: "kernel assigned"
+:required: "no"
+:shortdesc: "The name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} nictype infiniband-common
+:required: "yes"
+:shortdesc: "The device type (one of `physical` or `sriov`)"
+:type: "string"
+
+```
+
+```{config:option} parent infiniband-common
+:defaultdesc: "kernel assigned"
+:required: "no"
+:shortdesc: "The name of the interface inside the instance"
+:type: "string"
+
+```
+
+<!-- config group infiniband-common end -->
 <!-- config group instance-boot start -->
 ```{config:option} boot.autorestart instance-boot
 :liveupdate: "no"

--- a/doc/reference/devices_infiniband.md
+++ b/doc/reference/devices_infiniband.md
@@ -29,10 +29,8 @@ To create an `sriov` `infiniband` device, use the following command:
 
 `infiniband` devices have the following device options:
 
-Key                     | Type      | Default           | Required  | Description
-:--                     | :--       | :--               | :--       | :--
-`hwaddr`                | string    | randomly assigned | no        | The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)
-`mtu`                   | integer   | parent MTU        | no        | The MTU of the new interface
-`name`                  | string    | kernel assigned   | no        | The name of the interface inside the instance
-`nictype`               | string    | -                 | yes       | The device type (one of `physical` or `sriov`)
-`parent`                | string    | -                 | yes       | The name of the host device or bridge
+% Include content from [config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group infiniband-common start -->
+    :end-before: <!-- config group infiniband-common end -->
+```

--- a/internal/server/device/device_load.go
+++ b/internal/server/device/device_load.go
@@ -46,6 +46,12 @@ func newByType(state *state.State, projectName string, conf deviceConfig.Device)
 		}
 
 	case "infiniband":
+		// gendoc:generate(entity=infiniband, group=common, key=nictype)
+		//
+		// ---
+		//  type: string
+		//  required: yes
+		//  shortdesc: The device type (one of `physical` or `sriov`)
 		switch nicType {
 		case "physical":
 			dev = &infinibandPhysical{}

--- a/internal/server/device/infiniband_physical.go
+++ b/internal/server/device/infiniband_physical.go
@@ -20,10 +20,43 @@ type infinibandPhysical struct {
 
 // validateConfig checks the supplied config for correctness.
 func (d *infinibandPhysical) validateConfig(instConf instance.ConfigReader) error {
-	requiredFields := []string{"parent"}
+	requiredFields := []string{
+		// gendoc:generate(entity=infiniband, group=common, key=parent)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  defaultdesc: kernel assigned
+		//  shortdesc: The name of the interface inside the instance
+		"parent",
+	}
+
 	optionalFields := []string{
+		// gendoc:generate(entity=infiniband, group=common, key=name)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  defaultdesc: kernel assigned
+		//  shortdesc: The name of the interface inside the instance
 		"name",
+
+		// gendoc:generate(entity=infiniband, group=common, key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  required: no
+		//  defaultdesc: parent MTU
+		//  shortdesc: The MTU of the new interface
 		"mtu",
+
+		// gendoc:generate(entity=infiniband, group=common, key=hwaddr)
+		//
+		// ---
+		//  type: string
+		//  required: no
+		//  defaultdesc: randomly assigned
+		//  shortdesc: The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)
 		"hwaddr",
 	}
 

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1810,6 +1810,56 @@
 				]
 			}
 		},
+		"infiniband": {
+			"common": {
+				"keys": [
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The MAC address of the new interface (can be either the full 20-byte variant or the short 8-byte variant, which will only modify the last 8 bytes of the parent device)",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"nictype": {
+							"longdesc": "",
+							"required": "yes",
+							"shortdesc": "The device type (one of `physical` or `sriov`)",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "The name of the interface inside the instance",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"instance": {
 			"boot": {
 				"keys": [


### PR DESCRIPTION
The previous Infiniband device documentation used a static table of valid options. This was moved to an auto-generated table using gendoc. We closed our old PR and created this new one.

https://github.com/lxc/incus/issues/1787