### PR TITLE
doc: Fix default value of ipv6.routes network_bridge

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -3104,7 +3104,7 @@ User keys can be used in search.
 ```
 
 ```{config:option} ipv6.routes network_bridge-common
-:condition: "IPv6"
+:condition: "IPv6 address"
 :default: "-"
 :shortdesc: "Comma-separated list of additional IPv6 CIDR subnets to route to the bridge"
 :type: "string"

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -3500,7 +3500,7 @@
 					},
 					{
 						"ipv6.routes": {
-							"condition": "IPv6",
+							"condition": "IPv6 address",
 							"default": "-",
 							"longdesc": "",
 							"shortdesc": "Comma-separated list of additional IPv6 CIDR subnets to route to the bridge",

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -404,7 +404,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//
 		// ---
 		//  type: string
-		//  condition: IPv6
+		//  condition: IPv6 address
 		//  default: -
 		//  shortdesc: Comma-separated list of additional IPv6 CIDR subnets to route to the bridge
 		"ipv6.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),


### PR DESCRIPTION
It was changed from "IPv6 address" to "IPv6"
in
https://github.com/lxc/incus/commit/70897e34e459f53e3ef1b189cc84706546e9aca1#diff-ea939356d9c610505874f52d8134c991919241ef130a0d667572db54ce8ded46L97 and
https://github.com/lxc/incus/commit/47599d89620f930d7423f0a2252651504ad7e969#diff-5f4225b439a90e9d63cf9e7463cb3c8ae433e26a64e277494cbc124c97dee6daR1893

I think it was a mistake.