### PR TITLE
Fix reference passing when yaml unmarshal

### DIFF
--- a/cmd/incus-agent/templates.go
+++ b/cmd/incus-agent/templates.go
@@ -27,7 +27,7 @@ func templatesApply(path string) ([]string, error) {
 	}
 
 	metadata := new(api.ImageMetadata)
-	err = yaml.Unmarshal(content, &metadata)
+	err = yaml.Unmarshal(content, metadata)
 	if err != nil {
 		return nil, fmt.Errorf("Could not parse metadata.yaml: %w", err)
 	}

--- a/cmd/incus-agent/templates.go
+++ b/cmd/incus-agent/templates.go
@@ -26,7 +26,7 @@ func templatesApply(path string) ([]string, error) {
 		return nil, fmt.Errorf("Failed to read metadata: %w", err)
 	}
 
-	metadata := new(api.ImageMetadata)
+	metadata := &api.ImageMetadata{}
 	err = yaml.Unmarshal(content, metadata)
 	if err != nil {
 		return nil, fmt.Errorf("Could not parse metadata.yaml: %w", err)

--- a/cmd/incus/utils_properties_test.go
+++ b/cmd/incus/utils_properties_test.go
@@ -13,7 +13,7 @@ type utilsPropertiesTestSuite struct {
 }
 
 func TestUtilsPropertiesTestSuite(t *testing.T) {
-	suite.Run(t, new(utilsPropertiesTestSuite))
+	suite.Run(t, &utilsPropertiesTestSuite{})
 }
 
 func (s *utilsPropertiesTestSuite) TestStringToTimeHookFuncValidData() {

--- a/cmd/incus/utils_test.go
+++ b/cmd/incus/utils_test.go
@@ -14,7 +14,7 @@ type utilsTestSuite struct {
 }
 
 func TestUtilsTestSuite(t *testing.T) {
-	suite.Run(t, new(utilsTestSuite))
+	suite.Run(t, &utilsTestSuite{})
 }
 
 func (s *utilsTestSuite) TestIsAliasesSubsetTrue() {

--- a/cmd/incusd/api_cluster_evacuation.go
+++ b/cmd/incusd/api_cluster_evacuation.go
@@ -362,7 +362,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		// Limit the number of concurrent migrations to run at the same time
 		numParallelMigrations := max(runtime.NumCPU()/16, 1)
 
-		group := new(errgroup.Group)
+		group := &errgroup.Group{}
 		group.SetLimit(numParallelMigrations)
 
 		// Migrate back the remote instances.

--- a/cmd/incusd/instance_test.go
+++ b/cmd/incusd/instance_test.go
@@ -532,5 +532,5 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 }
 
 func TestContainerTestSuite(t *testing.T) {
-	suite.Run(t, new(containerTestSuite))
+	suite.Run(t, &containerTestSuite{})
 }

--- a/cmd/incusd/snapshot_common_test.go
+++ b/cmd/incusd/snapshot_common_test.go
@@ -40,5 +40,5 @@ func (s *snapshotCommonTestSuite) TestSnapshotScheduling() {
 }
 
 func TestSnapshotCommon(t *testing.T) {
-	suite.Run(t, new(snapshotCommonTestSuite))
+	suite.Run(t, &snapshotCommonTestSuite{})
 }

--- a/internal/cmd/sort_test.go
+++ b/internal/cmd/sort_test.go
@@ -12,7 +12,7 @@ type sortSuite struct {
 }
 
 func TestSortSuite(t *testing.T) {
-	suite.Run(t, new(sortSuite))
+	suite.Run(t, &sortSuite{})
 }
 
 // stringList can be used to sort a list of strings.

--- a/internal/instancewriter/instance_tar_writer.go
+++ b/internal/instancewriter/instance_tar_writer.go
@@ -25,7 +25,7 @@ type InstanceTarWriter struct {
 
 // NewInstanceTarWriter returns a ContainerTarWriter for the provided target Writer and id map.
 func NewInstanceTarWriter(writer io.Writer, idmapSet *idmap.Set) *InstanceTarWriter {
-	ctw := new(InstanceTarWriter)
+	ctw := &InstanceTarWriter{}
 	ctw.tarWriter = tar.NewWriter(writer)
 	ctw.idmapSet = idmapSet
 	ctw.linkMap = map[uint64]string{}

--- a/internal/server/auth/authorization_objects_test.go
+++ b/internal/server/auth/authorization_objects_test.go
@@ -14,7 +14,7 @@ type objectSuite struct {
 }
 
 func TestObjectSuite(t *testing.T) {
-	suite.Run(t, new(objectSuite))
+	suite.Run(t, &objectSuite{})
 }
 
 func (s *objectSuite) TestObjectCertificate() {

--- a/internal/server/db/db_internal_test.go
+++ b/internal/server/db/db_internal_test.go
@@ -78,7 +78,7 @@ func (s *dbTestSuite) CreateTestTx() (*sql.Tx, func()) {
 }
 
 func TestDBTestSuite(t *testing.T) {
-	suite.Run(t, new(dbTestSuite))
+	suite.Run(t, &dbTestSuite{})
 }
 
 func (s *dbTestSuite) Test_deleting_a_container_cascades_on_related_tables() {

--- a/internal/server/dns/handler.go
+++ b/internal/server/dns/handler.go
@@ -23,7 +23,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 	// Check if we're ready to serve queries.
 	if d.server.zoneRetriever == nil {
-		m := new(dns.Msg)
+		m := &dns.Msg{}
 		m.SetRcode(r, dns.RcodeServerFailure)
 		err := w.WriteMsg(m)
 		if err != nil {
@@ -35,7 +35,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 	// Only allow a single request.
 	if len(r.Question) != 1 {
-		m := new(dns.Msg)
+		m := &dns.Msg{}
 		m.SetRcode(r, dns.RcodeServerFailure)
 		err := w.WriteMsg(m)
 		if err != nil {
@@ -47,7 +47,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 	// Check that it's a supported request type.
 	if r.Question[0].Qtype != dns.TypeAXFR && r.Question[0].Qtype != dns.TypeIXFR && r.Question[0].Qtype != dns.TypeSOA {
-		m := new(dns.Msg)
+		m := &dns.Msg{}
 		m.SetRcode(r, dns.RcodeNotImplemented)
 		err := w.WriteMsg(m)
 		if err != nil {
@@ -61,7 +61,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	name := strings.TrimSuffix(r.Question[0].Name, ".")
 	ip, _, err := net.SplitHostPort(w.RemoteAddr().String())
 	if err != nil {
-		m := new(dns.Msg)
+		m := &dns.Msg{}
 		m.SetRcode(r, dns.RcodeServerFailure)
 		err := w.WriteMsg(m)
 		if err != nil {
@@ -72,7 +72,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	// Prepare the response.
-	m := new(dns.Msg)
+	m := &dns.Msg{}
 	m.SetReply(r)
 	m.Authoritative = true
 
@@ -80,7 +80,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	zone, err := d.server.zoneRetriever(name, r.Question[0].Qtype != dns.TypeSOA)
 	if err != nil {
 		// On failure, return NXDOMAIN.
-		m := new(dns.Msg)
+		m := &dns.Msg{}
 		m.SetRcode(r, dns.RcodeNameError)
 		err := w.WriteMsg(m)
 		if err != nil {
@@ -93,7 +93,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	// Check access.
 	if !d.isAllowed(zone.Info, ip, r.IsTsig(), w.TsigStatus() == nil) {
 		// On auth failure, return NXDOMAIN to avoid information leaks.
-		m := new(dns.Msg)
+		m := &dns.Msg{}
 		m.SetRcode(r, dns.RcodeNameError)
 		err := w.WriteMsg(m)
 		if err != nil {
@@ -111,7 +111,7 @@ func (d dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 			if err != nil {
 				logger.Errorf("Bad DNS record in zone %q: %v", name, err)
 
-				m := new(dns.Msg)
+				m := &dns.Msg{}
 				m.SetRcode(r, dns.RcodeFormatError)
 				err := w.WriteMsg(m)
 				if err != nil {

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -6176,7 +6176,7 @@ func (d *lxc) resetContainerDiskIdmap(srcIdmap *idmap.Set) error {
 	}
 
 	if dstIdmap == nil {
-		dstIdmap = new(idmap.Set)
+		dstIdmap = &idmap.Set{}
 	}
 
 	if !srcIdmap.Equals(dstIdmap) {
@@ -6364,7 +6364,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 	d.logger.Debug("Sent migration response to source")
 
-	srcIdmap := new(idmap.Set)
+	srcIdmap := &idmap.Set{}
 	for _, idmapSet := range offerHeader.Idmap {
 		e := idmap.Entry{
 			IsUID:    *idmapSet.Isuid,
@@ -6950,7 +6950,7 @@ func (d *lxc) templateApplyNow(trigger instance.TemplateTrigger) error {
 		return fmt.Errorf("Failed to read metadata: %w", err)
 	}
 
-	metadata := new(api.ImageMetadata)
+	metadata := &api.ImageMetadata{}
 	err = yaml.Unmarshal(content, &metadata)
 	if err != nil {
 		return fmt.Errorf("Could not parse %s: %w", fname, err)

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3244,7 +3244,7 @@ func (d *qemu) templateApplyNow(trigger instance.TemplateTrigger, path string) e
 	}
 
 	metadata := new(api.ImageMetadata)
-	err = yaml.Unmarshal(content, &metadata)
+	err = yaml.Unmarshal(content, metadata)
 	if err != nil {
 		return fmt.Errorf("Could not parse %s: %w", fname, err)
 	}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3243,7 +3243,7 @@ func (d *qemu) templateApplyNow(trigger instance.TemplateTrigger, path string) e
 		return fmt.Errorf("Failed to read metadata: %w", err)
 	}
 
-	metadata := new(api.ImageMetadata)
+	metadata := &api.ImageMetadata{}
 	err = yaml.Unmarshal(content, metadata)
 	if err != nil {
 		return fmt.Errorf("Could not parse %s: %w", fname, err)

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -11,7 +11,7 @@ type versionTestSuite struct {
 }
 
 func TestVersionTestSuite(t *testing.T) {
-	suite.Run(t, new(versionTestSuite))
+	suite.Run(t, &versionTestSuite{})
 }
 
 func (s *versionTestSuite) TestNewVersion() {

--- a/shared/cliconfig/file.go
+++ b/shared/cliconfig/file.go
@@ -64,7 +64,7 @@ func LoadConfig(path string) (*Config, error) {
 
 	// Decode the YAML document
 	c := NewConfig(configDir, false)
-	err = yaml.Unmarshal(content, &c)
+	err = yaml.Unmarshal(content, c)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to decode the configuration: %w", err)
 	}
@@ -80,7 +80,7 @@ func LoadConfig(path string) (*Config, error) {
 	globalConf := NewConfig("", false)
 	content, err = os.ReadFile(globalConf.GlobalConfigPath("config.yml"))
 	if err == nil {
-		err = yaml.Unmarshal(content, &globalConf)
+		err = yaml.Unmarshal(content, globalConf)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to decode the configuration: %w", err)
 		}

--- a/shared/osarch/release_test.go
+++ b/shared/osarch/release_test.go
@@ -12,7 +12,7 @@ type releaseTestSuite struct {
 }
 
 func TestReleaseTestSuite(t *testing.T) {
-	suite.Run(t, new(releaseTestSuite))
+	suite.Run(t, &releaseTestSuite{})
 }
 
 func (s *releaseTestSuite) TestGetOSRelease() {

--- a/shared/util/struct.go
+++ b/shared/util/struct.go
@@ -7,7 +7,8 @@ import (
 
 // DeepCopy copies src to dest by using encoding/gob so its not that fast.
 func DeepCopy(src, dest any) error {
-	buff := new(bytes.Buffer)
+	buff := &bytes.Buffer{}
+
 	enc := gob.NewEncoder(buff)
 	dec := gob.NewDecoder(buff)
 	err := enc.Encode(src)


### PR DESCRIPTION
For example:
	metadata := new(api.ImageMetadata) // type: *api.ImageMetadata
	err = yaml.Unmarshal(content, &metadata)

It works on `yaml.v2` and `yaml.v3` but not work under `goccy/go-yaml`, and `goccy/go-yaml` behavior is correct. So fixed it and add test cases to pretect.