### PR TITLE
Replace yaml.v2 with goccy/go-yaml

### DIFF
--- a/cmd/incus-agent/templates.go
+++ b/cmd/incus-agent/templates.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/util"

--- a/cmd/incus-migrate/main_migrate.go
+++ b/cmd/incus-migrate/main_migrate.go
@@ -14,9 +14,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus-simplestreams/main_add.go
+++ b/cmd/incus-simplestreams/main_add.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	internalUtil "github.com/lxc/incus/v6/internal/util"

--- a/cmd/incus-simplestreams/main_generate_metadata.go
+++ b/cmd/incus-simplestreams/main_generate_metadata.go
@@ -9,8 +9,8 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/shared/api"

--- a/cmd/incus/admin_init_dump.go
+++ b/cmd/incus/admin_init_dump.go
@@ -5,7 +5,7 @@ package main
 import (
 	"fmt"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/admin_init_interactive.go
+++ b/cmd/incus/admin_init_interactive.go
@@ -14,9 +14,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/admin_init_preseed.go
+++ b/cmd/incus/admin_init_preseed.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/internal/i18n"
 	"github.com/lxc/incus/v6/shared/api"
@@ -24,7 +24,7 @@ func (c *cmdAdminInit) RunPreseed() (*api.InitPreseed, error) {
 	// Parse the YAML
 	config := api.InitPreseed{}
 	// Use strict checking to notify about unknown keys.
-	err = yaml.UnmarshalStrict(bytes, &config)
+	err = yaml.UnmarshalWithOptions(bytes, &config, yaml.Strict())
 	if err != nil {
 		return nil, fmt.Errorf(i18n.G("Failed to parse the preseed: %w"), err)
 	}

--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/cluster_group.go
+++ b/cmd/incus/cluster_group.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/config.go
+++ b/cmd/incus/config.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus/config_device.go
+++ b/cmd/incus/config_device.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/config_metadata.go
+++ b/cmd/incus/config_metadata.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -13,8 +13,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/create.go
+++ b/cmd/incus/create.go
@@ -9,8 +9,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -12,8 +12,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus/monitor.go
+++ b/cmd/incus/monitor.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"slices"
 
+	"github.com/goccy/go-yaml"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
@@ -443,7 +443,7 @@ func (c *cmdNetworkACLCreate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &aclPut)
+		err = yaml.UnmarshalWithOptions(contents, &aclPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -706,7 +706,7 @@ func (c *cmdNetworkACLEdit) Run(cmd *cobra.Command, args []string) error {
 		// Allow output of `incus network acl show` command to be passed in here, but only take the contents
 		// of the NetworkACLPut fields when updating the ACL. The other fields are silently discarded.
 		newdata := api.NetworkACL{}
-		err = yaml.UnmarshalStrict(contents, &newdata)
+		err = yaml.UnmarshalWithOptions(contents, &newdata, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -734,7 +734,7 @@ func (c *cmdNetworkACLEdit) Run(cmd *cobra.Command, args []string) error {
 	for {
 		// Parse the text received from the editor.
 		newdata := api.NetworkACL{} // We show the full ACL info, but only send the writable fields.
-		err = yaml.UnmarshalStrict(content, &newdata)
+		err = yaml.UnmarshalWithOptions(content, &newdata, yaml.Strict())
 		if err == nil {
 			err = resource.server.UpdateNetworkACL(resource.name, newdata.Writable(), etag)
 		}

--- a/cmd/incus/network_address_set.go
+++ b/cmd/incus/network_address_set.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
@@ -287,7 +287,7 @@ func (c *cmdNetworkAddressSetCreate) Run(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &asPut)
+		err = yaml.UnmarshalWithOptions(contents, &asPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -525,7 +525,7 @@ func (c *cmdNetworkAddressSetEdit) Run(cmd *cobra.Command, args []string) error 
 		}
 
 		newdata := api.NetworkAddressSet{}
-		err = yaml.UnmarshalStrict(contents, &newdata)
+		err = yaml.UnmarshalWithOptions(contents, &newdata, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -551,7 +551,7 @@ func (c *cmdNetworkAddressSetEdit) Run(cmd *cobra.Command, args []string) error 
 
 	for {
 		newdata := api.NetworkAddressSet{}
-		err = yaml.UnmarshalStrict(content, &newdata)
+		err = yaml.UnmarshalWithOptions(content, &newdata, yaml.Strict())
 		if err == nil {
 			err = resource.server.UpdateNetworkAddressSet(resource.name, newdata.Writable(), etag)
 		}

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
@@ -380,7 +380,7 @@ func (c *cmdNetworkForwardCreate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &forwardPut)
+		err = yaml.UnmarshalWithOptions(contents, &forwardPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -776,7 +776,7 @@ func (c *cmdNetworkForwardEdit) Run(cmd *cobra.Command, args []string) error {
 		// Allow output of `incus network forward show` command to be passed in here, but only take the
 		// contents of the NetworkForwardPut fields when updating. The other fields are silently discarded.
 		newData := api.NetworkForward{}
-		err = yaml.UnmarshalStrict(contents, &newData)
+		err = yaml.UnmarshalWithOptions(contents, &newData, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -806,7 +806,7 @@ func (c *cmdNetworkForwardEdit) Run(cmd *cobra.Command, args []string) error {
 	for {
 		// Parse the text received from the editor.
 		newData := api.NetworkForward{} // We show the full info, but only send the writable fields.
-		err = yaml.UnmarshalStrict(content, &newData)
+		err = yaml.UnmarshalWithOptions(content, &newData, yaml.Strict())
 		if err == nil {
 			newData.Normalise()
 			err = client.UpdateNetworkForward(resource.name, args[1], newData.Writable(), etag)

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
@@ -383,7 +383,7 @@ func (c *cmdNetworkLoadBalancerCreate) Run(cmd *cobra.Command, args []string) er
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &loadBalancerPut)
+		err = yaml.UnmarshalWithOptions(contents, &loadBalancerPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -756,7 +756,7 @@ func (c *cmdNetworkLoadBalancerEdit) Run(cmd *cobra.Command, args []string) erro
 		// contents of the NetworkLoadBalancerPut fields when updating.
 		// The other fields are silently discarded.
 		newData := api.NetworkLoadBalancer{}
-		err = yaml.UnmarshalStrict(contents, &newData)
+		err = yaml.UnmarshalWithOptions(contents, &newData, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -786,7 +786,7 @@ func (c *cmdNetworkLoadBalancerEdit) Run(cmd *cobra.Command, args []string) erro
 	for {
 		// Parse the text received from the editor.
 		newData := api.NetworkLoadBalancer{} // We show the full info, but only send the writable fields.
-		err = yaml.UnmarshalStrict(content, &newData)
+		err = yaml.UnmarshalWithOptions(content, &newData, yaml.Strict())
 		if err == nil {
 			newData.Normalise()
 			err = client.UpdateNetworkLoadBalancer(resource.name, args[1], newData.Writable(), etag)

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
@@ -406,7 +406,7 @@ func (c *cmdNetworkPeerCreate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &peerPut)
+		err = yaml.UnmarshalWithOptions(contents, &peerPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -794,7 +794,7 @@ func (c *cmdNetworkPeerEdit) Run(cmd *cobra.Command, args []string) error {
 		// Allow output of `incus network peer show` command to be passed in here, but only take the contents
 		// of the NetworkPeerPut fields when updating. The other fields are silently discarded.
 		newData := api.NetworkPeer{}
-		err = yaml.UnmarshalStrict(contents, &newData)
+		err = yaml.UnmarshalWithOptions(contents, &newData, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -822,7 +822,7 @@ func (c *cmdNetworkPeerEdit) Run(cmd *cobra.Command, args []string) error {
 	for {
 		// Parse the text received from the editor.
 		newData := api.NetworkPeer{} // We show the full info, but only send the writable fields.
-		err = yaml.UnmarshalStrict(content, &newData)
+		err = yaml.UnmarshalWithOptions(content, &newData, yaml.Strict())
 		if err == nil {
 			err = client.UpdateNetworkPeer(resource.name, args[1], newData.Writable(), etag)
 		}

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"
@@ -450,7 +450,7 @@ func (c *cmdNetworkZoneCreate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &zonePut)
+		err = yaml.UnmarshalWithOptions(contents, &zonePut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -699,7 +699,7 @@ func (c *cmdNetworkZoneEdit) Run(cmd *cobra.Command, args []string) error {
 		// Allow output of `incus network zone show` command to be passed in here, but only take the contents
 		// of the NetworkZonePut fields when updating the Zone. The other fields are silently discarded.
 		newdata := api.NetworkZone{}
-		err = yaml.UnmarshalStrict(contents, &newdata)
+		err = yaml.UnmarshalWithOptions(contents, &newdata, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -727,7 +727,7 @@ func (c *cmdNetworkZoneEdit) Run(cmd *cobra.Command, args []string) error {
 	for {
 		// Parse the text received from the editor.
 		newdata := api.NetworkZone{} // We show the full Zone info, but only send the writable fields.
-		err = yaml.UnmarshalStrict(content, &newdata)
+		err = yaml.UnmarshalWithOptions(content, &newdata, yaml.Strict())
 		if err == nil {
 			err = resource.server.UpdateNetworkZone(resource.name, newdata.Writable(), etag)
 		}
@@ -1166,7 +1166,7 @@ func (c *cmdNetworkZoneRecordCreate) Run(cmd *cobra.Command, args []string) erro
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &recordPut)
+		err = yaml.UnmarshalWithOptions(contents, &recordPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -1423,7 +1423,7 @@ func (c *cmdNetworkZoneRecordEdit) Run(cmd *cobra.Command, args []string) error 
 		// Allow output of `incus network zone show` command to be passed in here, but only take the contents
 		// of the NetworkZonePut fields when updating the Zone. The other fields are silently discarded.
 		newdata := api.NetworkZoneRecord{}
-		err = yaml.UnmarshalStrict(contents, &newdata)
+		err = yaml.UnmarshalWithOptions(contents, &newdata)
 		if err != nil {
 			return err
 		}
@@ -1451,7 +1451,7 @@ func (c *cmdNetworkZoneRecordEdit) Run(cmd *cobra.Command, args []string) error 
 	for {
 		// Parse the text received from the editor.
 		newdata := api.NetworkZoneRecord{} // We show the full Zone info, but only send the writable fields.
-		err = yaml.UnmarshalStrict(content, &newdata)
+		err = yaml.UnmarshalWithOptions(content, &newdata)
 		if err == nil {
 			err = resource.server.UpdateNetworkZoneRecord(resource.name, args[1], newdata.Writable(), etag)
 		}

--- a/cmd/incus/operation.go
+++ b/cmd/incus/operation.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/profile.go
+++ b/cmd/incus/profile.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"
@@ -145,7 +145,7 @@ func (c *cmdStorageBucketCreate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &bucketPut)
+		err = yaml.UnmarshalWithOptions(contents, &bucketPut, yaml.Strict())
 		if err != nil {
 			return err
 		}
@@ -1124,7 +1124,7 @@ func (c *cmdStorageBucketKeyCreate) RunAdd(cmd *cobra.Command, args []string) er
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &bucketKeyPut)
+		err = yaml.UnmarshalWithOptions(contents, &bucketKeyPut, yaml.Strict())
 		if err != nil {
 			return err
 		}

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"
@@ -640,7 +640,7 @@ func (c *cmdStorageVolumeCreate) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = yaml.UnmarshalStrict(contents, &volumePut)
+		err = yaml.UnmarshalWithOptions(contents, &volumePut, yaml.Strict())
 		if err != nil {
 			return err
 		}

--- a/cmd/incus/warning.go
+++ b/cmd/incus/warning.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 
 	cli "github.com/lxc/incus/v6/internal/cmd"
 	"github.com/lxc/incus/v6/internal/i18n"

--- a/cmd/incusd/backup.go
+++ b/cmd/incusd/backup.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/internal/instancewriter"
 	"github.com/lxc/incus/v6/internal/server/backup"

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -22,10 +22,10 @@ import (
 
 	dqliteClient "github.com/cowsql/go-cowsql/client"
 	"github.com/cowsql/go-cowsql/driver"
+	"github.com/goccy/go-yaml"
 	"github.com/gorilla/mux"
 	liblxc "github.com/lxc/go-lxc"
 	"golang.org/x/sys/unix"
-	yaml "gopkg.in/yaml.v2"
 
 	internalIO "github.com/lxc/incus/v6/internal/io"
 	"github.com/lxc/incus/v6/internal/linux"

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -25,9 +25,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/gorilla/mux"
 	"github.com/kballard/go-shellquote"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/internal/filter"

--- a/cmd/incusd/instance_instance_types.go
+++ b/cmd/incusd/instance_instance_types.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/internal/server/db/operationtype"
 	"github.com/lxc/incus/v6/internal/server/operations"

--- a/cmd/incusd/instance_metadata.go
+++ b/cmd/incusd/instance_metadata.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/gorilla/mux"
-	"gopkg.in/yaml.v2"
 
 	internalInstance "github.com/lxc/incus/v6/internal/instance"
 	"github.com/lxc/incus/v6/internal/server/instance"

--- a/cmd/incusd/main_cluster.go
+++ b/cmd/incusd/main_cluster.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/cowsql/go-cowsql/client"
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	cli "github.com/lxc/incus/v6/internal/cmd"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-logr/logr v1.4.2
+	github.com/goccy/go-yaml v1.17.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0
@@ -62,7 +63,6 @@ require (
 	golang.org/x/tools v0.32.0
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 )
 
@@ -138,6 +138,7 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250421163800-61c742ae3ef0 // indirect
 	google.golang.org/grpc v1.72.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIx
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=

--- a/internal/cmd/table.go
+++ b/internal/cmd/table.go
@@ -9,8 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/olekukonko/tablewriter"
-	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/incus/v6/internal/i18n"
 )

--- a/internal/server/backup/backup_config_utils.go
+++ b/internal/server/backup/backup_config_utils.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/internal/instance"
 	"github.com/lxc/incus/v6/internal/server/backup/config"

--- a/internal/server/backup/backup_info.go
+++ b/internal/server/backup/backup_info.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/internal/server/backup/config"
 	"github.com/lxc/incus/v6/internal/server/sys"

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/checkpoint-restore/go-criu/v6/crit"
 	"github.com/flosch/pongo2/v6"
+	"github.com/goccy/go-yaml"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/kballard/go-shellquote"
@@ -36,7 +37,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
-	yaml "gopkg.in/yaml.v2"
 
 	internalInstance "github.com/lxc/incus/v6/internal/instance"
 	"github.com/lxc/incus/v6/internal/instancewriter"

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -30,6 +30,7 @@ import (
 	"unsafe"
 
 	"github.com/flosch/pongo2/v6"
+	"github.com/goccy/go-yaml"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/kballard/go-shellquote"
@@ -38,7 +39,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	internalInstance "github.com/lxc/incus/v6/internal/instance"

--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/internal/server/db"

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -20,9 +20,9 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/goccy/go-yaml"
 	"github.com/minio/minio-go/v7"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/v6/client"
 	internalInstance "github.com/lxc/incus/v6/internal/instance"

--- a/internal/server/storage/drivers/driver_btrfs_utils.go
+++ b/internal/server/storage/drivers/driver_btrfs_utils.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/goccy/go-yaml"
 	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
-	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/internal/server/backup"

--- a/internal/server/storage/drivers/driver_btrfs_volumes.go
+++ b/internal/server/storage/drivers/driver_btrfs_volumes.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/incus/v6/internal/instancewriter"
 	"github.com/lxc/incus/v6/internal/linux"

--- a/shared/cliconfig/file.go
+++ b/shared/cliconfig/file.go
@@ -6,7 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/util"

--- a/shared/subprocess/manager.go
+++ b/shared/subprocess/manager.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 )
 
 // NewProcess is a constructor for a process object. Represents a process with argument config.

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 
 	"github.com/lxc/incus/v6/shared/util"
 )

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/adhocore/gronx"
+	"github.com/goccy/go-yaml"
 	"github.com/google/uuid"
 	"github.com/kballard/go-shellquote"
-	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/incus/v6/shared/osarch"
 	"github.com/lxc/incus/v6/shared/units"
@@ -804,7 +804,6 @@ func IsCloudInitUserData(value string) error {
 // IsYAML checks value is valid YAML.
 func IsYAML(value string) error {
 	out := struct{}{}
-
 	err := yaml.Unmarshal([]byte(value), &out)
 	if err != nil {
 		return err

--- a/test/dev_incus-client/dev_incus_client.go
+++ b/test/dev_incus-client/dev_incus_client.go
@@ -18,8 +18,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/gorilla/websocket"
-	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/incus/v6/shared/api"
 )

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -1,3 +1,4 @@
+github.com/goccy/go-yaml
 github.com/gorilla/websocket
 github.com/lxc/incus/v6/client
 github.com/lxc/incus/v6/shared/api
@@ -19,4 +20,3 @@ github.com/zitadel/oidc/v3/pkg/http
 github.com/zitadel/oidc/v3/pkg/oidc
 golang.org/x/crypto/ssh
 golang.org/x/oauth2
-gopkg.in/yaml.v2


### PR DESCRIPTION
`github.com/goccy/go-yaml` is active, stable, fast and no additional dependencies on others except go std.