### PR TITLE
doc: Fix default value of ipv4.dhcp.gateway to IPv4 address

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2945,7 +2945,7 @@ User keys can be used in search.
 
 ```{config:option} ipv4.dhcp.gateway network_bridge-common
 :condition: "IPv4 DHCP"
-:default: "all addresses"
+:default: "IPv4 address"
 :shortdesc: "Address of the gateway for the subnet"
 :type: "string"
 

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -3321,7 +3321,7 @@
 					{
 						"ipv4.dhcp.gateway": {
 							"condition": "IPv4 DHCP",
-							"default": "all addresses",
+							"default": "IPv4 address",
 							"longdesc": "",
 							"shortdesc": "Address of the gateway for the subnet",
 							"type": "string"

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -270,7 +270,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  condition: IPv4 DHCP
-		//  default: all addresses
+		//  default: IPv4 address
 		//  shortdesc: Address of the gateway for the subnet
 		"ipv4.dhcp.gateway": validate.Optional(validate.IsNetworkAddressV4),
 		// gendoc:generate(entity=network_bridge, group=common, key=ipv4.dhcp.expiry)


### PR DESCRIPTION
It was changed from "IPv4 address" to "all addresses" in
https://github.com/lxc/incus/commit/70897e34e459f53e3ef1b189cc84706546e9aca1#diff-ea939356d9c610505874f52d8134c991919241ef130a0d667572db54ce8ded46L77 and
https://github.com/lxc/incus/commit/47599d89620f930d7423f0a2252651504ad7e969#diff-5f4225b439a90e9d63cf9e7463cb3c8ae433e26a64e277494cbc124c97dee6daR1734

I think it was a mistake.