### PR TITLE
Add server side filtering for `incus profile list`

### DIFF
--- a/client/incus_profiles.go
+++ b/client/incus_profiles.go
@@ -36,6 +36,22 @@ func (r *ProtocolIncus) GetProfiles() ([]api.Profile, error) {
 	return profiles, nil
 }
 
+// GetProfilesWithFilter returns a filtered list of available Profile structs.
+func (r *ProtocolIncus) GetProfilesWithFilter(filters []string) ([]api.Profile, error) {
+	profiles := []api.Profile{}
+
+	v := url.Values{}
+	v.Set("recursion", "1")
+	v.Set("filter", parseFilters(filters))
+
+	_, err := r.queryStruct("GET", fmt.Sprintf("/profiles?%s", v.Encode()), nil, "", &profiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return profiles, nil
+}
+
 // GetProfilesAllProjects returns a list of profiles across all projects as Profile structs.
 func (r *ProtocolIncus) GetProfilesAllProjects() ([]api.Profile, error) {
 	err := r.CheckExtension("profiles_all_projects")
@@ -45,6 +61,28 @@ func (r *ProtocolIncus) GetProfilesAllProjects() ([]api.Profile, error) {
 
 	profiles := []api.Profile{}
 	_, err = r.queryStruct("GET", "/profiles?recursion=1&all-projects=true", nil, "", &profiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return profiles, nil
+}
+
+// GetProfilesAllProjectsWithFilter returns a filtered list of profiles across all projects as Profile structs.
+func (r *ProtocolIncus) GetProfilesAllProjectsWithFilter(filters []string) ([]api.Profile, error) {
+	err := r.CheckExtension("profiles_all_projects")
+	if err != nil {
+		return nil, fmt.Errorf(`The server is missing the required "profiles_all_projects" API extension`)
+	}
+
+	profiles := []api.Profile{}
+
+	v := url.Values{}
+	v.Set("recursion", "1")
+	v.Set("all-projects", "true")
+	v.Set("filter", parseFilters(filters))
+
+	_, err = r.queryStruct("GET", fmt.Sprintf("/profiles?%s", v.Encode()), nil, "", &profiles)
 	if err != nil {
 		return nil, err
 	}

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -290,8 +290,10 @@ type InstanceServer interface {
 
 	// Profile functions
 	GetProfilesAllProjects() (profiles []api.Profile, err error)
+	GetProfilesAllProjectsWithFilter(filters []string) ([]api.Profile, error)
 	GetProfileNames() (names []string, err error)
 	GetProfiles() (profiles []api.Profile, err error)
+	GetProfilesWithFilter(filters []string) ([]api.Profile, error)
 	GetProfile(name string) (profile *api.Profile, ETag string, err error)
 	CreateProfile(profile api.ProfilesPost) (err error)
 	UpdateProfile(name string, profile api.ProfilePut, ETag string) (err error)

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -534,7 +534,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -665,7 +665,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -984,7 +984,7 @@ msgstr "Ports zu einem Network Forward hinzufügen"
 msgid "Add ports to a load balancer"
 msgstr "Ports zu einem Load Balancer hinzufügen"
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr "Profile zu Instanzen hinzufügen"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Einem Clustermitglied eine oder mehrere Gruppen zuweisen"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr "Ein oder mehrere Profile einer Instanz zuweisen"
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr "\"Kann --fast nicht zusammen mit --columns angeben.\""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr "Kann --project nicht zusammen mit --all-projects angeben"
 
@@ -1648,7 +1648,7 @@ msgstr "Clustering aktiviert"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1718,7 +1718,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1808,7 +1808,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1823,7 +1823,7 @@ msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -2023,7 +2023,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2080,7 +2080,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2230,7 +2230,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -2370,12 +2370,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2577,7 +2577,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display network zones from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2771,7 +2771,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2899,7 +2899,7 @@ msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
@@ -2921,7 +2921,7 @@ msgstr "Fehler beim Löschen der Parameter: %v"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3631,7 +3631,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3778,7 +3778,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3865,7 +3865,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -5012,8 +5012,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -5097,13 +5097,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5627,7 +5636,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5676,8 +5685,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5803,8 +5812,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5939,9 +5948,9 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5957,7 +5966,7 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing required arguments"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -6084,7 +6093,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6592,7 +6601,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6728,7 +6737,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6781,37 +6790,37 @@ msgstr "Erstellt: %s"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 #, fuzzy
 msgid "Profile description"
 msgstr "Profil %s erstellt\n"
@@ -6831,7 +6840,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -7135,7 +7144,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7209,7 +7218,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -7666,11 +7675,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7824,7 +7833,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7985,7 +7994,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8571,7 +8580,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8846,7 +8855,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8893,7 +8902,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -9010,7 +9019,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -9096,7 +9105,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -9143,7 +9152,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9478,9 +9487,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -9522,7 +9530,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -9884,7 +9892,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9893,7 +9901,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -10583,8 +10591,8 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10616,7 +10624,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10624,7 +10632,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10640,7 +10648,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10648,7 +10656,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -10930,8 +10938,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -11018,19 +11026,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -11118,16 +11126,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -11180,7 +11188,7 @@ msgstr ""
 "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Zeigt Details der genannten operation UUID"
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -11201,7 +11209,7 @@ msgstr ""
 "incus profile assign foo ''\n"
 "    Die Profile der Instanz \"foo\" zurücksetzen und kein Profil zuweisen."
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 #, fuzzy
 msgid ""
 "incus profile create p1\n"
@@ -11236,7 +11244,7 @@ msgstr ""
 "   Mounted das Storage Volume \"some-volume\" im Storage pool \"some-pool\" "
 "in den Dateipfad \"/opt\" innerhalb der Instanz."
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -11258,8 +11266,8 @@ msgstr ""
 "   Erstellt ein Projekt namens \"p1\"\n"
 "\n"
 "incus project create p1 < config.yaml\n"
-"    Erstellt ein Projekt namens \"p1\" mit der Konfigurationsdatei "
-"\"config.yaml\""
+"    Erstellt ein Projekt namens \"p1\" mit der Konfigurationsdatei \"config."
+"yaml\""
 
 #: cmd/incus/project.go:316
 msgid ""
@@ -11375,8 +11383,8 @@ msgstr ""
 "\n"
 "incus storage bucket key create p1 b01 k1 < config.yaml\n"
 "\tErzeugt einen Schlüssel genannt \"k1\" für einen storage bucket \"b01\" im "
-"pool \"p1\" unter Nutzung der Konfigurationsdetails aus der Datei "
-"\"config.yaml\"."
+"pool \"p1\" unter Nutzung der Konfigurationsdetails aus der Datei \"config."
+"yaml\"."
 
 #: cmd/incus/storage_bucket.go:1383
 msgid ""
@@ -11438,8 +11446,8 @@ msgstr ""
 "\n"
 "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
-"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei "
-"\"config.yaml\"."
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
 
 #: cmd/incus/storage_volume.go:986
 #, fuzzy
@@ -11457,8 +11465,8 @@ msgstr ""
 "\n"
 "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
-"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei "
-"\"config.yaml\"."
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
 
 #: cmd/incus/storage_volume.go:1214
 msgid ""
@@ -11530,8 +11538,8 @@ msgstr ""
 "\n"
 "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
-"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei "
-"\"config.yaml\"."
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
 
 #: cmd/incus/storage_volume.go:2302
 msgid ""
@@ -11654,8 +11662,8 @@ msgstr "ja"
 
 #, fuzzy
 #~ msgid ""
-#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < "
-#~ "volume.yaml\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
 #~ "    Update a storage volume using the content of pool.yaml."
 #~ msgstr ""
 #~ "incus storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -11667,8 +11675,8 @@ msgstr "ja"
 #~ "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 #~ msgstr ""
 #~ "incus storage volume import default backup0.tar.gz\n"
-#~ "\t\tErstellt ein neues benutzerdefiniertes Volume aus der Datei "
-#~ "\"backup0.tar.gz\"."
+#~ "\t\tErstellt ein neues benutzerdefiniertes Volume aus der Datei \"backup0."
+#~ "tar.gz\"."
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage or --target-project"
@@ -12600,8 +12608,8 @@ msgstr "ja"
 #~ "lxc image edit [remote:]<image>\n"
 #~ "    Edit image, either by launching external editor or reading STDIN.\n"
 #~ "    Example: lxc image edit <image> # launch editor\n"
-#~ "             cat image.yaml | lxc image edit <image> # read from "
-#~ "image.yml\n"
+#~ "             cat image.yaml | lxc image edit <image> # read from image."
+#~ "yml\n"
 #~ "\n"
 #~ "Lists the images at specified remote, or local images.\n"
 #~ "Filters are not yet supported.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -540,7 +540,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -663,7 +663,7 @@ msgstr "%s no es un directorio"
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1353,7 +1353,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr "No se puede especificar --fast con --columns"
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1587,7 +1587,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1649,7 +1649,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1737,7 +1737,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2144,7 +2144,7 @@ msgstr "Perfil %s creado"
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -2283,12 +2283,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2480,7 +2480,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display network zones from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2663,7 +2663,7 @@ msgstr "Perfil %s creado"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2709,7 +2709,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2784,7 +2784,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
@@ -2806,7 +2806,7 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3457,7 +3457,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3603,7 +3603,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4820,8 +4820,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4905,13 +4905,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5413,7 +5422,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5457,8 +5466,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5583,8 +5592,8 @@ msgstr "Nombre del Miembro del Cluster"
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -5717,9 +5726,9 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5735,7 +5744,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing required arguments"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5857,7 +5866,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6353,7 +6362,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6487,7 +6496,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6540,37 +6549,37 @@ msgstr "Creado: %s"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 #, fuzzy
 msgid "Profile description"
 msgstr "Descripción"
@@ -6590,7 +6599,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6883,7 +6892,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6955,7 +6964,7 @@ msgstr "Perfil %s creado"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7395,11 +7404,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7546,7 +7555,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7698,7 +7707,7 @@ msgstr "Perfil %s creado"
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8268,7 +8277,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -8538,7 +8547,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8584,7 +8593,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8697,7 +8706,7 @@ msgstr "Perfil %s creado"
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8780,7 +8789,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8825,7 +8834,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9139,9 +9148,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9166,7 +9174,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9389,12 +9397,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9822,8 +9830,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9843,12 +9851,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9858,12 +9866,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -10075,8 +10083,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10163,19 +10171,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10253,16 +10261,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -10312,7 +10320,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10324,7 +10332,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10344,7 +10352,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -539,7 +539,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -670,7 +670,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -923,9 +923,8 @@ msgstr ""
 "\n"
 "L'authentification HTTP Basic (RFC 26176) peut être utilisée si elle est "
 "combinée avec le protocole « simplestreams » :\n"
-"  incus remote add ressource_distante_identifiant https://"
-"UTILISATEUR:MOTDEPASSE@exemple.com/complement/de/chemin --"
-"protocol=simplestreams\n"
+"  incus remote add ressource_distante_identifiant https://UTILISATEUR:"
+"MOTDEPASSE@exemple.com/complement/de/chemin --protocol=simplestreams\n"
 
 #: cmd/incus/config_trust.go:92
 msgid "Add new trusted client"
@@ -970,7 +969,7 @@ msgstr "Ajoutez des ports à la redirection"
 msgid "Add ports to a load balancer"
 msgstr "Ajoutez des ports à l'équilibreur de charge"
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr "Ajouter des profils aux instances"
 
@@ -1097,7 +1096,7 @@ msgstr "Machine virtuelle a été demandé mais l'image est de type conteneur"
 msgid "Assign sets of groups to cluster members"
 msgstr "Attribuer des ensemble de groupes aux membres du cluster"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr "Attribuer un ensemble de profils à des instances"
 
@@ -1378,7 +1377,7 @@ msgstr "Impossible de supprimer le serveur distant par défaut"
 msgid "Can't specify --fast with --columns"
 msgstr "Impossible de spécifier --fast avec --columns"
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr "Impossible de spécifier --project avec --all-projects"
 
@@ -1622,7 +1621,7 @@ msgstr "Clustering activé"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1690,7 +1689,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1796,7 +1795,7 @@ msgstr ""
 "Copier les périphériques hérités et surcharge les clés de configuration du "
 "profile"
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr "Copier les profiles"
 
@@ -1809,7 +1808,7 @@ msgid "Copy the volume without its snapshots"
 msgstr "Copier le volume sans ses instantanés"
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr "Copie dans un projet différent de la source"
 
@@ -2028,7 +2027,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new networks"
 msgstr "Créer de nouveaux réseaux"
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
@@ -2085,7 +2084,7 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2241,7 +2240,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete networks"
 msgstr "Supprime les réseaux"
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr "Supprime les profiles"
 
@@ -2382,12 +2381,12 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2585,7 +2584,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display network zones from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2776,7 +2775,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr "Modifier les configurations de profil au format YAML"
 
@@ -2824,7 +2823,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2916,7 +2915,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2938,7 +2937,7 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3693,7 +3692,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3844,7 +3843,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr "Obtenir la clé en tant que propriété du profil"
 
@@ -3932,7 +3931,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5109,8 +5108,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -5176,8 +5175,8 @@ msgstr ""
 "Colonnes en mode rapide : nsacPt\n"
 "\n"
 "Exemple :\n"
-"    lxc list -c n,volatile.base_image:\\BASE "
-"IMAGE\\:0,s46,volatile.eth0.hwaddr:MAC"
+"    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
+"hwaddr:MAC"
 
 #: cmd/incus/network_acl.go:101
 #, fuzzy
@@ -5254,13 +5253,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5779,7 +5787,7 @@ msgstr "Nom du réseau"
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5827,8 +5835,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5954,8 +5962,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6091,9 +6099,9 @@ msgstr "Résumé manquant."
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -6109,7 +6117,7 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing required arguments"
 msgstr "Résumé manquant."
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -6239,7 +6247,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6759,7 +6767,7 @@ msgstr "PROFILS"
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6895,7 +6903,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6949,37 +6957,37 @@ msgstr "Marque : %v"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 #, fuzzy
 msgid "Profile description"
 msgstr "Description"
@@ -6999,7 +7007,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
@@ -7306,7 +7314,7 @@ msgstr "Création du conteneur"
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -7381,7 +7389,7 @@ msgstr "Nom du réseau"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7851,12 +7859,12 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -8009,7 +8017,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -8173,7 +8181,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
@@ -8771,7 +8779,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -9051,7 +9059,7 @@ msgstr "Création du conteneur"
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -9098,7 +9106,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -9216,7 +9224,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -9303,7 +9311,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -9350,7 +9358,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9681,9 +9689,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<serveur distant>:]"
 
@@ -9711,7 +9718,7 @@ msgstr "[<serveur distant>:] <certificat>"
 msgid "[<remote>:] <name>"
 msgstr "[<serveur distant>:] <nom>"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<serveur distant>:] [<filtre>...]"
 
@@ -10075,7 +10082,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -10087,7 +10094,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -10846,8 +10853,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10879,7 +10886,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10887,7 +10894,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10903,7 +10910,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10911,7 +10918,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -11203,8 +11210,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -11301,19 +11308,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -11403,16 +11410,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -11462,7 +11469,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -11474,7 +11481,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -11494,7 +11501,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -12506,9 +12513,9 @@ msgstr "oui"
 #~ "lxc config trust list "
 #~ "[<remote>:]                                           Lister tous les "
 #~ "certificats de confiance.\n"
-#~ "lxc config trust add [<remote>:] "
-#~ "<certfile.crt>                             Ajouter certfile.crt aux hôtes "
-#~ "de confiance.\n"
+#~ "lxc config trust add [<remote>:] <certfile."
+#~ "crt>                             Ajouter certfile.crt aux hôtes de "
+#~ "confiance.\n"
 #~ "lxc config trust remove [<remote>:] [hostname|"
 #~ "fingerprint]                  Supprimer le certificat des hôtes de "
 #~ "confiance.\n"
@@ -12520,8 +12527,8 @@ msgstr "oui"
 #~ "share/c1 path=opt\n"
 #~ "\n"
 #~ "Pour positionner une clé de configuration dans la configuration lxc :\n"
-#~ "    lxc config set [<remote>:]<container> raw.lxc "
-#~ "'lxc.aa_allow_incomplete = 1'\n"
+#~ "    lxc config set [<remote>:]<container> raw.lxc 'lxc."
+#~ "aa_allow_incomplete = 1'\n"
 #~ "\n"
 #~ "Pour écouter sur le port 8443 en IPv4 et IPv6 (vous pouvez omettre 8443 "
 #~ "c'est la valeur par défaut) :\n"
@@ -12711,8 +12718,8 @@ msgstr "oui"
 #~ "lxc image edit [<remote>:]<image>\n"
 #~ "    Edit image, either by launching external editor or reading STDIN.\n"
 #~ "    Example: lxc image edit <image> # launch editor\n"
-#~ "             cat image.yaml | lxc image edit <image> # read from "
-#~ "image.yaml\n"
+#~ "             cat image.yaml | lxc image edit <image> # read from image."
+#~ "yaml\n"
 #~ "\n"
 #~ "lxc image alias create [<remote>:]<alias> <fingerprint>\n"
 #~ "    Create a new alias for an existing image.\n"
@@ -12802,8 +12809,8 @@ msgstr "oui"
 #~ "    Éditer l'image, soit en lançant un éditeur externe ou en lisant "
 #~ "STDIN.\n"
 #~ "    Exemple : lxc image edit <image> # lance l'éditeur\n"
-#~ "              cat image.yaml | lxc image edit <image> # lit depuis "
-#~ "image.yaml\n"
+#~ "              cat image.yaml | lxc image edit <image> # lit depuis image."
+#~ "yaml\n"
 #~ "\n"
 #~ "lxc image alias create [<remote>:]<alias> <fingerprint>\n"
 #~ "    Créer un nouvel alias pour une image existante.\n"
@@ -13397,8 +13404,8 @@ msgstr "oui"
 #~ "  f - Base Image Fingerprint (short)\n"
 #~ "  F - Base Image Fingerprint (long)\n"
 #~ "\n"
-#~ "Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-#~ "\":\n"
+#~ "Custom columns are defined with \"[config:|devices:]key[:name][:"
+#~ "maxWidth]\":\n"
 #~ "  KEY: The (extended) config or devices key to display. If [config:|"
 #~ "devices:] is omitted then it defaults to config key.\n"
 #~ "  NAME: Name to display in the column header.\n"
@@ -13464,8 +13471,8 @@ msgstr "oui"
 #~ "Colonnes en mode rapide : nsacPt\n"
 #~ "\n"
 #~ "Exemple :\n"
-#~ "    lxc list -c n,volatile.base_image:\\BASE "
-#~ "IMAGE\\:0,s46,volatile.eth0.hwaddr:MAC"
+#~ "    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
+#~ "hwaddr:MAC"
 
 #~ msgid "Failed to generate 'lxc.%s.1': %v"
 #~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -318,7 +318,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -411,7 +411,7 @@ msgstr "%s bukan direktori"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' bukan tipe berkas yang didukung"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(nihil)"
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1310,7 +1310,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1368,7 +1368,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1455,7 +1455,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr "Buat profil"
 
@@ -1702,7 +1702,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -1841,7 +1841,7 @@ msgstr "Hapus zona jaringan"
 msgid "Delete networks"
 msgstr "Hapus jaringan"
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr "Hapus profil"
 
@@ -1978,12 +1978,12 @@ msgstr "Hapus peringatan"
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2385,7 +2385,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2460,7 +2460,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2482,7 +2482,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3125,7 +3125,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3261,7 +3261,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3334,7 +3334,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4438,8 +4438,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4519,13 +4519,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5013,7 +5022,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5053,8 +5062,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5174,8 +5183,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5299,9 +5308,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5315,7 +5324,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5432,7 +5441,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -5926,7 +5935,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6059,7 +6068,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6112,37 +6121,37 @@ msgstr "Produk: %v"
 msgid "Product: %v (%v)"
 msgstr "Produk: %v (%v)"
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ditambahkan ke %s"
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s dibuat"
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s dihapus"
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s saat ini tidak diterapkan ke %s"
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s dihapus dari %s"
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s diganti nama menjadi %s"
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 #, fuzzy
 msgid "Profile description"
 msgstr "deskripsi"
@@ -6159,7 +6168,7 @@ msgstr "Profil yang akan diterapkan ke instansi baru"
 msgid "Profile to apply to the target instance"
 msgstr "Profil yang akan diterapkan ke instansi target"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s diterapkan ke %s"
@@ -6444,7 +6453,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6510,7 +6519,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -6933,11 +6942,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7075,7 +7084,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7217,7 +7226,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -7778,7 +7787,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8045,7 +8054,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8090,7 +8099,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8191,7 +8200,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8264,7 +8273,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8307,7 +8316,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8617,9 +8626,8 @@ msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>] [<path>]"
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -8639,7 +8647,7 @@ msgstr "[<remote>:] <cert>"
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <nama>"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -8825,11 +8833,11 @@ msgstr "[<remote>:]<instansi> <nama>..."
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "[<remote>:]<instansi> <nama snapshot lama> <nama snapshot baru>"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instansi> <profil>"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instansi> <profil>"
 
@@ -9180,8 +9188,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9197,11 +9205,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9209,11 +9217,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9406,8 +9414,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9494,19 +9502,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9584,16 +9592,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -9643,7 +9651,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9655,7 +9663,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9675,7 +9683,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2025-04-22 13:09-0400\n"
+        "POT-Creation-Date: 2025-04-23 16:05-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -294,7 +294,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -384,7 +384,7 @@ msgstr  ""
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid   "(none)"
 msgstr  ""
 
@@ -649,7 +649,7 @@ msgstr  ""
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid   "Add profiles to instances"
 msgstr  ""
 
@@ -768,7 +768,7 @@ msgstr  ""
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
@@ -1026,7 +1026,7 @@ msgstr  ""
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
@@ -1208,7 +1208,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433 cmd/incus/config_trust.go:628 cmd/incus/image.go:1114 cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126 cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64 cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439 cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114 cmd/incus/network_zone.go:118 cmd/incus/operation.go:144 cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751 cmd/incus/snapshot.go:323 cmd/incus/storage.go:707 cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936 cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640 cmd/incus/top.go:64 cmd/incus/warning.go:97
+#: cmd/incus/cluster.go:153 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:486 cmd/incus/config_trust.go:433 cmd/incus/config_trust.go:628 cmd/incus/image.go:1114 cmd/incus/image_alias.go:218 cmd/incus/list.go:136 cmd/incus/network.go:1126 cmd/incus/network.go:1334 cmd/incus/network_allocations.go:64 cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439 cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114 cmd/incus/network_zone.go:118 cmd/incus/operation.go:144 cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751 cmd/incus/snapshot.go:323 cmd/incus/storage.go:707 cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936 cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640 cmd/incus/top.go:64 cmd/incus/warning.go:97
 msgid   "Columns"
 msgstr  ""
 
@@ -1253,7 +1253,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364 cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744 cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797 cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737 cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622 cmd/incus/project.go:417 cmd/incus/storage.go:383 cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349 cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
+#: cmd/incus/cluster.go:988 cmd/incus/cluster_group.go:422 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:158 cmd/incus/config_trust.go:364 cmd/incus/image.go:474 cmd/incus/network.go:829 cmd/incus/network_acl.go:744 cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797 cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737 cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623 cmd/incus/project.go:417 cmd/incus/storage.go:383 cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349 cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1331,7 +1331,7 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid   "Copy profiles"
 msgstr  ""
 
@@ -1343,7 +1343,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67 cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67 cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1523,7 +1523,7 @@ msgstr  ""
 msgid   "Create new networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid   "Create profiles"
 msgstr  ""
 
@@ -1567,7 +1567,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512 cmd/incus/config_trust.go:451 cmd/incus/image.go:1143 cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157 cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164 cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455 cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136 cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953 cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580 cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
+#: cmd/incus/cluster.go:183 cmd/incus/cluster_group.go:512 cmd/incus/config_trust.go:451 cmd/incus/image.go:1143 cmd/incus/image_alias.go:258 cmd/incus/list.go:503 cmd/incus/network.go:1157 cmd/incus/network_acl.go:177 cmd/incus/network_address_set.go:164 cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455 cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136 cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953 cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580 cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1702,7 +1702,7 @@ msgstr  ""
 msgid   "Delete networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid   "Delete profiles"
 msgstr  ""
 
@@ -1726,7 +1726,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327 cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522 cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710 cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021 cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268 cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484 cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36 cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189 cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341 cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622 cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763 cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903 cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52 cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96 cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752 cmd/incus/config.go:884 cmd/incus/config_device.go:26 cmd/incus/config_device.go:81 cmd/incus/config_device.go:225 cmd/incus/config_device.go:324 cmd/incus/config_device.go:409 cmd/incus/config_device.go:513 cmd/incus/config_device.go:631 cmd/incus/config_device.go:638 cmd/incus/config_device.go:773 cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:69 cmd/incus/config_template.go:139 cmd/incus/config_template.go:195 cmd/incus/config_template.go:297 cmd/incus/config_template.go:371 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608 cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815 cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43 cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33 cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306 cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704 cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140 cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386 cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38 cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350 cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627 cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947 cmd/incus/network.go:1107 cmd/incus/network.go:1312 cmd/incus/network.go:1472 cmd/incus/network.go:1534 cmd/incus/network.go:1632 cmd/incus/network.go:1706 cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97 cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397 cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060 cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93 cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247 cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94 cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337 cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029 cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86 cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231 cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417 cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:340 cmd/incus/network_load_balancer.go:450 cmd/incus/network_load_balancer.go:520 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:923 cmd/incus/network_load_balancer.go:1003 cmd/incus/network_load_balancer.go:1104 cmd/incus/network_load_balancer.go:1120 cmd/incus/network_load_balancer.go:1197 cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30 cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258 cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94 cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327 cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507 cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642 cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971 cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117 cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574 cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112 cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368 cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657 cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991 cmd/incus/profile.go:1053 cmd/incus/profile.go:1144 cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108 cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452 cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817 cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016 cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45 cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686 cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301 cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525 cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105 cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418 cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852 cmd/incus/storage.go:958 cmd/incus/storage.go:1054 cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101 cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277 cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867 cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245 cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455 cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58 cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259 cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589 cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782 cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981 cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592 cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943 cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190 cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357 cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545 cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642 cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894 cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065 cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:56 cmd/incus/action.go:81 cmd/incus/action.go:106 cmd/incus/action.go:130 cmd/incus/admin.go:21 cmd/incus/admin_cluster.go:26 cmd/incus/admin_init.go:47 cmd/incus/admin_other.go:21 cmd/incus/admin_recover.go:31 cmd/incus/admin_shutdown.go:32 cmd/incus/admin_sql.go:32 cmd/incus/admin_waitready.go:28 cmd/incus/alias.go:24 cmd/incus/alias.go:62 cmd/incus/alias.go:112 cmd/incus/alias.go:173 cmd/incus/alias.go:228 cmd/incus/cluster.go:37 cmd/incus/cluster.go:133 cmd/incus/cluster.go:327 cmd/incus/cluster.go:386 cmd/incus/cluster.go:447 cmd/incus/cluster.go:522 cmd/incus/cluster.go:604 cmd/incus/cluster.go:650 cmd/incus/cluster.go:710 cmd/incus/cluster.go:803 cmd/incus/cluster.go:898 cmd/incus/cluster.go:1021 cmd/incus/cluster.go:1101 cmd/incus/cluster.go:1268 cmd/incus/cluster.go:1358 cmd/incus/cluster.go:1484 cmd/incus/cluster.go:1514 cmd/incus/cluster_group.go:36 cmd/incus/cluster_group.go:102 cmd/incus/cluster_group.go:189 cmd/incus/cluster_group.go:281 cmd/incus/cluster_group.go:341 cmd/incus/cluster_group.go:466 cmd/incus/cluster_group.go:622 cmd/incus/cluster_group.go:707 cmd/incus/cluster_group.go:763 cmd/incus/cluster_group.go:826 cmd/incus/cluster_group.go:903 cmd/incus/cluster_group.go:978 cmd/incus/cluster_group.go:1060 cmd/incus/cluster_role.go:25 cmd/incus/cluster_role.go:52 cmd/incus/cluster_role.go:116 cmd/incus/config.go:33 cmd/incus/config.go:96 cmd/incus/config.go:389 cmd/incus/config.go:526 cmd/incus/config.go:752 cmd/incus/config.go:884 cmd/incus/config_device.go:26 cmd/incus/config_device.go:81 cmd/incus/config_device.go:225 cmd/incus/config_device.go:324 cmd/incus/config_device.go:409 cmd/incus/config_device.go:513 cmd/incus/config_device.go:631 cmd/incus/config_device.go:638 cmd/incus/config_device.go:773 cmd/incus/config_device.go:860 cmd/incus/config_metadata.go:28 cmd/incus/config_metadata.go:57 cmd/incus/config_metadata.go:192 cmd/incus/config_template.go:28 cmd/incus/config_template.go:69 cmd/incus/config_template.go:139 cmd/incus/config_template.go:195 cmd/incus/config_template.go:297 cmd/incus/config_template.go:371 cmd/incus/config_trust.go:37 cmd/incus/config_trust.go:93 cmd/incus/config_trust.go:176 cmd/incus/config_trust.go:285 cmd/incus/config_trust.go:412 cmd/incus/config_trust.go:608 cmd/incus/config_trust.go:767 cmd/incus/config_trust.go:815 cmd/incus/config_trust.go:888 cmd/incus/console.go:40 cmd/incus/copy.go:43 cmd/incus/create.go:46 cmd/incus/debug.go:24 cmd/incus/debug.go:45 cmd/incus/delete.go:34 cmd/incus/exec.go:42 cmd/incus/export.go:33 cmd/incus/file.go:59 cmd/incus/file.go:106 cmd/incus/file.go:306 cmd/incus/file.go:390 cmd/incus/file.go:470 cmd/incus/file.go:704 cmd/incus/file.go:1373 cmd/incus/image.go:44 cmd/incus/image.go:153 cmd/incus/image.go:315 cmd/incus/image.go:372 cmd/incus/image.go:509 cmd/incus/image.go:680 cmd/incus/image.go:943 cmd/incus/image.go:1088 cmd/incus/image.go:1444 cmd/incus/image.go:1530 cmd/incus/image.go:1599 cmd/incus/image.go:1666 cmd/incus/image.go:1732 cmd/incus/image_alias.go:32 cmd/incus/image_alias.go:71 cmd/incus/image_alias.go:140 cmd/incus/image_alias.go:196 cmd/incus/image_alias.go:386 cmd/incus/import.go:28 cmd/incus/info.go:37 cmd/incus/launch.go:25 cmd/incus/list.go:52 cmd/incus/main.go:101 cmd/incus/manpage.go:25 cmd/incus/monitor.go:35 cmd/incus/move.go:37 cmd/incus/network.go:38 cmd/incus/network.go:150 cmd/incus/network.go:249 cmd/incus/network.go:350 cmd/incus/network.go:468 cmd/incus/network.go:528 cmd/incus/network.go:627 cmd/incus/network.go:726 cmd/incus/network.go:864 cmd/incus/network.go:947 cmd/incus/network.go:1107 cmd/incus/network.go:1312 cmd/incus/network.go:1472 cmd/incus/network.go:1534 cmd/incus/network.go:1632 cmd/incus/network.go:1706 cmd/incus/network_acl.go:30 cmd/incus/network_acl.go:97 cmd/incus/network_acl.go:199 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:320 cmd/incus/network_acl.go:397 cmd/incus/network_acl.go:502 cmd/incus/network_acl.go:592 cmd/incus/network_acl.go:637 cmd/incus/network_acl.go:778 cmd/incus/network_acl.go:837 cmd/incus/network_acl.go:897 cmd/incus/network_acl.go:913 cmd/incus/network_acl.go:1060 cmd/incus/network_address_set.go:30 cmd/incus/network_address_set.go:93 cmd/incus/network_address_set.go:187 cmd/incus/network_address_set.go:247 cmd/incus/network_address_set.go:351 cmd/incus/network_address_set.go:429 cmd/incus/network_address_set.go:472 cmd/incus/network_address_set.go:594 cmd/incus/network_address_set.go:649 cmd/incus/network_address_set.go:703 cmd/incus/network_address_set.go:756 cmd/incus/network_allocations.go:36 cmd/incus/network_forward.go:30 cmd/incus/network_forward.go:94 cmd/incus/network_forward.go:257 cmd/incus/network_forward.go:337 cmd/incus/network_forward.go:447 cmd/incus/network_forward.go:534 cmd/incus/network_forward.go:646 cmd/incus/network_forward.go:695 cmd/incus/network_forward.go:851 cmd/incus/network_forward.go:928 cmd/incus/network_forward.go:944 cmd/incus/network_forward.go:1029 cmd/incus/network_integration.go:29 cmd/incus/network_integration.go:86 cmd/incus/network_integration.go:179 cmd/incus/network_integration.go:231 cmd/incus/network_integration.go:353 cmd/incus/network_integration.go:417 cmd/incus/network_integration.go:564 cmd/incus/network_integration.go:618 cmd/incus/network_integration.go:699 cmd/incus/network_integration.go:732 cmd/incus/network_load_balancer.go:31 cmd/incus/network_load_balancer.go:103 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:340 cmd/incus/network_load_balancer.go:450 cmd/incus/network_load_balancer.go:520 cmd/incus/network_load_balancer.go:632 cmd/incus/network_load_balancer.go:664 cmd/incus/network_load_balancer.go:831 cmd/incus/network_load_balancer.go:907 cmd/incus/network_load_balancer.go:923 cmd/incus/network_load_balancer.go:1003 cmd/incus/network_load_balancer.go:1104 cmd/incus/network_load_balancer.go:1120 cmd/incus/network_load_balancer.go:1197 cmd/incus/network_load_balancer.go:1321 cmd/incus/network_peer.go:30 cmd/incus/network_peer.go:90 cmd/incus/network_peer.go:258 cmd/incus/network_peer.go:332 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:574 cmd/incus/network_peer.go:678 cmd/incus/network_peer.go:727 cmd/incus/network_peer.go:866 cmd/incus/network_zone.go:34 cmd/incus/network_zone.go:94 cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:327 cmd/incus/network_zone.go:404 cmd/incus/network_zone.go:507 cmd/incus/network_zone.go:597 cmd/incus/network_zone.go:642 cmd/incus/network_zone.go:771 cmd/incus/network_zone.go:829 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:971 cmd/incus/network_zone.go:1037 cmd/incus/network_zone.go:1117 cmd/incus/network_zone.go:1223 cmd/incus/network_zone.go:1314 cmd/incus/network_zone.go:1363 cmd/incus/network_zone.go:1495 cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574 cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32 cmd/incus/operation.go:66 cmd/incus/operation.go:119 cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113 cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369 cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658 cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016 cmd/incus/profile.go:1078 cmd/incus/profile.go:1169 cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108 cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452 cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817 cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016 cmd/incus/project.go:1086 cmd/incus/project.go:1202 cmd/incus/publish.go:34 cmd/incus/query.go:35 cmd/incus/rebuild.go:29 cmd/incus/remote.go:45 cmd/incus/remote.go:110 cmd/incus/remote.go:639 cmd/incus/remote.go:686 cmd/incus/remote.go:725 cmd/incus/remote.go:902 cmd/incus/remote.go:983 cmd/incus/remote.go:1048 cmd/incus/remote.go:1096 cmd/incus/remote_unix.go:38 cmd/incus/rename.go:23 cmd/incus/snapshot.go:33 cmd/incus/snapshot.go:81 cmd/incus/snapshot.go:208 cmd/incus/snapshot.go:301 cmd/incus/snapshot.go:462 cmd/incus/snapshot.go:525 cmd/incus/snapshot.go:604 cmd/incus/storage.go:39 cmd/incus/storage.go:105 cmd/incus/storage.go:224 cmd/incus/storage.go:284 cmd/incus/storage.go:418 cmd/incus/storage.go:502 cmd/incus/storage.go:685 cmd/incus/storage.go:852 cmd/incus/storage.go:958 cmd/incus/storage.go:1054 cmd/incus/storage_bucket.go:36 cmd/incus/storage_bucket.go:101 cmd/incus/storage_bucket.go:214 cmd/incus/storage_bucket.go:277 cmd/incus/storage_bucket.go:412 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:831 cmd/incus/storage_bucket.go:867 cmd/incus/storage_bucket.go:915 cmd/incus/storage_bucket.go:1066 cmd/incus/storage_bucket.go:1179 cmd/incus/storage_bucket.go:1245 cmd/incus/storage_bucket.go:1382 cmd/incus/storage_bucket.go:1455 cmd/incus/storage_bucket.go:1606 cmd/incus/storage_volume.go:58 cmd/incus/storage_volume.go:166 cmd/incus/storage_volume.go:259 cmd/incus/storage_volume.go:369 cmd/incus/storage_volume.go:589 cmd/incus/storage_volume.go:707 cmd/incus/storage_volume.go:782 cmd/incus/storage_volume.go:882 cmd/incus/storage_volume.go:981 cmd/incus/storage_volume.go:1207 cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1507 cmd/incus/storage_volume.go:1592 cmd/incus/storage_volume.go:1848 cmd/incus/storage_volume.go:1943 cmd/incus/storage_volume.go:2025 cmd/incus/storage_volume.go:2190 cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2357 cmd/incus/storage_volume.go:2408 cmd/incus/storage_volume.go:2545 cmd/incus/storage_volume.go:2636 cmd/incus/storage_volume.go:2642 cmd/incus/storage_volume.go:2805 cmd/incus/storage_volume.go:2894 cmd/incus/storage_volume.go:2976 cmd/incus/storage_volume.go:3065 cmd/incus/storage_volume.go:3233 cmd/incus/top.go:43 cmd/incus/version.go:23 cmd/incus/warning.go:32 cmd/incus/warning.go:76 cmd/incus/warning.go:273 cmd/incus/warning.go:316 cmd/incus/warning.go:372 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -1863,7 +1863,7 @@ msgstr  ""
 msgid   "Display network zones from all projects"
 msgstr  ""
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid   "Display profiles from all projects"
 msgstr  ""
 
@@ -2031,7 +2031,7 @@ msgstr  ""
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
@@ -2066,7 +2066,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150 cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463 cmd/incus/config_trust.go:653 cmd/incus/image.go:1161 cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172 cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465 cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147 cmd/incus/network_zone.go:154 cmd/incus/operation.go:176 cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778 cmd/incus/snapshot.go:357 cmd/incus/storage.go:746 cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961 cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755 cmd/incus/top.go:92 cmd/incus/warning.go:245
+#: cmd/incus/cluster.go:194 cmd/incus/cluster.go:1150 cmd/incus/cluster_group.go:520 cmd/incus/config_trust.go:463 cmd/incus/config_trust.go:653 cmd/incus/image.go:1161 cmd/incus/image_alias.go:267 cmd/incus/list.go:562 cmd/incus/network.go:1172 cmd/incus/network.go:1372 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465 cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147 cmd/incus/network_zone.go:154 cmd/incus/operation.go:176 cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778 cmd/incus/snapshot.go:357 cmd/incus/storage.go:746 cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961 cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755 cmd/incus/top.go:92 cmd/incus/warning.go:245
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2126,7 +2126,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034 cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609 cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404 cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673 cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652 cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288 cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923 cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2160
+#: cmd/incus/cluster.go:578 cmd/incus/cluster_group.go:1034 cmd/incus/config.go:642 cmd/incus/config.go:674 cmd/incus/network.go:1609 cmd/incus/network_acl.go:566 cmd/incus/network_address_set.go:404 cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673 cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652 cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288 cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923 cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2160
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2141,7 +2141,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028 cmd/incus/network.go:1603 cmd/incus/network_acl.go:560 cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667 cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646 cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282 cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917 cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111 cmd/incus/storage_volume.go:2154
+#: cmd/incus/cluster.go:572 cmd/incus/cluster_group.go:1028 cmd/incus/network.go:1603 cmd/incus/network_acl.go:560 cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667 cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646 cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282 cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917 cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111 cmd/incus/storage_volume.go:2154
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2751,7 +2751,7 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable if demanded, e.g. csv,header"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154 cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627 cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137 cmd/incus/network.go:1127 cmd/incus/network.go:1333 cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61 cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113 cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890 cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550 cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322 cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617 cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
+#: cmd/incus/admin_sql.go:57 cmd/incus/alias.go:114 cmd/incus/cluster.go:154 cmd/incus/cluster_group.go:487 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:434 cmd/incus/config_trust.go:627 cmd/incus/image.go:1115 cmd/incus/image_alias.go:217 cmd/incus/list.go:137 cmd/incus/network.go:1127 cmd/incus/network.go:1333 cmd/incus/network_acl.go:100 cmd/incus/network_allocations.go:61 cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113 cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890 cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550 cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322 cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617 cmd/incus/storage_volume.go:2653 cmd/incus/warning.go:98
 msgid   "Format (csv|json|table|yaml|compact), use suffix \",noheader\" to disable headers and \",header\" to enable it if missing, e.g. csv,header"
 msgstr  ""
 
@@ -2879,7 +2879,7 @@ msgstr  ""
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid   "Get the key as a profile property"
 msgstr  ""
 
@@ -2951,7 +2951,7 @@ msgstr  ""
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
@@ -4094,12 +4094,20 @@ msgstr  ""
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid   "List profiles"
 msgstr  ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid   "List profiles\n"
+        "\n"
+        "Filters may be of the <key>=<value> form for property based filtering,\n"
+        "or part of the profile name. Filters must be delimited by a ','.\n"
+        "\n"
+        "Examples:\n"
+        "  - \"foo\" lists all profiles that start with the name foo\n"
+        "  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+        "  - \"description=.*bar.*\" lists all profiles with a description that contains \"bar\"\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
         "that control which image attributes to output when displaying in table\n"
@@ -4569,7 +4577,7 @@ msgstr  ""
 msgid   "Manage network zones"
 msgstr  ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid   "Manage profiles"
 msgstr  ""
 
@@ -4715,7 +4723,7 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225 cmd/incus/config_template.go:119 cmd/incus/config_template.go:176 cmd/incus/config_template.go:232 cmd/incus/config_template.go:335 cmd/incus/config_template.go:408 cmd/incus/profile.go:149 cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225 cmd/incus/config_template.go:119 cmd/incus/config_template.go:176 cmd/incus/config_template.go:232 cmd/incus/config_template.go:335 cmd/incus/config_template.go:408 cmd/incus/profile.go:150 cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -4763,7 +4771,7 @@ msgstr  ""
 msgid   "Missing pool name"
 msgstr  ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576 cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094 cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577 cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119 cmd/incus/profile.go:1202
 msgid   "Missing profile name"
 msgstr  ""
 
@@ -4775,7 +4783,7 @@ msgstr  ""
 msgid   "Missing required arguments"
 msgstr  ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid   "Missing source profile name"
 msgstr  ""
 
@@ -4879,7 +4887,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140 cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:643 cmd/incus/list.go:511 cmd/incus/network.go:1152 cmd/incus/network_acl.go:176 cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454 cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140 cmd/incus/network_zone.go:952 cmd/incus/profile.go:776 cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764 cmd/incus/snapshot.go:346 cmd/incus/storage.go:732 cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951 cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
+#: cmd/incus/cluster.go:178 cmd/incus/cluster.go:1140 cmd/incus/cluster_group.go:510 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:643 cmd/incus/list.go:511 cmd/incus/network.go:1152 cmd/incus/network_acl.go:176 cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454 cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140 cmd/incus/network_zone.go:952 cmd/incus/profile.go:785 cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764 cmd/incus/snapshot.go:346 cmd/incus/storage.go:732 cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951 cmd/incus/storage_volume.go:1720 cmd/incus/storage_volume.go:2745
 msgid   "NAME"
 msgstr  ""
 
@@ -5352,7 +5360,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151 cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170 cmd/incus/network_zone.go:139 cmd/incus/profile.go:777 cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739 cmd/incus/top.go:79 cmd/incus/warning.go:222
+#: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151 cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170 cmd/incus/network_zone.go:139 cmd/incus/profile.go:786 cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739 cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid   "PROJECT"
 msgstr  ""
 
@@ -5473,7 +5481,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423 cmd/incus/config.go:278 cmd/incus/config.go:353 cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262 cmd/incus/config_trust.go:365 cmd/incus/image.go:475 cmd/incus/network.go:830 cmd/incus/network_acl.go:745 cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818 cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798 cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738 cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623 cmd/incus/project.go:418 cmd/incus/storage.go:384 cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350 cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
+#: cmd/incus/cluster.go:989 cmd/incus/cluster_group.go:423 cmd/incus/config.go:278 cmd/incus/config.go:353 cmd/incus/config_metadata.go:159 cmd/incus/config_template.go:262 cmd/incus/config_trust.go:365 cmd/incus/image.go:475 cmd/incus/network.go:830 cmd/incus/network_acl.go:745 cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818 cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798 cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738 cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624 cmd/incus/project.go:418 cmd/incus/storage.go:384 cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350 cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5523,37 +5531,37 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid   "Profile description"
 msgstr  ""
 
@@ -5569,7 +5577,7 @@ msgstr  ""
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
@@ -5842,7 +5850,7 @@ msgstr  ""
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -5907,7 +5915,7 @@ msgstr  ""
 msgid   "Rename networks"
 msgstr  ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid   "Rename profiles"
 msgstr  ""
 
@@ -6303,11 +6311,11 @@ msgstr  ""
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6433,7 +6441,7 @@ msgstr  ""
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid   "Set the key as a profile property"
 msgstr  ""
 
@@ -6573,7 +6581,7 @@ msgstr  ""
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid   "Show profile configurations"
 msgstr  ""
 
@@ -7107,7 +7115,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
@@ -7354,7 +7362,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77 cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142 cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736 cmd/incus/storage_volume.go:1723
+#: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178 cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77 cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142 cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736 cmd/incus/storage_volume.go:1723
 msgid   "USED BY"
 msgstr  ""
 
@@ -7390,7 +7398,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156 cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469 cmd/incus/config_trust.go:659 cmd/incus/image.go:1167 cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178 cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95 cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471 cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153 cmd/incus/network_zone.go:160 cmd/incus/operation.go:182 cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784 cmd/incus/snapshot.go:363 cmd/incus/storage.go:752 cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967 cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761 cmd/incus/top.go:98 cmd/incus/warning.go:251
+#: cmd/incus/cluster.go:200 cmd/incus/cluster.go:1156 cmd/incus/cluster_group.go:526 cmd/incus/config_trust.go:469 cmd/incus/config_trust.go:659 cmd/incus/image.go:1167 cmd/incus/image_alias.go:273 cmd/incus/list.go:571 cmd/incus/network.go:1178 cmd/incus/network.go:1378 cmd/incus/network_allocations.go:95 cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471 cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153 cmd/incus/network_zone.go:160 cmd/incus/operation.go:182 cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784 cmd/incus/snapshot.go:363 cmd/incus/storage.go:752 cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967 cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761 cmd/incus/top.go:98 cmd/incus/warning.go:251
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7487,7 +7495,7 @@ msgstr  ""
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
@@ -7558,7 +7566,7 @@ msgstr  ""
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
@@ -7599,7 +7607,7 @@ msgstr  ""
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
@@ -7885,7 +7893,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099 cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33 cmd/incus/network.go:1104 cmd/incus/network_acl.go:94 cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414 cmd/incus/network_zone.go:91 cmd/incus/operation.go:116 cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:1099 cmd/incus/cluster_group.go:463 cmd/incus/config_trust.go:409 cmd/incus/config_trust.go:606 cmd/incus/monitor.go:33 cmd/incus/network.go:1104 cmd/incus/network_acl.go:94 cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414 cmd/incus/network_zone.go:91 cmd/incus/operation.go:116 cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -7905,7 +7913,7 @@ msgstr  ""
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -8077,11 +8085,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr  ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
@@ -8401,7 +8409,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769 cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517 cmd/incus/profile.go:1142
+#: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769 cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518 cmd/incus/profile.go:1167
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -8417,11 +8425,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
@@ -8429,11 +8437,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
@@ -8806,7 +8814,7 @@ msgid   "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid   "incus profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -8817,7 +8825,7 @@ msgid   "incus profile assign foo default,bar\n"
         "    Remove all profile from \"foo\""
 msgstr  ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid   "incus profile create p1\n"
         "    Create a profile named p1\n"
         "\n"
@@ -8833,7 +8841,7 @@ msgid   "incus profile device add [<remote>:]profile1 <device-name> disk source=
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid   "incus profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -544,7 +544,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -667,7 +667,7 @@ msgstr "%s non è una directory"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -951,7 +951,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1638,7 +1638,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1739,7 +1739,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1933,7 +1933,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -1986,7 +1986,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2134,7 +2134,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -2273,12 +2273,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2471,7 +2471,7 @@ msgstr "Creazione del container in corso"
 msgid "Display network zones from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
@@ -2654,7 +2654,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2700,7 +2700,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2775,7 +2775,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2797,7 +2797,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3448,7 +3448,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3592,7 +3592,7 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3673,7 +3673,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4804,8 +4804,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4889,13 +4889,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5402,7 +5411,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5446,8 +5455,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5571,8 +5580,8 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -5705,9 +5714,9 @@ msgstr "Il nome del container è: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5723,7 +5732,7 @@ msgstr "Il nome del container è: %s"
 msgid "Missing required arguments"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5845,7 +5854,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6338,7 +6347,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6471,7 +6480,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6524,37 +6533,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6572,7 +6581,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6864,7 +6873,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6936,7 +6945,7 @@ msgstr "Creazione del container in corso"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7373,11 +7382,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7522,7 +7531,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7674,7 +7683,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8246,7 +8255,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
@@ -8517,7 +8526,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8564,7 +8573,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8675,7 +8684,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8755,7 +8764,7 @@ msgstr "Creazione del container in corso"
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8800,7 +8809,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9117,9 +9126,8 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
@@ -9144,7 +9152,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -9367,12 +9375,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
@@ -9800,8 +9808,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -9821,12 +9829,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
@@ -9836,12 +9844,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -10053,8 +10061,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10141,19 +10149,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10231,16 +10239,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -10290,7 +10298,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10302,7 +10310,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10322,7 +10330,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-12-14 14:00+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -530,7 +530,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -656,7 +656,7 @@ msgstr "%s はディレクトリではありません"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(none)"
 
@@ -951,7 +951,7 @@ msgstr "フォワードにポートを追加します"
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
@@ -1074,7 +1074,7 @@ msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
@@ -1354,7 +1354,7 @@ msgstr "デフォルトのリモートは削除できません"
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr "--project と --all-project は同時に指定できません"
 
@@ -1594,7 +1594,7 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1660,7 +1660,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
@@ -1778,7 +1778,7 @@ msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1966,7 +1966,7 @@ msgstr "新たにネットワークゾーンを作成します"
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
@@ -2018,7 +2018,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2163,7 +2163,7 @@ msgstr "ネットワークゾーンを削除します"
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
@@ -2300,12 +2300,12 @@ msgstr "警告を削除します"
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2499,7 +2499,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display network zones from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのイメージを表示します"
@@ -2706,7 +2706,7 @@ msgstr "ネットワークゾーン設定をYAMLで編集します"
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
@@ -2756,7 +2756,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2841,7 +2841,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2863,7 +2863,7 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3568,7 +3568,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3716,7 +3716,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr "key をプロファイルプロパティとして取得します"
 
@@ -3794,7 +3794,7 @@ msgstr "ネットワークゾーンの設定値を取得します"
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
@@ -5301,8 +5301,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -5341,8 +5341,8 @@ msgstr ""
 "  - \"type=container status=running\" 実行中のコンテナインスタンスをすべて表"
 "示します\n"
 "\n"
-"設定項目もしくは値とマッチする正規表現 "
-"(例:volatile.eth0.hwaddr=00:16:3e:.*)。\n"
+"設定項目もしくは値とマッチする正規表現 (例:volatile.eth0.hwaddr=00:16:3e:."
+"*)。\n"
 "\n"
 "複数のフィルタを指定した場合は、指定したフィルタが順に追加され、\n"
 "すべてのフィルタを満たすインスタンスが選択されます。\n"
@@ -5514,14 +5514,23 @@ msgstr "証明書の使用を制限するプロジェクトのリスト"
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 #, fuzzy
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -6227,7 +6236,7 @@ msgstr "ネットワークゾーンレコードを管理します"
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
@@ -6268,8 +6277,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -6393,8 +6402,8 @@ msgstr "クラスターメンバー名がありません"
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -6520,9 +6529,9 @@ msgstr "ピア名を指定する必要があります"
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
@@ -6537,7 +6546,7 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing required arguments"
 msgstr "プロファイル名を指定する必要があります"
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
@@ -6678,7 +6687,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -7191,7 +7200,7 @@ msgstr "PROFILES"
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -7326,7 +7335,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -7381,37 +7390,37 @@ msgstr "製品名: %v (%v)"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 #, fuzzy
 msgid "Profile description"
 msgstr "説明"
@@ -7428,7 +7437,7 @@ msgstr "新しいインスタンスに適用するプロファイル"
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
@@ -7727,7 +7736,7 @@ msgstr "フォワードからポートを削除します"
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -7798,7 +7807,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
@@ -8287,11 +8296,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 #, fuzzy
 msgid ""
 "Set profile configuration keys\n"
@@ -8466,7 +8475,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr "プロファイルプロパティとして設定します"
 
@@ -8614,7 +8623,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
@@ -9225,7 +9234,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -9532,7 +9541,7 @@ msgstr "上位デバイス"
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr "USED BY"
@@ -9578,7 +9587,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -9682,7 +9691,7 @@ msgstr "ネットワークゾーンの設定を削除します"
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
@@ -9769,7 +9778,7 @@ msgstr "新たにネットワークゾーンレコードを作成します"
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr "プロファイルプロパティの設定を削除します"
 
@@ -9816,7 +9825,7 @@ msgid ""
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 #, fuzzy
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
@@ -10157,9 +10166,8 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -10180,7 +10188,7 @@ msgstr "[<remote>:] [<cert>]"
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -10373,11 +10381,11 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
@@ -10757,8 +10765,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -10774,11 +10782,11 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
@@ -10786,11 +10794,11 @@ msgstr "[<remote>:]<profile> <key><value>..."
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
@@ -11035,8 +11043,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 "lxc init ubuntu:22.04 u1\n"
@@ -11168,12 +11176,12 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 "lxc launch ubuntu:22.04 u1\n"
@@ -11187,8 +11195,8 @@ msgstr ""
 #: cmd/incus/list.go:126
 #, fuzzy
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -11198,8 +11206,8 @@ msgid ""
 "incus list -c ns,user.comment:comment\n"
 "  List instances with their running state and user comment."
 msgstr ""
-"lxc list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  \"NAME\"、\"BASE IMAGE\"、\"STATE\"、\"IPV4\"、\"IPV6\"、\"MAC\" カラムを"
 "使ってインスタンスを一覧表示します。\n"
 "  \"BASE IMAGE\" と \"MAC\" と \"IMAGE OS\" はインスタンスの設定から生成した"
@@ -11320,8 +11328,8 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
@@ -11331,10 +11339,10 @@ msgstr ""
 #: cmd/incus/network_integration.go:233
 #, fuzzy
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
@@ -11416,7 +11424,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 #, fuzzy
 msgid ""
 "incus profile assign foo default,bar\n"
@@ -11438,7 +11446,7 @@ msgstr ""
 "lxc profile assign foo ''\n"
 "    \"foo\" からすべてのプロファイルを削除します。"
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 #, fuzzy
 msgid ""
 "incus profile create p1\n"
@@ -11472,7 +11480,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 #, fuzzy
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
@@ -11954,8 +11962,8 @@ msgstr "yes"
 #~ "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 "
 #~ "GiB.\n"
 #~ "\n"
-#~ "incus storage volume set default virtual-machine/data "
-#~ "snapshots.expiry=7d\n"
+#~ "incus storage volume set default virtual-machine/data snapshots."
+#~ "expiry=7d\n"
 #~ "    Sets the snapshot expiration period for a virtual machine \"data\" in "
 #~ "pool \"default\" to seven days."
 #~ msgstr ""
@@ -11972,8 +11980,8 @@ msgstr "yes"
 #~ "incus storage volume create p1 v1\n"
 #~ "\n"
 #~ "incus storage volume create p1 v1 < config.yaml\n"
-#~ "\tCreate storage volume v1 for pool p1 with configuration from "
-#~ "config.yaml."
+#~ "\tCreate storage volume v1 for pool p1 with configuration from config."
+#~ "yaml."
 #~ msgstr ""
 #~ "lxc init ubuntu:22.04 u1\n"
 #~ "\n"
@@ -11982,8 +11990,8 @@ msgstr "yes"
 
 #, fuzzy
 #~ msgid ""
-#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < "
-#~ "volume.yaml\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
 #~ "    Update a storage volume using the content of pool.yaml."
 #~ msgstr ""
 #~ "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
@@ -12050,8 +12058,8 @@ msgstr "yes"
 #~ "Provide the type of the storage volume if it is not custom.\n"
 #~ "Supported types are custom, image, container and virtual-machine.\n"
 #~ "\n"
-#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < "
-#~ "volume.yaml\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
 #~ "    Update a storage volume using the content of pool.yaml."
 #~ msgstr ""
 #~ "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
@@ -13104,8 +13112,8 @@ msgstr "yes"
 #~ "lxc image edit [<remote>:]<image>\n"
 #~ "    Edit image, either by launching external editor or reading STDIN.\n"
 #~ "    Example: lxc image edit <image> # launch editor\n"
-#~ "             cat image.yaml | lxc image edit <image> # read from "
-#~ "image.yaml\n"
+#~ "             cat image.yaml | lxc image edit <image> # read from image."
+#~ "yaml\n"
 #~ "\n"
 #~ "lxc image alias create [<remote>:]<alias> <fingerprint>\n"
 #~ "    Create a new alias for an existing image.\n"
@@ -14292,8 +14300,8 @@ msgstr "yes"
 #~ "  f - Base Image Fingerprint (short)\n"
 #~ "  F - Base Image Fingerprint (long)\n"
 #~ "\n"
-#~ "Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-#~ "\":\n"
+#~ "Custom columns are defined with \"[config:|devices:]key[:name][:"
+#~ "maxWidth]\":\n"
 #~ "  KEY: The (extended) config or devices key to display. If [config:|"
 #~ "devices:] is omitted then it defaults to config key.\n"
 #~ "  NAME: Name to display in the column header.\n"
@@ -14333,8 +14341,8 @@ msgstr "yes"
 #~ "  - \"type=container status=running\" 実行中のコンテナインスタンスをすべて"
 #~ "表示します\n"
 #~ "\n"
-#~ "設定項目もしくは値とマッチする正規表現 "
-#~ "(例:volatile.eth0.hwaddr=00:16:3e:.*)。\n"
+#~ "設定項目もしくは値とマッチする正規表現 (例:volatile.eth0.hwaddr=00:16:3e:."
+#~ "*)。\n"
 #~ "\n"
 #~ "複数のフィルタを指定した場合は、指定したフィルタが順に追加され、\n"
 #~ "すべてのフィルタを満たすインスタンスが選択されます。\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -327,7 +327,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1083,7 +1083,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1371,7 +1371,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1458,7 +1458,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -1705,7 +1705,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -1980,12 +1980,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2462,7 +2462,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2484,7 +2484,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3127,7 +3127,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3263,7 +3263,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4438,8 +4438,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4519,13 +4519,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5012,7 +5021,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5052,8 +5061,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5173,8 +5182,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5298,9 +5307,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5314,7 +5323,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5431,7 +5440,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -5921,7 +5930,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6052,7 +6061,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6105,37 +6114,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6151,7 +6160,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6434,7 +6443,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6500,7 +6509,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -6921,11 +6930,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7063,7 +7072,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7204,7 +7213,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -7763,7 +7772,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8030,7 +8039,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8075,7 +8084,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8176,7 +8185,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8249,7 +8258,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8292,7 +8301,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8600,9 +8609,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -8622,7 +8630,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -8802,11 +8810,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9156,8 +9164,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9173,11 +9181,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9185,11 +9193,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9382,8 +9390,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9470,19 +9478,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9560,16 +9568,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -9619,7 +9627,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9631,7 +9639,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9651,7 +9659,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
-"Last-Translator: Dklfajsjfi49wefklsf32 "
-"<nlincus@users.noreply.hosted.weblate.org>\n"
+"Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
+"org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/incus/cli/nl/>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###\n"
 "### Merk op dat alleen de configuratie kan worden aangepast."
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -682,7 +682,7 @@ msgstr "%s is geen directory"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' is geen ondersteund bestandstype"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(geen)"
 
@@ -973,7 +973,7 @@ msgstr "Voeg poorten (ports) toe aan een doorstuurregel (forward)"
 msgid "Add ports to a load balancer"
 msgstr "Voeg poorten (ports) toe aan een werkverdeler (load balancer)"
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr "Voeg profielen (profiles) toe aan instantiaties (instances)"
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Wijs collecties van groepen toe aan clusterleden (cluster members)"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 "Wijs collecties van profielen (set of profiles) toe aan instantiaties "
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1607,7 +1607,7 @@ msgstr "Clustering aan"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1673,7 +1673,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1773,7 +1773,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1956,7 +1956,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2147,7 +2147,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -2284,12 +2284,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr "Toon netwerk zones van alle projecten"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr "Toon profielen van alle projecten"
 
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2692,7 +2692,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2767,7 +2767,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2789,7 +2789,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3432,7 +3432,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3641,7 +3641,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4743,8 +4743,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4824,13 +4824,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5318,7 +5327,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5358,8 +5367,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5479,8 +5488,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5605,9 +5614,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5621,7 +5630,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5738,7 +5747,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6228,7 +6237,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6359,7 +6368,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6412,37 +6421,37 @@ msgstr "Product: %v"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6458,7 +6467,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6741,7 +6750,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6808,7 +6817,7 @@ msgstr "Hernoem netwerk integraties"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7230,11 +7239,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7376,7 +7385,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7518,7 +7527,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8077,7 +8086,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8344,7 +8353,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8389,7 +8398,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8491,7 +8500,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8566,7 +8575,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8609,7 +8618,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8917,9 +8926,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -8939,7 +8947,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -9119,11 +9127,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9473,8 +9481,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9490,11 +9498,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9502,11 +9510,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9699,8 +9707,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9787,19 +9795,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9877,16 +9885,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -9936,7 +9944,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9948,7 +9956,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9968,7 +9976,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -315,7 +315,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -408,7 +408,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1359,7 +1359,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1446,7 +1446,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -1693,7 +1693,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -1968,12 +1968,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2330,7 +2330,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2375,7 +2375,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2450,7 +2450,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2472,7 +2472,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3115,7 +3115,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3251,7 +3251,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3324,7 +3324,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4425,8 +4425,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4506,13 +4506,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -4999,7 +5008,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5039,8 +5048,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5160,8 +5169,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5285,9 +5294,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5301,7 +5310,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5418,7 +5427,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -5908,7 +5917,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6039,7 +6048,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6092,37 +6101,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6138,7 +6147,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6421,7 +6430,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6487,7 +6496,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -6908,11 +6917,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7050,7 +7059,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7191,7 +7200,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -7750,7 +7759,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8017,7 +8026,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8062,7 +8071,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8163,7 +8172,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8279,7 +8288,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8587,9 +8596,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -8609,7 +8617,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -8789,11 +8797,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9143,8 +9151,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9160,11 +9168,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9172,11 +9180,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9369,8 +9377,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9457,19 +9465,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9547,16 +9555,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -9606,7 +9614,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9618,7 +9626,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9638,7 +9646,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -528,7 +528,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -656,7 +656,7 @@ msgstr "%s não é um diretório"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
@@ -1359,7 +1359,7 @@ msgstr "Não é possível remover o default remoto"
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 #, fuzzy
 msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
@@ -1593,7 +1593,7 @@ msgstr "Clustering ativado"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1663,7 +1663,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1752,7 +1752,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
@@ -1765,7 +1765,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1966,7 +1966,7 @@ msgstr "Criar novas redes"
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr "Criar perfis"
 
@@ -2019,7 +2019,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2173,7 +2173,7 @@ msgstr "Criar novas redes"
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -2312,12 +2312,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
@@ -2700,7 +2700,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
@@ -2748,7 +2748,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2823,7 +2823,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
@@ -2845,7 +2845,7 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3493,7 +3493,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3640,7 +3640,7 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3726,7 +3726,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4853,8 +4853,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4939,13 +4939,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5455,7 +5464,7 @@ msgstr "Criar novas redes"
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5499,8 +5508,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5626,8 +5635,8 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5759,9 +5768,9 @@ msgstr "Nome de membro do cluster"
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5776,7 +5785,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5899,7 +5908,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6397,7 +6406,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6531,7 +6540,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6584,37 +6593,37 @@ msgstr "Marca: %v"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 #, fuzzy
 msgid "Profile description"
 msgstr "Descrição"
@@ -6634,7 +6643,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6933,7 +6942,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -7009,7 +7018,7 @@ msgstr "Criar novas redes"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7458,11 +7467,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7610,7 +7619,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7770,7 +7779,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8344,7 +8353,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
@@ -8615,7 +8624,7 @@ msgstr "Editar arquivos no container"
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8662,7 +8671,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8780,7 +8789,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8864,7 +8873,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8909,7 +8918,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9224,9 +9233,8 @@ msgstr "Criar perfis"
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -9249,7 +9257,7 @@ msgstr "Criar perfis"
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -9455,11 +9463,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9858,8 +9866,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -9876,11 +9884,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9888,11 +9896,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -10095,8 +10103,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10183,19 +10191,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10273,16 +10281,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -10332,7 +10340,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10344,7 +10352,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10364,7 +10372,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -553,7 +553,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -682,7 +682,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1604,7 +1604,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1662,7 +1662,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1750,7 +1750,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1763,7 +1763,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -2017,7 +2017,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2167,7 +2167,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -2306,12 +2306,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2504,7 +2504,7 @@ msgstr "Копирование образа: %s"
 msgid "Display network zones from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 #, fuzzy
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
@@ -2688,7 +2688,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2809,7 +2809,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, fuzzy, c-format
@@ -2831,7 +2831,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3487,7 +3487,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3633,7 +3633,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4851,8 +4851,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4936,13 +4936,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5455,7 +5464,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5502,8 +5511,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5629,8 +5638,8 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -5763,9 +5772,9 @@ msgstr "Имя контейнера: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5781,7 +5790,7 @@ msgstr "Имя контейнера: %s"
 msgid "Missing required arguments"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5903,7 +5912,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6407,7 +6416,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6539,7 +6548,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6592,37 +6601,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6638,7 +6647,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6931,7 +6940,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -7003,7 +7012,7 @@ msgstr "Копирование образа: %s"
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7443,11 +7452,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7594,7 +7603,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7751,7 +7760,7 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8327,7 +8336,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, fuzzy, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
@@ -8598,7 +8607,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8644,7 +8653,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8757,7 +8766,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8840,7 +8849,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8887,7 +8896,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9207,9 +9216,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -9249,7 +9257,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -9601,7 +9609,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -9609,7 +9617,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -10275,8 +10283,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -10308,7 +10316,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -10316,7 +10324,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -10332,7 +10340,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -10340,7 +10348,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -10609,8 +10617,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -10697,19 +10705,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -10787,16 +10795,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -10846,7 +10854,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10858,7 +10866,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10878,7 +10886,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -315,7 +315,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -408,7 +408,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1359,7 +1359,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1446,7 +1446,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1459,7 +1459,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -1693,7 +1693,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -1968,12 +1968,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2330,7 +2330,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2375,7 +2375,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2450,7 +2450,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2472,7 +2472,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3115,7 +3115,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3251,7 +3251,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3324,7 +3324,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4425,8 +4425,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4506,13 +4506,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -4999,7 +5008,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5039,8 +5048,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5160,8 +5169,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5285,9 +5294,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5301,7 +5310,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5418,7 +5427,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -5908,7 +5917,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6039,7 +6048,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6092,37 +6101,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6138,7 +6147,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6421,7 +6430,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6487,7 +6496,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -6908,11 +6917,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7050,7 +7059,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7191,7 +7200,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -7750,7 +7759,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8017,7 +8026,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8062,7 +8071,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8163,7 +8172,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8236,7 +8245,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8279,7 +8288,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8587,9 +8596,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -8609,7 +8617,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -8789,11 +8797,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9143,8 +9151,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9160,11 +9168,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9172,11 +9180,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9369,8 +9377,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9457,19 +9465,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9547,16 +9555,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -9606,7 +9614,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9618,7 +9626,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9638,7 +9646,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2025-03-01 08:01+0000\n"
 "Last-Translator: Loge X <wazolm5643@163.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -536,7 +536,7 @@ msgstr ""
 "###\n"
 "### 请注意，只能更改配置项。"
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -664,7 +664,7 @@ msgstr "%s 不是目录"
 msgid "'%s' isn't a supported file type"
 msgstr "“%s”不是受支持的文件类型"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "（无）"
 
@@ -955,7 +955,7 @@ msgstr "将端口添加到转发"
 msgid "Add ports to a load balancer"
 msgstr "向负载平衡器添加端口"
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr "向实例添加配置文件"
 
@@ -1077,7 +1077,7 @@ msgstr "请求 VM，但映像的类型为容器"
 msgid "Assign sets of groups to cluster members"
 msgstr "为集群成员分配组集"
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr "为实例分配配置文件集"
 
@@ -1347,7 +1347,7 @@ msgstr "无法移除默认远程服务器"
 msgid "Can't specify --fast with --columns"
 msgstr "不能用 --columns 指定 --fast"
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr "不能用 --all-projects 指定 --project"
 
@@ -1577,7 +1577,7 @@ msgstr "已启用集群"
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1641,7 +1641,7 @@ msgstr "配置选项的格式应为 KEY=VALUE"
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1742,7 +1742,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "复制配置文件继承的设备并覆盖配置密钥"
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr "复制配置文件"
 
@@ -1755,7 +1755,7 @@ msgid "Copy the volume without its snapshots"
 msgstr "复制卷但不复制快照"
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr "复制到与源不同的项目"
 
@@ -1941,7 +1941,7 @@ msgstr "创建新的网络区域"
 msgid "Create new networks"
 msgstr "创建新网络"
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr "创建配置文件"
 
@@ -1993,7 +1993,7 @@ msgstr "默认目标地址"
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -2132,7 +2132,7 @@ msgstr "删除网络区域"
 msgid "Delete networks"
 msgstr "删除网络"
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr "删除配置文件"
 
@@ -2269,12 +2269,12 @@ msgstr "删除警告"
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2457,7 +2457,7 @@ msgstr "显示所有项目的实例"
 msgid "Display network zones from all projects"
 msgstr "显示所有项目的网络区域"
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr "显示所有项目的配置文件"
 
@@ -2649,7 +2649,7 @@ msgstr "将网络区域配置编辑为 YAML"
 msgid "Edit network zone record configurations as YAML"
 msgstr "将网络区域记录配置编辑为 YAML"
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr "将配置文件配置编辑为YAML"
 
@@ -2698,7 +2698,7 @@ msgstr "将信任配置编辑为 YAML"
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2781,7 +2781,7 @@ msgstr "检索别名时出错：%w"
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2803,7 +2803,7 @@ msgstr "取消设置属性时出错：%v"
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3493,7 +3493,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3631,7 +3631,7 @@ msgstr "获取作为网络区域属性的密钥"
 msgid "Get the key as a network zone record property"
 msgstr "获取作为网络区域记录属性的密钥"
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr "获取作为配置文件属性的密钥"
 
@@ -3704,7 +3704,7 @@ msgstr "获取网络区域配置键的值"
 msgid "Get values for network zone record configuration keys"
 msgstr "获取网络区域记录配置键的值"
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr "获取配置文件配置键的值"
 
@@ -4830,8 +4830,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4911,13 +4911,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5404,7 +5413,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5444,8 +5453,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5565,8 +5574,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5690,9 +5699,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5706,7 +5715,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5824,7 +5833,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -6315,7 +6324,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6446,7 +6455,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6499,37 +6508,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6545,7 +6554,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6838,7 +6847,7 @@ msgstr "从转发中移除端口"
 msgid "Remove ports from a load balancer"
 msgstr "从负载均衡器中移除端口"
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6904,7 +6913,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -7326,11 +7335,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7469,7 +7478,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7611,7 +7620,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -8171,7 +8180,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8438,7 +8447,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8483,7 +8492,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8585,7 +8594,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8659,7 +8668,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8702,7 +8711,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -9010,9 +9019,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -9032,7 +9040,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -9214,11 +9222,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9568,8 +9576,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9585,11 +9593,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9597,11 +9605,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9794,8 +9802,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9882,19 +9890,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9972,16 +9980,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -10031,7 +10039,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -10043,7 +10051,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -10063,7 +10071,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2025-04-22 13:09-0400\n"
+"POT-Creation-Date: 2025-04-23 16:05-0500\n"
 "PO-Revision-Date: 2024-12-30 10:00+0000\n"
 "Last-Translator: pesder <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -318,7 +318,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: cmd/incus/profile.go:539
+#: cmd/incus/profile.go:540
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -411,7 +411,7 @@ msgstr "%s 不是目錄"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' 不是受支援的檔案類型"
 
-#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:257
+#: cmd/incus/cluster_group.go:166 cmd/incus/profile.go:258
 msgid "(none)"
 msgstr "(沒有)"
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:111 cmd/incus/profile.go:112
+#: cmd/incus/profile.go:112 cmd/incus/profile.go:113
 msgid "Add profiles to instances"
 msgstr ""
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: cmd/incus/profile.go:188 cmd/incus/profile.go:189
+#: cmd/incus/profile.go:189 cmd/incus/profile.go:190
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
-#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:835
+#: cmd/incus/cluster.go:257 cmd/incus/list.go:412 cmd/incus/profile.go:844
 msgid "Can't specify --project with --all-projects"
 msgstr ""
 
@@ -1304,7 +1304,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:118 cmd/incus/network_integration.go:439
 #: cmd/incus/network_load_balancer.go:126 cmd/incus/network_peer.go:114
 #: cmd/incus/network_zone.go:118 cmd/incus/operation.go:144
-#: cmd/incus/profile.go:750 cmd/incus/project.go:548 cmd/incus/remote.go:751
+#: cmd/incus/profile.go:759 cmd/incus/project.go:548 cmd/incus/remote.go:751
 #: cmd/incus/snapshot.go:323 cmd/incus/storage.go:707
 #: cmd/incus/storage_bucket.go:521 cmd/incus/storage_bucket.go:936
 #: cmd/incus/storage_volume.go:1590 cmd/incus/storage_volume.go:2640
@@ -1362,7 +1362,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:560 cmd/incus/network_forward.go:817
 #: cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:797
 #: cmd/incus/network_peer.go:832 cmd/incus/network_zone.go:737
-#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:622
+#: cmd/incus/network_zone.go:1461 cmd/incus/profile.go:623
 #: cmd/incus/project.go:417 cmd/incus/storage.go:383
 #: cmd/incus/storage_bucket.go:377 cmd/incus/storage_bucket.go:1349
 #: cmd/incus/storage_volume.go:1139 cmd/incus/storage_volume.go:1171
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:281 cmd/incus/profile.go:282
+#: cmd/incus/profile.go:282 cmd/incus/profile.go:283
 msgid "Copy profiles"
 msgstr ""
 
@@ -1462,7 +1462,7 @@ msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:64 cmd/incus/image.go:165 cmd/incus/move.go:67
-#: cmd/incus/profile.go:284 cmd/incus/storage_volume.go:376
+#: cmd/incus/profile.go:285 cmd/incus/storage_volume.go:376
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: cmd/incus/profile.go:367 cmd/incus/profile.go:368
+#: cmd/incus/profile.go:368 cmd/incus/profile.go:369
 msgid "Create profiles"
 msgstr ""
 
@@ -1696,7 +1696,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:140 cmd/incus/network_integration.go:455
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:136
 #: cmd/incus/network_zone.go:141 cmd/incus/network_zone.go:953
-#: cmd/incus/operation.go:161 cmd/incus/profile.go:778 cmd/incus/project.go:580
+#: cmd/incus/operation.go:161 cmd/incus/profile.go:787 cmd/incus/project.go:580
 #: cmd/incus/storage.go:734 cmd/incus/storage_bucket.go:538
 #: cmd/incus/storage_bucket.go:952 cmd/incus/storage_volume.go:1721
 msgid "DESCRIPTION"
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: cmd/incus/profile.go:458 cmd/incus/profile.go:459
+#: cmd/incus/profile.go:459 cmd/incus/profile.go:460
 msgid "Delete profiles"
 msgstr ""
 
@@ -1971,12 +1971,12 @@ msgstr ""
 #: cmd/incus/network_zone.go:1558 cmd/incus/network_zone.go:1574
 #: cmd/incus/network_zone.go:1634 cmd/incus/operation.go:32
 #: cmd/incus/operation.go:66 cmd/incus/operation.go:119
-#: cmd/incus/operation.go:300 cmd/incus/profile.go:36 cmd/incus/profile.go:112
-#: cmd/incus/profile.go:189 cmd/incus/profile.go:282 cmd/incus/profile.go:368
-#: cmd/incus/profile.go:459 cmd/incus/profile.go:519 cmd/incus/profile.go:657
-#: cmd/incus/profile.go:735 cmd/incus/profile.go:901 cmd/incus/profile.go:991
-#: cmd/incus/profile.go:1053 cmd/incus/profile.go:1144
-#: cmd/incus/profile.go:1210 cmd/incus/project.go:38 cmd/incus/project.go:108
+#: cmd/incus/operation.go:300 cmd/incus/profile.go:37 cmd/incus/profile.go:113
+#: cmd/incus/profile.go:190 cmd/incus/profile.go:283 cmd/incus/profile.go:369
+#: cmd/incus/profile.go:460 cmd/incus/profile.go:520 cmd/incus/profile.go:658
+#: cmd/incus/profile.go:736 cmd/incus/profile.go:926 cmd/incus/profile.go:1016
+#: cmd/incus/profile.go:1078 cmd/incus/profile.go:1169
+#: cmd/incus/profile.go:1235 cmd/incus/project.go:38 cmd/incus/project.go:108
 #: cmd/incus/project.go:214 cmd/incus/project.go:314 cmd/incus/project.go:452
 #: cmd/incus/project.go:529 cmd/incus/project.go:750 cmd/incus/project.go:817
 #: cmd/incus/project.go:907 cmd/incus/project.go:953 cmd/incus/project.go:1016
@@ -2159,7 +2159,7 @@ msgstr ""
 msgid "Display network zones from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:752
+#: cmd/incus/profile.go:761
 msgid "Display profiles from all projects"
 msgstr ""
 
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: cmd/incus/profile.go:518 cmd/incus/profile.go:519
+#: cmd/incus/profile.go:519 cmd/incus/profile.go:520
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2378,7 +2378,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:154 cmd/incus/network_integration.go:465
 #: cmd/incus/network_load_balancer.go:161 cmd/incus/network_peer.go:147
 #: cmd/incus/network_zone.go:154 cmd/incus/operation.go:176
-#: cmd/incus/profile.go:794 cmd/incus/project.go:590 cmd/incus/remote.go:778
+#: cmd/incus/profile.go:803 cmd/incus/project.go:590 cmd/incus/remote.go:778
 #: cmd/incus/snapshot.go:357 cmd/incus/storage.go:746
 #: cmd/incus/storage_bucket.go:555 cmd/incus/storage_bucket.go:961
 #: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:2755
@@ -2453,7 +2453,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:618 cmd/incus/network_integration.go:673
 #: cmd/incus/network_load_balancer.go:604 cmd/incus/network_peer.go:652
 #: cmd/incus/network_zone.go:571 cmd/incus/network_zone.go:1288
-#: cmd/incus/profile.go:1121 cmd/incus/project.go:881 cmd/incus/storage.go:923
+#: cmd/incus/profile.go:1146 cmd/incus/project.go:881 cmd/incus/storage.go:923
 #: cmd/incus/storage_bucket.go:732 cmd/incus/storage_volume.go:2117
 #: cmd/incus/storage_volume.go:2160
 #, c-format
@@ -2475,7 +2475,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:612 cmd/incus/network_integration.go:667
 #: cmd/incus/network_load_balancer.go:598 cmd/incus/network_peer.go:646
 #: cmd/incus/network_zone.go:565 cmd/incus/network_zone.go:1282
-#: cmd/incus/profile.go:1115 cmd/incus/project.go:875 cmd/incus/storage.go:917
+#: cmd/incus/profile.go:1140 cmd/incus/project.go:875 cmd/incus/storage.go:917
 #: cmd/incus/storage_bucket.go:726 cmd/incus/storage_volume.go:2111
 #: cmd/incus/storage_volume.go:2154
 #, c-format
@@ -3118,7 +3118,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:117 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:125 cmd/incus/network_peer.go:113
 #: cmd/incus/network_zone.go:116 cmd/incus/network_zone.go:890
-#: cmd/incus/operation.go:142 cmd/incus/profile.go:751 cmd/incus/project.go:550
+#: cmd/incus/operation.go:142 cmd/incus/profile.go:760 cmd/incus/project.go:550
 #: cmd/incus/project.go:1089 cmd/incus/remote.go:750 cmd/incus/snapshot.go:322
 #: cmd/incus/storage.go:709 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:934 cmd/incus/storage_volume.go:1617
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "Get the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:662
+#: cmd/incus/profile.go:663
 msgid "Get the key as a profile property"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:656 cmd/incus/profile.go:657
+#: cmd/incus/profile.go:657 cmd/incus/profile.go:658
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -4428,8 +4428,8 @@ msgid ""
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]"
-"\":\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
 "  KEY: The (extended) config or devices key to display. If [config:|"
 "devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
@@ -4509,13 +4509,22 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: cmd/incus/profile.go:734
+#: cmd/incus/profile.go:735
 msgid "List profiles"
 msgstr ""
 
-#: cmd/incus/profile.go:735
+#: cmd/incus/profile.go:736
 msgid ""
 "List profiles\n"
+"\n"
+"Filters may be of the <key>=<value> form for property based filtering,\n"
+"or part of the profile name. Filters must be delimited by a ','.\n"
+"\n"
+"Examples:\n"
+"  - \"foo\" lists all profiles that start with the name foo\n"
+"  - \"name=foo\" lists all profiles that exactly have the name foo\n"
+"  - \"description=.*bar.*\" lists all profiles with a description that "
+"contains \"bar\"\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -5002,7 +5011,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: cmd/incus/profile.go:35 cmd/incus/profile.go:36
+#: cmd/incus/profile.go:36 cmd/incus/profile.go:37
 msgid "Manage profiles"
 msgstr ""
 
@@ -5042,8 +5051,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:44 cmd/incus/remote.go:45
@@ -5163,8 +5172,8 @@ msgstr ""
 #: cmd/incus/config_metadata.go:114 cmd/incus/config_metadata.go:225
 #: cmd/incus/config_template.go:119 cmd/incus/config_template.go:176
 #: cmd/incus/config_template.go:232 cmd/incus/config_template.go:335
-#: cmd/incus/config_template.go:408 cmd/incus/profile.go:149
-#: cmd/incus/profile.go:232 cmd/incus/profile.go:938 cmd/incus/rebuild.go:44
+#: cmd/incus/config_template.go:408 cmd/incus/profile.go:150
+#: cmd/incus/profile.go:233 cmd/incus/profile.go:963 cmd/incus/rebuild.go:44
 msgid "Missing instance name"
 msgstr ""
 
@@ -5288,9 +5297,9 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:423 cmd/incus/profile.go:492 cmd/incus/profile.go:576
-#: cmd/incus/profile.go:696 cmd/incus/profile.go:1024 cmd/incus/profile.go:1094
-#: cmd/incus/profile.go:1177
+#: cmd/incus/profile.go:424 cmd/incus/profile.go:493 cmd/incus/profile.go:577
+#: cmd/incus/profile.go:697 cmd/incus/profile.go:1049 cmd/incus/profile.go:1119
+#: cmd/incus/profile.go:1202
 msgid "Missing profile name"
 msgstr ""
 
@@ -5304,7 +5313,7 @@ msgstr ""
 msgid "Missing required arguments"
 msgstr ""
 
-#: cmd/incus/profile.go:322
+#: cmd/incus/profile.go:323
 msgid "Missing source profile name"
 msgstr ""
 
@@ -5421,7 +5430,7 @@ msgstr ""
 #: cmd/incus/network.go:1152 cmd/incus/network_acl.go:176
 #: cmd/incus/network_address_set.go:163 cmd/incus/network_integration.go:454
 #: cmd/incus/network_peer.go:135 cmd/incus/network_zone.go:140
-#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:776
+#: cmd/incus/network_zone.go:952 cmd/incus/profile.go:785
 #: cmd/incus/project.go:573 cmd/incus/project.go:716 cmd/incus/remote.go:764
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:732
 #: cmd/incus/storage_bucket.go:537 cmd/incus/storage_bucket.go:951
@@ -5911,7 +5920,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1144 cmd/incus/list.go:505 cmd/incus/network.go:1151
 #: cmd/incus/network_acl.go:182 cmd/incus/network_address_set.go:170
-#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:777
+#: cmd/incus/network_zone.go:139 cmd/incus/profile.go:786
 #: cmd/incus/storage_bucket.go:536 cmd/incus/storage_volume.go:1739
 #: cmd/incus/top.go:79 cmd/incus/warning.go:222
 msgid "PROJECT"
@@ -6042,7 +6051,7 @@ msgstr ""
 #: cmd/incus/network_address_set.go:561 cmd/incus/network_forward.go:818
 #: cmd/incus/network_integration.go:314 cmd/incus/network_load_balancer.go:798
 #: cmd/incus/network_peer.go:833 cmd/incus/network_zone.go:738
-#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:623
+#: cmd/incus/network_zone.go:1462 cmd/incus/profile.go:624
 #: cmd/incus/project.go:418 cmd/incus/storage.go:384
 #: cmd/incus/storage_bucket.go:378 cmd/incus/storage_bucket.go:1350
 #: cmd/incus/storage_volume.go:1140 cmd/incus/storage_volume.go:1172
@@ -6095,37 +6104,37 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: cmd/incus/profile.go:171
+#: cmd/incus/profile.go:172
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:441
+#: cmd/incus/profile.go:442
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: cmd/incus/profile.go:502
+#: cmd/incus/profile.go:503
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: cmd/incus/profile.go:948
+#: cmd/incus/profile.go:973
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:973
+#: cmd/incus/profile.go:998
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: cmd/incus/profile.go:1034
+#: cmd/incus/profile.go:1059
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/profile.go:378
+#: cmd/incus/profile.go:379
 msgid "Profile description"
 msgstr ""
 
@@ -6141,7 +6150,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: cmd/incus/profile.go:261
+#: cmd/incus/profile.go:262
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -6424,7 +6433,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: cmd/incus/profile.go:900 cmd/incus/profile.go:901
+#: cmd/incus/profile.go:925 cmd/incus/profile.go:926
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -6490,7 +6499,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: cmd/incus/profile.go:990 cmd/incus/profile.go:991
+#: cmd/incus/profile.go:1015 cmd/incus/profile.go:1016
 msgid "Rename profiles"
 msgstr ""
 
@@ -6911,11 +6920,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1052
+#: cmd/incus/profile.go:1077
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1053
+#: cmd/incus/profile.go:1078
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -7053,7 +7062,7 @@ msgstr ""
 msgid "Set the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1060
+#: cmd/incus/profile.go:1085
 msgid "Set the key as a profile property"
 msgstr ""
 
@@ -7194,7 +7203,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: cmd/incus/profile.go:1143 cmd/incus/profile.go:1144
+#: cmd/incus/profile.go:1168 cmd/incus/profile.go:1169
 msgid "Show profile configurations"
 msgstr ""
 
@@ -7753,7 +7762,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
 
-#: cmd/incus/profile.go:709
+#: cmd/incus/profile.go:710
 #, c-format
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
@@ -8020,7 +8029,7 @@ msgstr ""
 #: cmd/incus/network.go:1158 cmd/incus/network_acl.go:178
 #: cmd/incus/network_address_set.go:166 cmd/incus/network_allocations.go:77
 #: cmd/incus/network_integration.go:457 cmd/incus/network_zone.go:142
-#: cmd/incus/profile.go:779 cmd/incus/project.go:581 cmd/incus/storage.go:736
+#: cmd/incus/profile.go:788 cmd/incus/project.go:581 cmd/incus/storage.go:736
 #: cmd/incus/storage_volume.go:1723
 msgid "USED BY"
 msgstr ""
@@ -8065,7 +8074,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:160 cmd/incus/network_integration.go:471
 #: cmd/incus/network_load_balancer.go:167 cmd/incus/network_peer.go:153
 #: cmd/incus/network_zone.go:160 cmd/incus/operation.go:182
-#: cmd/incus/profile.go:800 cmd/incus/project.go:596 cmd/incus/remote.go:784
+#: cmd/incus/profile.go:809 cmd/incus/project.go:596 cmd/incus/remote.go:784
 #: cmd/incus/snapshot.go:363 cmd/incus/storage.go:752
 #: cmd/incus/storage_bucket.go:561 cmd/incus/storage_bucket.go:967
 #: cmd/incus/storage_volume.go:1755 cmd/incus/storage_volume.go:2761
@@ -8166,7 +8175,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: cmd/incus/profile.go:1209 cmd/incus/profile.go:1210
+#: cmd/incus/profile.go:1234 cmd/incus/profile.go:1235
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -8239,7 +8248,7 @@ msgstr ""
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
-#: cmd/incus/profile.go:1214
+#: cmd/incus/profile.go:1239
 msgid "Unset the key as a profile property"
 msgstr ""
 
@@ -8282,7 +8291,7 @@ msgid ""
 "files."
 msgstr ""
 
-#: cmd/incus/profile.go:285
+#: cmd/incus/profile.go:286
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
@@ -8590,9 +8599,8 @@ msgstr ""
 #: cmd/incus/network.go:1104 cmd/incus/network_acl.go:94
 #: cmd/incus/network_address_set.go:90 cmd/incus/network_integration.go:414
 #: cmd/incus/network_zone.go:91 cmd/incus/operation.go:116
-#: cmd/incus/profile.go:732 cmd/incus/project.go:526 cmd/incus/storage.go:682
-#: cmd/incus/top.go:41 cmd/incus/version.go:21 cmd/incus/warning.go:73
-#: cmd/incus/webui.go:17
+#: cmd/incus/project.go:526 cmd/incus/storage.go:682 cmd/incus/top.go:41
+#: cmd/incus/version.go:21 cmd/incus/warning.go:73 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 
@@ -8612,7 +8620,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1085 cmd/incus/list.go:49
+#: cmd/incus/image.go:1085 cmd/incus/list.go:49 cmd/incus/profile.go:733
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -8792,11 +8800,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <old snapshot name> <new snapshot name>"
 msgstr ""
 
-#: cmd/incus/profile.go:110 cmd/incus/profile.go:899
+#: cmd/incus/profile.go:111 cmd/incus/profile.go:924
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: cmd/incus/profile.go:186
+#: cmd/incus/profile.go:187
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -9146,8 +9154,8 @@ msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
 #: cmd/incus/config_device.go:329 cmd/incus/config_device.go:769
-#: cmd/incus/profile.go:366 cmd/incus/profile.go:456 cmd/incus/profile.go:517
-#: cmd/incus/profile.go:1142
+#: cmd/incus/profile.go:367 cmd/incus/profile.go:457 cmd/incus/profile.go:518
+#: cmd/incus/profile.go:1167
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -9163,11 +9171,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: cmd/incus/profile.go:655 cmd/incus/profile.go:1208
+#: cmd/incus/profile.go:656 cmd/incus/profile.go:1233
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: cmd/incus/profile.go:1051
+#: cmd/incus/profile.go:1076
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -9175,11 +9183,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: cmd/incus/profile.go:988
+#: cmd/incus/profile.go:1013
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: cmd/incus/profile.go:279
+#: cmd/incus/profile.go:280
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -9372,8 +9380,8 @@ msgid ""
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
@@ -9460,19 +9468,19 @@ msgid ""
 "    Create and start a container using the same size as an AWS t2.micro (1 "
 "vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c "
-"limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM\n"
 "\n"
-"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d "
-"root,io.bus=nvme\n"
+"incus launch images:debian/12 v2 --vm -d root,size=50GiB -d root,io."
+"bus=nvme\n"
 "    Create and start a virtual machine, overriding the disk size and bus"
 msgstr ""
 
 #: cmd/incus/list.go:126
 msgid ""
-"incus list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
 "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
@@ -9550,16 +9558,16 @@ msgid ""
 "incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from "
-"config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:233
 msgid ""
-"incus network integration edit <network integration> < network-"
-"integration.yaml\n"
-"    Update a network integration using the content of network-"
-"integration.yaml"
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:341
@@ -9609,7 +9617,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: cmd/incus/profile.go:191
+#: cmd/incus/profile.go:192
 msgid ""
 "incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -9621,7 +9629,7 @@ msgid ""
 "    Remove all profile from \"foo\""
 msgstr ""
 
-#: cmd/incus/profile.go:370
+#: cmd/incus/profile.go:371
 msgid ""
 "incus profile create p1\n"
 "    Create a profile named p1\n"
@@ -9641,7 +9649,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: cmd/incus/profile.go:521
+#: cmd/incus/profile.go:522
 msgid ""
 "incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"


### PR DESCRIPTION
Resolves #1910

Adds server-side filtering for the `incus profile list` command.

Filters are either:
- **a string**, which filters the names of profiles
(e.g. `incus profile list foo` lists all profile names that start with `foo`)
- **a list of  `<key>=<value>` pairs** delimited by a comma `,`, which filters by profile properties.
(e,g, `incus profile list description=foobar.*` lists all profiles with a description that starts with `foobar`)