### PR TITLE
Add dhcp static routes via 0.0.0.0 with link scope in forknet

### DIFF
--- a/cmd/incusd/main_forknet.go
+++ b/cmd/incusd/main_forknet.go
@@ -385,8 +385,11 @@ func (c *cmdForknet) RunDHCP(cmd *cobra.Command, args []string) error {
 			route := &ip.Route{
 				DevName: iface,
 				Route:   staticRoute.Dest.String(),
-				Via:     staticRoute.Router.String(),
 				Family:  ip.FamilyV4,
+			}
+
+			if !staticRoute.Router.IsUnspecified() {
+				route.Via = staticRoute.Router.String()
 			}
 
 			err = route.Add()


### PR DESCRIPTION
Systemd-networkd (and probably others) adds dhcp static routes via `0.0.0.0` with link scope, which is arguably the only reasonable thing to do with them and allows configuring later routes via those routes, e.g. `192.168.0.2/32,0.0.0.0,10.0.0.0/8,192.168.0.2` to configure `192.168.0.2/32` on the link itself and `10.0.0.0/8` via `192.168.0.2`. 
The `ip route` command uses link scope when called like `ip route add dev eth0 192.168.0.2/32` but not when called like `ip route add dev eth0 192.168.0.2/32 via 0.0.0.0`.