### PR TITLE
rename reverters from revert to reverter to not conflict with the package

### DIFF
--- a/cmd/incus-agent/network.go
+++ b/cmd/incus-agent/network.go
@@ -101,8 +101,8 @@ func reconfigureNetworkInterfaces() {
 
 	// configureNIC applies any config specified for the interface based on its current MAC address.
 	configureNIC := func(currentNIC net.Interface) error {
-		revert := revert.New()
-		defer revert.Fail()
+		reverter := revert.New()
+		defer reverter.Fail()
 
 		// Look for a NIC config entry for this interface based on its MAC address.
 		nic, ok := nicData[currentNIC.HardwareAddr.String()]
@@ -133,7 +133,7 @@ func reconfigureNetworkInterfaces() {
 			return err
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			_ = link.SetUp()
 		})
 
@@ -144,7 +144,7 @@ func reconfigureNetworkInterfaces() {
 				return err
 			}
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				err := link.SetName(currentNIC.Name)
 				if err != nil {
 					return
@@ -165,7 +165,7 @@ func reconfigureNetworkInterfaces() {
 
 			link.MTU = nic.MTU
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				err := link.SetMTU(uint32(currentNIC.MTU))
 				if err != nil {
 					return
@@ -180,7 +180,7 @@ func reconfigureNetworkInterfaces() {
 			return err
 		}
 
-		revert.Success()
+		reverter.Success()
 		return nil
 	}
 

--- a/cmd/incus-user/server.go
+++ b/cmd/incus-user/server.go
@@ -174,8 +174,8 @@ func serverSetupUser(uid uint32) error {
 	}
 
 	// Setup reverter.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create certificate directory.
 	err = os.MkdirAll(userPath, 0o700)
@@ -183,7 +183,7 @@ func serverSetupUser(uid uint32) error {
 		return fmt.Errorf("Failed to create user directory: %w", err)
 	}
 
-	revert.Add(func() { _ = os.RemoveAll(userPath) })
+	reverter.Add(func() { _ = os.RemoveAll(userPath) })
 
 	// Generate certificate.
 	if !util.PathExists(filepath.Join(userPath, "client.crt")) || !util.PathExists(filepath.Join(userPath, "client.key")) {
@@ -229,7 +229,7 @@ func serverSetupUser(uid uint32) error {
 			return fmt.Errorf("Unable to create project: %w", err)
 		}
 
-		revert.Add(func() { _ = client.DeleteProject(projectName) })
+		reverter.Add(func() { _ = client.DeleteProject(projectName) })
 
 		// Create user-specific bridge.
 		network := api.NetworksPost{}
@@ -324,13 +324,13 @@ func serverSetupUser(uid uint32) error {
 		return fmt.Errorf("Unable to add user certificate: %w", err)
 	}
 
-	revert.Add(func() { _ = client.DeleteCertificate(localtls.CertFingerprint(x509Cert)) })
+	reverter.Add(func() { _ = client.DeleteCertificate(localtls.CertFingerprint(x509Cert)) })
 
 	// Add the new project to our list.
 	if !slices.Contains(projectNames, projectName) {
 		projectNames = append(projectNames, projectName)
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }

--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -651,10 +651,10 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		}
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		for key := range nodeValues {
 			val, ok := oldNodeConfig[key]
 			if !ok {
@@ -714,7 +714,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		}
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		for key := range req.Config {
 			val, ok := oldClusterConfig[key]
 			if !ok {
@@ -777,7 +777,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		return response.SmartError(err)
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	s.Events.SendLifecycle(api.ProjectDefaultName, lifecycle.ConfigUpdated.Event(request.CreateRequestor(r), nil))
 

--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -538,8 +538,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			return fmt.Errorf("Failed to connect to local server: %w", err)
 		}
 
-		revert := revert.New()
-		defer revert.Fail()
+		reverter := revert.New()
+		defer reverter.Fail()
 
 		// Update server name.
 		oldServerName := d.serverName
@@ -547,7 +547,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		d.serverName = req.ServerName
 		d.serverClustered = true
 		d.globalConfigMu.Unlock()
-		revert.Add(func() {
+		reverter.Add(func() {
 			d.globalConfigMu.Lock()
 			d.serverName = oldServerName
 			d.serverClustered = false
@@ -716,7 +716,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Start clustering tasks.
 		d.startClusterTasks()
-		revert.Add(func() { d.stopClusterTasks() })
+		reverter.Add(func() { d.stopClusterTasks() })
 
 		// Load the configuration.
 		var nodeConfig *node.Config
@@ -797,7 +797,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		s.Events.SendLifecycle(request.ProjectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.Requestor(), nil))
 
-		revert.Success()
+		reverter.Success()
 		return nil
 	}
 

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -845,8 +845,8 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 
 	internalImportRootDevicePopulate(instancePoolName, backupConf.Container.Devices, backupConf.Container.ExpandedDevices, profiles)
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if backupConf.Container == nil {
 		return fmt.Errorf("No instance config in backup config")
@@ -862,7 +862,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
 
-	revert.Add(cleanup)
+	reverter.Add(cleanup)
 	defer instOp.Done(err)
 
 	instancePath := storagePools.InstancePath(instanceType, projectName, backupConf.Container.Name, false)
@@ -976,7 +976,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 			return fmt.Errorf("Failed creating instance snapshot record %q: %w", snap.Name, err)
 		}
 
-		revert.Add(cleanup)
+		reverter.Add(cleanup)
 		defer snapInstOp.Done(err)
 
 		// Recreate missing mountpoints and symlinks.
@@ -991,7 +991,7 @@ func internalImportFromBackup(ctx context.Context, s *state.State, projectName s
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1963,10 +1963,10 @@ func (d *Daemon) setupOpenFGA(apiURL string, apiToken string, storeID string) er
 		"openfga.store.id":  storeID,
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		// Reset to default authorizer.
 		d.authorizer, _ = auth.LoadAuthorizer(d.shutdownCtx, auth.DriverTLS, logger.Log, d.clientCerts)
 	})
@@ -2222,7 +2222,7 @@ func (d *Daemon) setupOpenFGA(apiURL string, apiToken string, storeID string) er
 
 	d.authorizer = openfgaAuthorizer
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/cmd/incusd/instance_file.go
+++ b/cmd/incusd/instance_file.go
@@ -149,8 +149,8 @@ func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func instanceFileGet(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Get a SFTP client.
 	client, err := inst.FileSFTP()
@@ -158,7 +158,7 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 		return response.InternalError(err)
 	}
 
-	revert.Add(func() { _ = client.Close() })
+	reverter.Add(func() { _ = client.Close() })
 
 	// Get the file stats.
 	stat, err := client.Lstat(path)
@@ -191,11 +191,11 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 			return response.SmartError(err)
 		}
 
-		revert.Add(func() { _ = file.Close() })
+		reverter.Add(func() { _ = file.Close() })
 
 		// Setup cleanup logic.
-		cleanup := revert.Clone()
-		revert.Success()
+		cleanup := reverter.Clone()
+		reverter.Success()
 
 		// Make a file response struct.
 		files := make([]response.FileResponseEntry, 1)
@@ -312,8 +312,8 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func instanceFileHead(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Get a SFTP client.
 	client, err := inst.FileSFTP()
@@ -321,7 +321,7 @@ func instanceFileHead(s *state.State, inst instance.Instance, path string, r *ht
 		return response.InternalError(err)
 	}
 
-	revert.Add(func() { _ = client.Close() })
+	reverter.Add(func() { _ = client.Close() })
 
 	// Get the file stats.
 	stat, err := client.Lstat(path)

--- a/cmd/incusd/instance_logs.go
+++ b/cmd/incusd/instance_logs.go
@@ -472,8 +472,8 @@ func instanceExecOutputsGet(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	s := d.State()
 
@@ -528,9 +528,9 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	revert.Add(func() { _ = pool.UnmountInstance(inst, nil) })
-	cleanup := revert.Clone()
-	revert.Success()
+	reverter.Add(func() { _ = pool.UnmountInstance(inst, nil) })
+	cleanup := reverter.Clone()
+	reverter.Success()
 
 	ent := response.FileResponseEntry{
 		Path:     filepath.Join(inst.ExecOutputPath(), file),

--- a/cmd/incusd/instance_put.go
+++ b/cmd/incusd/instance_put.go
@@ -87,15 +87,15 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	unlock, err := instanceOperationLock(s.ShutdownCtx, projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		unlock()
 	})
 
@@ -200,7 +200,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	revert.Success()
+	reverter.Success()
 	return operations.OperationResponse(op)
 }
 

--- a/cmd/incusd/main_cluster.go
+++ b/cmd/incusd/main_cluster.go
@@ -564,9 +564,9 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		revert := revert.New()
-		defer revert.Fail()
-		revert.Add(func() {
+		reverter := revert.New()
+		defer reverter.Fail()
+		reverter.Add(func() {
 			_ = f.Close()
 			_ = os.Remove(f.Name())
 		})
@@ -592,8 +592,8 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		revert.Success()
-		revert.Add(func() { _ = os.Remove(path) })
+		reverter.Success()
+		reverter.Add(func() { _ = os.Remove(path) })
 	} else {
 		path = inPath
 	}

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -487,8 +487,8 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 
 // patchThinpoolTypoFix renames any config incorrectly set config file entries due to the lvm.thinpool_name typo.
 func patchThinpoolTypoFix(name string, d *Daemon) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Setup a transaction.
 	tx, err := d.db.Cluster.Begin()
@@ -496,7 +496,7 @@ func patchThinpoolTypoFix(name string, d *Daemon) error {
 		return fmt.Errorf("Failed to begin transaction: %w", err)
 	}
 
-	revert.Add(func() { _ = tx.Rollback() })
+	reverter.Add(func() { _ = tx.Rollback() })
 
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(context.TODO(), tx, "SELECT id FROM nodes")
@@ -547,7 +547,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 		return fmt.Errorf("Failed to commit transaction: %w", err)
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -1260,8 +1260,8 @@ func patchRuntimeDirectory(name string, d *Daemon) error {
 
 // The lvm.vg.force_reuse config key is node-specific and need to be linked to nodes.
 func patchLvmForceReuseKey(name string, d *Daemon) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Setup a transaction.
 	tx, err := d.db.Cluster.Begin()
@@ -1269,7 +1269,7 @@ func patchLvmForceReuseKey(name string, d *Daemon) error {
 		return fmt.Errorf("Failed to begin transaction: %w", err)
 	}
 
-	revert.Add(func() { _ = tx.Rollback() })
+	reverter.Add(func() { _ = tx.Rollback() })
 
 	// Fetch the IDs of all existing nodes.
 	nodeIDs, err := query.SelectIntegers(context.TODO(), tx, "SELECT id FROM nodes")
@@ -1318,7 +1318,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 		return fmt.Errorf("Failed to commit transaction: %w", err)
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/cmd/incusd/storage_buckets.go
+++ b/cmd/incusd/storage_buckets.go
@@ -457,15 +457,15 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed loading storage pool: %w", err))
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	err = pool.CreateBucket(bucketProjectName, req, nil)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed creating storage bucket: %w", err))
 	}
 
-	revert.Add(func() { _ = pool.DeleteBucket(bucketProjectName, req.Name, nil) })
+	reverter.Add(func() { _ = pool.DeleteBucket(bucketProjectName, req.Name, nil) })
 
 	// Create admin key for new bucket.
 	adminKeyReq := api.StorageBucketKeysPost{
@@ -495,7 +495,7 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 
 	u := api.NewURL().Path(version.APIVersion, "storage-pools", pool.Name(), "buckets", req.Name)
 
-	revert.Success()
+	reverter.Success()
 	return response.SyncResponseLocation(true, adminKey, u.String())
 }
 

--- a/internal/linux/memfd.go
+++ b/internal/linux/memfd.go
@@ -19,7 +19,7 @@ func CreateMemfd(content []byte) (*os.File, error) {
 		return nil, err
 	}
 
-	reverter.Add(func() { unix.Close(fd) })
+	reverter.Add(func() { _ = unix.Close(fd) })
 
 	// Set its size.
 	err = unix.Ftruncate(fd, int64(len(content)))

--- a/internal/linux/memfd.go
+++ b/internal/linux/memfd.go
@@ -10,8 +10,8 @@ import (
 
 // CreateMemfd creates a new memfd for the provided byte slice.
 func CreateMemfd(content []byte) (*os.File, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the memfd.
 	fd, err := unix.MemfdCreate("memfd", unix.MFD_CLOEXEC)
@@ -19,7 +19,7 @@ func CreateMemfd(content []byte) (*os.File, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { unix.Close(fd) })
+	reverter.Add(func() { unix.Close(fd) })
 
 	// Set its size.
 	err = unix.Ftruncate(fd, int64(len(content)))
@@ -42,6 +42,7 @@ func CreateMemfd(content []byte) (*os.File, error) {
 		return nil, err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return os.NewFile(uintptr(fd), "memfd"), nil
 }

--- a/internal/linux/pty.go
+++ b/internal/linux/pty.go
@@ -12,8 +12,9 @@ import (
 
 // OpenPtyInDevpts creates a new PTS pair, configures them and returns them.
 func OpenPtyInDevpts(devpts_fd int, uid, gid int64) (*os.File, *os.File, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
+
 	var fd int
 	var ptx *os.File
 	var err error
@@ -30,7 +31,7 @@ func OpenPtyInDevpts(devpts_fd int, uid, gid int64) (*os.File, *os.File, error) 
 	}
 
 	ptx = os.NewFile(uintptr(fd), "/dev/pts/ptmx")
-	revert.Add(func() { _ = ptx.Close() })
+	reverter.Add(func() { _ = ptx.Close() })
 
 	// Unlock the ptx and pty.
 	val := 0
@@ -69,7 +70,8 @@ func OpenPtyInDevpts(devpts_fd int, uid, gid int64) (*os.File, *os.File, error) 
 			return nil, nil, err
 		}
 	}
-	revert.Add(func() { _ = pty.Close() })
+
+	reverter.Add(func() { _ = pty.Close() })
 
 	// Configure both sides
 	for _, entry := range []*os.File{ptx, pty} {
@@ -116,7 +118,8 @@ func OpenPtyInDevpts(devpts_fd int, uid, gid int64) (*os.File, *os.File, error) 
 		return nil, nil, err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return ptx, pty, nil
 }
 

--- a/internal/server/apparmor/archive.go
+++ b/internal/server/apparmor/archive.go
@@ -20,8 +20,8 @@ func ArchiveWrapper(sysOS *sys.OS, cmd *exec.Cmd, output string, allowedCmds []s
 		return func() {}, nil
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Load the profile.
 	profileName, err := archiveProfileLoad(sysOS, output, allowedCmds)
@@ -29,7 +29,7 @@ func ArchiveWrapper(sysOS *sys.OS, cmd *exec.Cmd, output string, allowedCmds []s
 		return nil, fmt.Errorf("Failed to load apparmor profile: %w", err)
 	}
 
-	revert.Add(func() { _ = deleteProfile(sysOS, profileName, profileName) })
+	reverter.Add(func() { _ = deleteProfile(sysOS, profileName, profileName) })
 
 	// Resolve aa-exec.
 	execPath, err := exec.LookPath("aa-exec")
@@ -48,14 +48,14 @@ func ArchiveWrapper(sysOS *sys.OS, cmd *exec.Cmd, output string, allowedCmds []s
 		_ = deleteProfile(sysOS, profileName, profileName)
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return cleanup, nil
 }
 
 func archiveProfileLoad(sysOS *sys.OS, output string, allowedCommandPaths []string) (string, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Generate a temporary profile name.
 	name := profileName("archive", uuid.New().String())
@@ -73,7 +73,7 @@ func archiveProfileLoad(sysOS *sys.OS, output string, allowedCommandPaths []stri
 		return "", err
 	}
 
-	revert.Add(func() { os.Remove(profilePath) })
+	reverter.Add(func() { os.Remove(profilePath) })
 
 	// Load it.
 	err = loadProfile(sysOS, name)
@@ -81,7 +81,7 @@ func archiveProfileLoad(sysOS *sys.OS, output string, allowedCommandPaths []stri
 		return "", err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return name, nil
 }
 

--- a/internal/server/apparmor/rsync.go
+++ b/internal/server/apparmor/rsync.go
@@ -73,8 +73,8 @@ func RsyncWrapper(sysOS *sys.OS, cmd *exec.Cmd, sourcePath string, dstPath strin
 		return func() {}, nil
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Attempt to deref all paths.
 	if sourcePath != "" {
@@ -97,7 +97,7 @@ func RsyncWrapper(sysOS *sys.OS, cmd *exec.Cmd, sourcePath string, dstPath strin
 		return nil, fmt.Errorf("Failed to load rsync profile: %w", err)
 	}
 
-	revert.Add(func() { _ = deleteProfile(sysOS, profileName, profileName) })
+	reverter.Add(func() { _ = deleteProfile(sysOS, profileName, profileName) })
 
 	// Resolve aa-exec.
 	execPath, err := exec.LookPath("aa-exec")
@@ -116,14 +116,14 @@ func RsyncWrapper(sysOS *sys.OS, cmd *exec.Cmd, sourcePath string, dstPath strin
 		_ = deleteProfile(sysOS, profileName, profileName)
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return cleanup, nil
 }
 
 func rsyncProfileLoad(sysOS *sys.OS, sourcePath string, dstPath string) (string, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Generate a temporary profile name.
 	name := profileName("rsync", uuid.New().String())
@@ -141,7 +141,7 @@ func rsyncProfileLoad(sysOS *sys.OS, sourcePath string, dstPath string) (string,
 		return "", err
 	}
 
-	revert.Add(func() { os.Remove(profilePath) })
+	reverter.Add(func() { os.Remove(profilePath) })
 
 	// Load it.
 	err = loadProfile(sysOS, name)
@@ -149,7 +149,7 @@ func rsyncProfileLoad(sysOS *sys.OS, sourcePath string, dstPath string) (string,
 		return "", err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return name, nil
 }
 

--- a/internal/server/backup/backup_volume.go
+++ b/internal/server/backup/backup_volume.go
@@ -66,8 +66,8 @@ func (b *VolumeBackup) Rename(newName string) error {
 	newParentName, _, _ := api.GetParentAndSnapshotName(newName)
 	newParentBackupsPath := internalUtil.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, newParentName))
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the new backup path if doesn't exist.
 	if !util.PathExists(newParentBackupsPath) {
@@ -83,7 +83,7 @@ func (b *VolumeBackup) Rename(newName string) error {
 		return err
 	}
 
-	revert.Add(func() { _ = os.Rename(newBackupPath, oldBackupPath) })
+	reverter.Add(func() { _ = os.Rename(newBackupPath, oldBackupPath) })
 
 	// Check if we can remove the old parent directory.
 	empty, _ := internalUtil.PathIsEmpty(oldParentBackupsPath)
@@ -102,7 +102,7 @@ func (b *VolumeBackup) Rename(newName string) error {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/bgp/server.go
+++ b/internal/server/bgp/server.go
@@ -204,8 +204,8 @@ func (s *Server) configure(address string, asn uint32, routerID net.IP) error {
 	oldRouterID := s.routerID
 
 	// Setup reverter.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Stop the listener.
 	err := s.stop()
@@ -216,7 +216,7 @@ func (s *Server) configure(address string, asn uint32, routerID net.IP) error {
 	// Check if we should start.
 	if address != "" && asn > 0 && routerID != nil {
 		// Restore old address on failure.
-		revert.Add(func() { _ = s.start(oldAddress, oldASN, oldRouterID) })
+		reverter.Add(func() { _ = s.start(oldAddress, oldASN, oldRouterID) })
 
 		// Start the listener with the new address.
 		err = s.start(address, asn, routerID)
@@ -226,7 +226,7 @@ func (s *Server) configure(address string, asn uint32, routerID net.IP) error {
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/cluster/events.go
+++ b/internal/server/cluster/events.go
@@ -400,8 +400,8 @@ func eventsConnect(address string, networkCert *localtls.CertInfo, serverCert *l
 		return nil, err
 	}
 
-	revert := revert.New()
-	revert.Add(func() {
+	reverter := revert.New()
+	reverter.Add(func() {
 		client.Disconnect()
 	})
 
@@ -410,7 +410,7 @@ func eventsConnect(address string, networkCert *localtls.CertInfo, serverCert *l
 		return nil, err
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	lc := &eventListenerClient{
 		EventListener: listener,

--- a/internal/server/cluster/gateway.go
+++ b/internal/server/cluster/gateway.go
@@ -1047,15 +1047,15 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 	deadline, _ := ctx.Deadline()
 	dialer := &net.Dialer{Timeout: time.Until(deadline)}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	conn, err := tls.DialWithDialer(dialer, "tcp", addr, config)
 	if err != nil {
 		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addr, err)
 	}
 
-	revert.Add(func() { _ = conn.Close() })
+	reverter.Add(func() { _ = conn.Close() })
 
 	l := logger.AddContext(logger.Ctx{"name": name, "local": conn.LocalAddr(), "remote": conn.RemoteAddr()})
 	l.Debug("Dqlite connected outbound")
@@ -1102,7 +1102,7 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 		return nil, fmt.Errorf("Missing or unexpected Upgrade header in response")
 	}
 
-	revert.Success()
+	reverter.Success()
 	return conn, nil
 }
 

--- a/internal/server/device/gpu_mdev.go
+++ b/internal/server/device/gpu_mdev.go
@@ -63,8 +63,8 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	var pciAddress string
 	for _, gpu := range gpus.Cards {
@@ -137,7 +137,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 				return nil, fmt.Errorf("Failed to create virtual gpu %q: %w", mdevUUID, err)
 			}
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				path := fmt.Sprintf("/sys/bus/mdev/devices/%s", mdevUUID)
 
 				if util.PathExists(path) {
@@ -179,7 +179,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return &runConf, nil
 }

--- a/internal/server/device/gpu_sriov.go
+++ b/internal/server/device/gpu_sriov.go
@@ -305,8 +305,8 @@ func (d *gpuSRIOV) getVF() (string, int, error) {
 // setupSriovParent configures a SR-IOV virtual function (VF) device on parent and stores original properties of
 // the physical device into voltatile for restoration on detach. Returns VF PCI device info.
 func (d *gpuSRIOV) setupSriovParent(parentPCIAddress string, vfID int, volatile map[string]string) (pcidev.Device, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	volatile["last_state.pci.parent"] = parentPCIAddress
 	volatile["last_state.vf.id"] = fmt.Sprintf("%d", vfID)
@@ -324,7 +324,7 @@ func (d *gpuSRIOV) setupSriovParent(parentPCIAddress string, vfID int, volatile 
 		return vfPCIDev, err
 	}
 
-	revert.Add(func() { _ = pcidev.DeviceProbe(vfPCIDev) })
+	reverter.Add(func() { _ = pcidev.DeviceProbe(vfPCIDev) })
 
 	// Register VF device with vfio-pci driver so it can be passed to VM.
 	err = pcidev.DeviceDriverOverride(vfPCIDev, "vfio-pci")
@@ -335,7 +335,7 @@ func (d *gpuSRIOV) setupSriovParent(parentPCIAddress string, vfID int, volatile 
 	// Record original driver used by VF device for restore.
 	volatile["last_state.pci.driver"] = vfPCIDev.Driver
 
-	revert.Success()
+	reverter.Success()
 
 	return vfPCIDev, nil
 }
@@ -389,8 +389,8 @@ func (d *gpuSRIOV) restoreSriovParent(volatile map[string]string) error {
 		return nil
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Get VF device's PCI info so we can unbind and rebind it from the host.
 	vfPCIDev, err := d.getVFDevicePCISlot(volatile["last_state.pci.parent"], volatile["last_state.vf.id"])
@@ -415,7 +415,7 @@ func (d *gpuSRIOV) restoreSriovParent(volatile map[string]string) error {
 
 	// However we return from this function, we must try to rebind the VF so its not orphaned.
 	// The OS won't let an already bound device be bound again so is safe to call twice.
-	revert.Add(func() { _ = pcidev.DeviceProbe(vfPCIDev) })
+	reverter.Add(func() { _ = pcidev.DeviceProbe(vfPCIDev) })
 
 	// Bind VF device onto the host so that the settings will take effect.
 	err = pcidev.DeviceProbe(vfPCIDev)
@@ -423,6 +423,7 @@ func (d *gpuSRIOV) restoreSriovParent(volatile map[string]string) error {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }

--- a/internal/server/device/infiniband_sriov.go
+++ b/internal/server/device/infiniband_sriov.go
@@ -323,8 +323,8 @@ func (d *infinibandSRIOV) postStop() error {
 // setupSriovParent configures a SR-IOV virtual function (VF) device on parent and stores original properties of
 // the physical device into voltatile for restoration on detach. Returns VF PCI device info.
 func (d *infinibandSRIOV) setupSriovParent(parentPCIAddress string, vfID int, volatile map[string]string) (pcidev.Device, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	volatile["last_state.pci.parent"] = parentPCIAddress
 	volatile["last_state.vf.id"] = fmt.Sprintf("%d", vfID)
@@ -342,7 +342,7 @@ func (d *infinibandSRIOV) setupSriovParent(parentPCIAddress string, vfID int, vo
 		return vfPCIDev, err
 	}
 
-	revert.Add(func() { _ = pcidev.DeviceProbe(vfPCIDev) })
+	reverter.Add(func() { _ = pcidev.DeviceProbe(vfPCIDev) })
 
 	// Register VF device with vfio-pci driver so it can be passed to VM.
 	err = pcidev.DeviceDriverOverride(vfPCIDev, "vfio-pci")
@@ -353,7 +353,7 @@ func (d *infinibandSRIOV) setupSriovParent(parentPCIAddress string, vfID int, vo
 	// Record original driver used by VF device for restore.
 	volatile["last_state.pci.driver"] = vfPCIDev.Driver
 
-	revert.Success()
+	reverter.Success()
 
 	return vfPCIDev, nil
 }

--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -733,8 +733,8 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	saveData := make(map[string]string)
 	saveData["host_name"] = d.config["host_name"]
@@ -766,7 +766,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
+	reverter.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
@@ -814,7 +814,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(r)
+	reverter.Add(r)
 
 	// Attach host side veth interface to bridge.
 	err = network.AttachInterface(d.state, d.config["parent"], saveData["host_name"])
@@ -822,7 +822,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = network.DetachInterface(d.state, d.config["parent"], saveData["host_name"]) })
+	reverter.Add(func() { _ = network.DetachInterface(d.state, d.config["parent"], saveData["host_name"]) })
 
 	// Attempt to disable router advertisement acceptance.
 	err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
@@ -919,7 +919,8 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 			}...)
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return &runConf, nil
 }
 
@@ -952,8 +953,8 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 		}
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// If instance is running, apply host side limits and filters first before rebuilding
 	// dnsmasq config below so that existing config can be used as part of the filter removal.
@@ -1001,7 +1002,7 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 			return err
 		}
 
-		revert.Add(r)
+		reverter.Add(r)
 	}
 
 	// Rebuild dnsmasq entry if needed and reload.
@@ -1037,7 +1038,8 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 
@@ -1205,8 +1207,8 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 // setupHostFilters applies any host side network filters.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
 func (d *nicBridged) setupHostFilters(oldConfig deviceConfig.Device) (revert.Hook, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Check br_netfilter kernel module is loaded and enabled for IPv6 before clearing existing rules.
 	// We won't try to load it as its default mode can cause unwanted traffic blocking.
@@ -1229,11 +1231,12 @@ func (d *nicBridged) setupHostFilters(oldConfig deviceConfig.Device) (revert.Hoo
 			return nil, err
 		}
 
-		revert.Add(func() { d.removeFilters(d.config) })
+		reverter.Add(func() { d.removeFilters(d.config) })
 	}
 
-	cleanup := revert.Clone().Fail
-	revert.Success()
+	cleanup := reverter.Clone().Fail
+	reverter.Success()
+
 	return cleanup, nil
 }
 
@@ -1400,9 +1403,10 @@ func (d *nicBridged) setFilters() (err error) {
 	}
 
 	// If anything goes wrong, clean up so we don't leave orphaned rules.
-	revert := revert.New()
-	defer revert.Fail()
-	revert.Add(func() { d.removeFilters(config) })
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() { d.removeFilters(config) })
 
 	ipv4Nets, ipv6Nets, err := allowedIPNets(config)
 	if err != nil {
@@ -1470,7 +1474,8 @@ func (d *nicBridged) setFilters() (err error) {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 

--- a/internal/server/device/nic_ipvlan.go
+++ b/internal/server/device/nic_ipvlan.go
@@ -309,8 +309,8 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 	networkCreateSharedDeviceLock.Lock()
 	defer networkCreateSharedDeviceLock.Unlock()
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	saveData := make(map[string]string)
 
@@ -402,7 +402,7 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 					return nil, fmt.Errorf("Failed adding host route %q: %w", r.Route, err)
 				}
 
-				revert.Add(func() { _ = r.Delete() })
+				reverter.Add(func() { _ = r.Delete() })
 
 				// Add static routes to instance IPs from custom routing tables if specified.
 				hostTableKey := fmt.Sprintf("%s.host_table", keyPrefix)
@@ -419,7 +419,7 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 						return nil, fmt.Errorf("Failed adding host route %q: %w", r.Route, err)
 					}
 
-					revert.Add(func() { _ = r.Delete() })
+					reverter.Add(func() { _ = r.Delete() })
 				}
 
 				// Add neighbour proxy entries on the host for l3s mode.
@@ -433,7 +433,7 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 					return nil, fmt.Errorf("Failed adding neighbour proxy %q to %q: %w", np.Addr.String(), np.DevName, err)
 				}
 
-				revert.Add(func() { _ = np.Delete() })
+				reverter.Add(func() { _ = np.Delete() })
 			}
 		}
 
@@ -458,7 +458,8 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf.NetworkInterface = nic
 
-	revert.Success()
+	reverter.Success()
+
 	return &runConf, nil
 }
 

--- a/internal/server/device/nic_macvlan.go
+++ b/internal/server/device/nic_macvlan.go
@@ -222,8 +222,8 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 	networkCreateSharedDeviceLock.Lock()
 	defer networkCreateSharedDeviceLock.Unlock()
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	saveData := make(map[string]string)
 
@@ -246,7 +246,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 	saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
 
 	if util.IsTrue(saveData["last_state.created"]) {
-		revert.Add(func() {
+		reverter.Add(func() {
 			_ = networkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
 		})
 	}
@@ -317,7 +317,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	revert.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
+	reverter.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
 
 	if d.inst.Type() == instancetype.VM {
 		// Disable IPv6 on host interface to avoid getting IPv6 link-local addresses unnecessarily.
@@ -353,7 +353,8 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 			}...)
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return &runConf, nil
 }
 

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -585,8 +585,8 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	saveData := make(map[string]string)
 	saveData["host_name"] = d.config["host_name"]
@@ -659,7 +659,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				return nil, fmt.Errorf("Failed setting up VF: %w", err)
 			}
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				_ = networkSRIOVRestoreVF(d.deviceCommon, false, saveData)
 			})
 
@@ -720,7 +720,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				return nil, err
 			}
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				_ = networkSRIOVRestoreVF(d.deviceCommon, false, saveData)
 			})
 
@@ -771,7 +771,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				}
 			}
 
-			revert.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
+			reverter.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
 		}
 	}
 
@@ -817,7 +817,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 
 	saveData["last_state.ip_addresses"] = dnsIPsStr.String()
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = d.network.InstanceDevicePortStop("", &network.OVNInstanceNICStopOpts{
 			InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 			DeviceName:   d.name,
@@ -832,7 +832,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 			return nil, err
 		}
 
-		revert.Add(cleanup)
+		reverter.Add(cleanup)
 	}
 
 	runConf := deviceConfig.RunConfig{}
@@ -914,7 +914,8 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return &runConf, nil
 }
 
@@ -1371,8 +1372,8 @@ func (d *nicOVN) Register() error {
 }
 
 func (d *nicOVN) setupHostNIC(hostName string, ovnPortName ovn.OVNSwitchPort) (revert.Hook, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Disable IPv6 on host-side veth interface (prevents host-side interface getting link-local address and
 	// accepting router advertisements) as not needed because the host-side interface is connected to a bridge.
@@ -1400,7 +1401,7 @@ func (d *nicOVN) setupHostNIC(hostName string, ovnPortName ovn.OVNSwitchPort) (r
 		return nil, err
 	}
 
-	revert.Add(func() { _ = vswitch.DeleteBridgePort(context.TODO(), integrationBridge, hostName) })
+	reverter.Add(func() { _ = vswitch.DeleteBridgePort(context.TODO(), integrationBridge, hostName) })
 
 	// Link OVS port to OVN logical port.
 	err = vswitch.AssociateInterfaceOVNSwitchPort(context.TODO(), hostName, string(ovnPortName))
@@ -1415,7 +1416,8 @@ func (d *nicOVN) setupHostNIC(hostName string, ovnPortName ovn.OVNSwitchPort) (r
 		return nil, fmt.Errorf("Failed to bring up the host interface %s: %w", hostName, err)
 	}
 
-	cleanup := revert.Clone().Fail
-	revert.Success()
+	cleanup := reverter.Clone().Fail
+	reverter.Success()
+
 	return cleanup, err
 }

--- a/internal/server/device/nic_p2p.go
+++ b/internal/server/device/nic_p2p.go
@@ -162,8 +162,8 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	saveData := make(map[string]string)
 	saveData["host_name"] = d.config["host_name"]
@@ -197,7 +197,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
+	reverter.Add(func() { _ = network.InterfaceRemove(saveData["host_name"]) })
 
 	// Attempt to disable router advertisement acceptance.
 	err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
@@ -246,7 +246,8 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 			}...)
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return &runConf, nil
 }
 

--- a/internal/server/device/nic_physical.go
+++ b/internal/server/device/nic_physical.go
@@ -179,8 +179,8 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 	saveData := make(map[string]string)
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// pciIOMMUGroup, used for VM physical passthrough.
 	var pciIOMMUGroup uint64
@@ -206,7 +206,7 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 		saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
 
 		if util.IsTrue(saveData["last_state.created"]) {
-			revert.Add(func() {
+			reverter.Add(func() {
 				_ = networkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
 			})
 		}
@@ -304,7 +304,8 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 			}...)
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return &runConf, nil
 }
 

--- a/internal/server/device/pci/pci.go
+++ b/internal/server/device/pci/pci.go
@@ -105,8 +105,8 @@ func DeviceProbe(pciDev Device) error {
 // DeviceDriverOverride unbinds the device, sets the driver override preference, then probes the device, and
 // waits for it to be activated with the specified driver.
 func DeviceDriverOverride(pciDev Device, driverOverride string) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Unbind the device from the host (ignore if not bound).
 	err := DeviceUnbind(pciDev)
@@ -114,7 +114,7 @@ func DeviceDriverOverride(pciDev Device, driverOverride string) error {
 		return err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		// Reset the driver override and rebind to original driver (if needed).
 		_ = DeviceUnbind(pciDev)
 		_ = DeviceSetDriverOverride(pciDev, pciDev.Driver)
@@ -146,7 +146,8 @@ func DeviceDriverOverride(pciDev Device, driverOverride string) error {
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 

--- a/internal/server/device/tpm.go
+++ b/internal/server/device/tpm.go
@@ -127,11 +127,11 @@ func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
 		return nil, fmt.Errorf("Failed to start process %q: %w", "swtpm", err)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Stop the TPM emulator if anything goes wrong.
-	revert.Add(func() { _ = proc.Stop() })
+	reverter.Add(func() { _ = proc.Stop() })
 
 	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
 
@@ -202,7 +202,7 @@ func (d *tpm) startContainer() (*deviceConfig.RunConfig, error) {
 		return nil, fmt.Errorf("Failed to setup unix device: %w", err)
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return &runConf, nil
 }
@@ -233,10 +233,10 @@ func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
 		return nil, fmt.Errorf("Failed to start swtpm for device %q: %w", d.name, err)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { _ = proc.Stop() })
+	reverter.Add(func() { _ = proc.Stop() })
 
 	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
 
@@ -260,7 +260,7 @@ func (d *tpm) startVM() (*deviceConfig.RunConfig, error) {
 		return nil, fmt.Errorf("swtpm socket didn't appear within 2s")
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return &runConf, nil
 }

--- a/internal/server/dns/server.go
+++ b/internal/server/dns/server.go
@@ -122,8 +122,8 @@ func (s *Server) reconfigure(address string) error {
 	oldAddress := s.address
 
 	// Setup reverter.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Stop the listener.
 	err := s.stop()
@@ -134,7 +134,7 @@ func (s *Server) reconfigure(address string) error {
 	// Check if we should start.
 	if address != "" {
 		// Restore old address on failure.
-		revert.Add(func() { _ = s.start(oldAddress) })
+		reverter.Add(func() { _ = s.start(oldAddress) })
 
 		// Start the listener with the new address.
 		err = s.start(address)
@@ -144,7 +144,8 @@ func (s *Server) reconfigure(address string) error {
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 

--- a/internal/server/firewall/drivers/drivers_xtables.go
+++ b/internal/server/firewall/drivers/drivers_xtables.go
@@ -937,9 +937,10 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 	listenAddressStr := forward.ListenAddress.String()
 	targetAddressStr := forward.TargetAddress.String()
 
-	revert := revert.New()
-	defer revert.Fail()
-	revert.Add(func() { _ = d.InstanceClearProxyNAT(projectName, instanceName, deviceName) })
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() { _ = d.InstanceClearProxyNAT(projectName, instanceName, deviceName) })
 
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
@@ -982,7 +983,8 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 
@@ -1658,6 +1660,7 @@ func (d Xtables) NetworkApplyForwards(networkName string, rules []AddressForward
 	}
 
 	reverter.Success()
+
 	return nil
 }
 

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -169,8 +169,8 @@ func lxcStatusCode(state liblxc.State) api.StatusCode {
 // lxcCreate creates the DB storage records and sets up instance devices.
 // Returns a revert fail function that can be used to undo this function if a subsequent step fails.
 func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project, op *operations.Operation) (instance.Instance, revert.Hook, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the container struct
 	d := &lxc{
@@ -315,7 +315,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project, op *operatio
 			return nil, nil, err
 		}
 
-		revert.Add(cleanup)
+		reverter.Add(cleanup)
 	}
 
 	if d.isSnapshot {
@@ -333,7 +333,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project, op *operatio
 			logger.Error("Failed to add instance to authorizer", logger.Ctx{"instanceName": d.Name(), "projectName": d.project.Name, "error": err})
 		}
 
-		revert.Add(func() { d.state.Authorizer.DeleteInstance(d.state.ShutdownCtx, d.project.Name, d.Name()) })
+		reverter.Add(func() { _ = d.state.Authorizer.DeleteInstance(d.state.ShutdownCtx, d.project.Name, d.Name()) })
 
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
 			"type":         api.InstanceTypeContainer,
@@ -342,8 +342,9 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project, op *operatio
 		}))
 	}
 
-	cleanup := revert.Clone().Fail
-	revert.Success()
+	cleanup := reverter.Clone().Fail
+	reverter.Success()
+
 	return d, cleanup, err
 }
 
@@ -671,8 +672,8 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 	// cleaned up (if needed) when the garbage collector destroys this instance struct.
 	d.cFinalizer.Do(func() { runtime.SetFinalizer(d, lxcUnload) })
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Load the go-lxc struct
 	cname := project.Instance(d.Project().Name, d.Name())
@@ -681,7 +682,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		return nil, err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = cc.Release()
 	})
 
@@ -752,7 +753,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 
 		d.c = cc
 
-		revert.Success()
+		reverter.Success()
 		return cc, err
 	}
 
@@ -1339,7 +1340,8 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 	}
 
 	d.c = cc
-	revert.Success()
+	reverter.Success()
+
 	return cc, err
 }
 
@@ -1419,8 +1421,8 @@ func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfi
 	l := d.logger.AddContext(logger.Ctx{"device": dev.Name(), "type": configCopy["type"]})
 	l.Debug("Starting device")
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if instanceRunning && !dev.CanHotPlug() {
 		return nil, fmt.Errorf("Device cannot be started when instance is running")
@@ -1431,7 +1433,7 @@ func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfi
 		return nil, err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		runConf, _ := dev.Stop()
 		if runConf != nil {
 			_ = d.runHooks(runConf.PostHooks)
@@ -1484,7 +1486,8 @@ func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfi
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return runConf, nil
 }
 
@@ -1920,8 +1923,8 @@ func (d *lxc) handleIdmappedStorage() (idmap.StorageType, *idmap.Set, error) {
 func (d *lxc) startCommon() (string, []func() error, error) {
 	postStartHooks := []func() error{}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Assign NUMA node(s) if needed.
 	if d.expandedConfig["limits.cpu.nodes"] == "balanced" {
@@ -2037,7 +2040,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		return nil
 	})
 
-	revert.Add(func() { _ = d.unmount() })
+	reverter.Add(func() { _ = d.unmount() })
 
 	idmapType, nextIdmap, err := d.handleIdmappedStorage()
 	if err != nil {
@@ -2142,7 +2145,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		}
 
 		// Stop device on failure to setup container.
-		revert.Add(func() {
+		reverter.Add(func() {
 			err := d.deviceStop(dev, false, "")
 			if err != nil {
 				d.logger.Error("Failed to cleanup device", logger.Ctx{"device": dev.Name(), "err": err})
@@ -2154,7 +2157,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		}
 
 		if runConf.Revert != nil {
-			revert.Add(runConf.Revert)
+			reverter.Add(runConf.Revert)
 		}
 
 		// Process rootfs setup.
@@ -2657,7 +2660,8 @@ ff02::2 ip6-allrouters
 		return "", nil, err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return configPath, postStartHooks, nil
 }
 
@@ -4006,8 +4010,8 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 
 	d.logger.Debug("Mounting instance to check for CRIU state path existence")
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Ensure that storage is mounted for state path checks and for backup.yaml updates.
 	_, err = d.mount()
@@ -4016,7 +4020,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		return err
 	}
 
-	revert.Add(func() { _ = d.unmount() })
+	reverter.Add(func() { _ = d.unmount() })
 
 	// Check for CRIU if necessary, before doing a bunch of filesystem manipulations.
 	// Requires container be mounted to check StatePath exists.
@@ -4035,7 +4039,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	// Restore the rootfs.
 	err = pool.RestoreInstanceSnapshot(d, sourceContainer, nil)
@@ -4410,12 +4414,13 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 			return fmt.Errorf("Failed renaming instance: %w", err)
 		}
 	}
-	revert := revert.New()
-	defer revert.Fail()
+
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Set the new name in the struct.
 	d.name = newName
-	revert.Add(func() { d.name = oldName })
+	reverter.Add(func() { d.name = oldName })
 
 	// Rename the backups.
 	backups, err := d.Backups()
@@ -4434,7 +4439,7 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 			return err
 		}
 
-		revert.Add(func() { _ = b.Rename(oldName) })
+		reverter.Add(func() { _ = b.Rename(oldName) })
 	}
 
 	// Invalidate the go-lxc cache.
@@ -4474,7 +4479,8 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 
@@ -6377,8 +6383,8 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		srcIdmap.Entries = append(srcIdmap.Entries, e)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	g, ctx := errgroup.WithContext(context.Background())
 
@@ -6540,7 +6546,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 						return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 					}
 
-					revert.Add(cleanup)
+					reverter.Add(cleanup)
 					defer snapInstOp.Done(err)
 				}
 			}
@@ -6556,7 +6562,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		// Only delete all instance volumes on error if the pool volume creation has succeeded to
 		// avoid deleting an existing conflicting volume.
 		if !volTargetArgs.Refresh && !isRemoteClusterMove {
-			revert.Add(func() {
+			reverter.Add(func() {
 				snapshots, _ := d.Snapshots()
 				snapshotCount := len(snapshots)
 				for k := range snapshots {
@@ -6726,7 +6732,8 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		// not collect the error, as it will just be a disconnect error from the source.
 		_ = g.Wait()
 
-		revert.Success()
+		reverter.Success()
+
 		return nil
 	}
 }
@@ -7204,8 +7211,8 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 	}
 
 	// Setup reverter.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the listener.
 	_ = os.Remove(forkfilePath)
@@ -7214,7 +7221,7 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 		return nil, err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = forkfileListener.Close()
 		_ = os.Remove(forkfilePath)
 	})
@@ -7367,7 +7374,8 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
+
 	return forkfileConn, nil
 }
 

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -658,8 +658,8 @@ func (m *Monitor) AddObject(args map[string]any) error {
 
 // AddBlockDevice adds a block device.
 func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	nodeName, ok := blockDev["node-name"].(string)
 	if !ok {
@@ -672,7 +672,7 @@ func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any)
 			return fmt.Errorf("Failed adding block device: %w", err)
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			_ = m.RemoveBlockDevice(nodeName)
 		})
 	}
@@ -682,7 +682,8 @@ func (m *Monitor) AddBlockDevice(blockDev map[string]any, device map[string]any)
 		return fmt.Errorf("Failed adding device: %w", err)
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 
@@ -776,8 +777,8 @@ func (m *Monitor) RemoveDevice(deviceID string) error {
 
 // AddNIC adds a NIC device.
 func (m *Monitor) AddNIC(netDev map[string]any, device map[string]any) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if netDev != nil {
 		err := m.Run("netdev_add", netDev, nil)
@@ -785,7 +786,7 @@ func (m *Monitor) AddNIC(netDev map[string]any, device map[string]any) error {
 			return fmt.Errorf("Failed adding NIC netdev: %w", err)
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			netDevDel := map[string]any{
 				"id": netDev["id"],
 			}
@@ -802,7 +803,8 @@ func (m *Monitor) AddNIC(netDev map[string]any, device map[string]any) error {
 		return fmt.Errorf("Failed adding NIC device: %w", err)
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }
 

--- a/internal/server/network/driver_macvlan.go
+++ b/internal/server/network/driver_macvlan.go
@@ -62,16 +62,16 @@ func (n *macvlan) Rename(newName string) error {
 func (n *macvlan) Start() error {
 	n.logger.Debug("Start")
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { n.setUnavailable() })
+	reverter.Add(func() { n.setUnavailable() })
 
 	if !InterfaceExists(n.config["parent"]) {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	// Ensure network is marked as available now its started.
 	n.setAvailable()
@@ -107,11 +107,11 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientTyp
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Define a function which reverts everything.
-	revert.Add(func() {
+	reverter.Add(func() {
 		// Reset changes to all nodes and database.
 		_ = n.common.update(oldNetwork, targetNode, clientType)
 	})
@@ -122,6 +122,7 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientTyp
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
+
 	return nil
 }

--- a/internal/server/network/driver_physical.go
+++ b/internal/server/network/driver_physical.go
@@ -154,17 +154,17 @@ func (n *physical) Rename(newName string) error {
 func (n *physical) Start() error {
 	n.logger.Debug("Start")
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { n.setUnavailable() })
+	reverter.Add(func() { n.setUnavailable() })
 
 	err := n.setup(nil)
 	if err != nil {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	// Ensure network is marked as available now its started.
 	n.setAvailable()
@@ -173,8 +173,8 @@ func (n *physical) Start() error {
 }
 
 func (n *physical) setup(oldConfig map[string]string) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if !InterfaceExists(n.config["parent"]) {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
@@ -188,7 +188,7 @@ func (n *physical) setup(oldConfig map[string]string) error {
 	}
 
 	if created {
-		revert.Add(func() { _ = InterfaceRemove(hostName) })
+		reverter.Add(func() { _ = InterfaceRemove(hostName) })
 	}
 
 	// Set the MTU.
@@ -223,7 +223,7 @@ func (n *physical) setup(oldConfig map[string]string) error {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -290,8 +290,8 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	hostNameChanged := slices.Contains(changedKeys, "vlan") || slices.Contains(changedKeys, "parent")
 
@@ -325,7 +325,7 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 	}
 
 	// Define a function which reverts everything.
-	revert.Add(func() {
+	reverter.Add(func() {
 		// Reset changes to all nodes and database.
 		_ = n.common.update(oldNetwork, targetNode, clientType)
 	})
@@ -366,7 +366,7 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	// Notify dependent networks (those using this network as their uplink) of the changes.
 	// Do this after the network has been successfully updated so that a failure to notify a dependent network

--- a/internal/server/network/driver_sriov.go
+++ b/internal/server/network/driver_sriov.go
@@ -61,16 +61,16 @@ func (n *sriov) Rename(newName string) error {
 func (n *sriov) Start() error {
 	n.logger.Debug("Start")
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { n.setUnavailable() })
+	reverter.Add(func() { n.setUnavailable() })
 
 	if !InterfaceExists(n.config["parent"]) {
 		return fmt.Errorf("Parent interface %q not found", n.config["parent"])
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	// Ensure network is marked as available now its started.
 	n.setAvailable()
@@ -106,11 +106,11 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType 
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Define a function which reverts everything.
-	revert.Add(func() {
+	reverter.Add(func() {
 		// Reset changes to all nodes and database.
 		_ = n.common.update(oldNetwork, targetNode, clientType)
 	})
@@ -121,6 +121,6 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType 
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }

--- a/internal/server/network/zone/zone.go
+++ b/internal/server/network/zone/zone.go
@@ -270,8 +270,8 @@ func (d *zone) Update(config *api.NetworkZonePut, clientType request.ClientType)
 		return err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Update the database and notify the rest of the cluster.
 	if clientType == request.ClientTypeNormal {
@@ -287,7 +287,7 @@ func (d *zone) Update(config *api.NetworkZonePut, clientType request.ClientType)
 		d.info.NetworkZonePut = *config
 		d.init(d.state, d.id, d.projectName, d.info)
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			_ = d.state.DB.Cluster.UpdateNetworkZone(d.id, &oldConfig)
 			d.info.NetworkZonePut = oldConfig
 			d.init(d.state, d.id, d.projectName, d.info)
@@ -313,7 +313,7 @@ func (d *zone) Update(config *api.NetworkZonePut, clientType request.ClientType)
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -142,8 +142,8 @@ func (d *btrfs) Create() error {
 	// Store the provided source as we are likely to be mangling it.
 	d.config["volatile.initial_source"] = d.config["source"]
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	err := d.FillConfig()
 	if err != nil {
@@ -166,7 +166,7 @@ func (d *btrfs) Create() error {
 			return fmt.Errorf("Failed to create the sparse file: %w", err)
 		}
 
-		revert.Add(func() { _ = os.Remove(d.config["source"]) })
+		reverter.Add(func() { _ = os.Remove(d.config["source"]) })
 
 		// Format the file.
 		_, err = makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name})
@@ -255,7 +255,7 @@ func (d *btrfs) Create() error {
 		return fmt.Errorf(`Invalid "source" property`)
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/storage/drivers/driver_btrfs_utils.go
+++ b/internal/server/storage/drivers/driver_btrfs_utils.go
@@ -182,8 +182,8 @@ func (d *btrfs) getSubvolumes(path string) ([]string, error) {
 // snapshotSubvolume creates a snapshot of the specified path at the dest supplied. If recursion is true and
 // sub volumes are found below the path then they are created at the relative location in dest.
 func (d *btrfs) snapshotSubvolume(path string, dest string, recursion bool) (revert.Hook, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Single subvolume creation.
 	snapshot := func(path string, dest string) error {
@@ -192,7 +192,7 @@ func (d *btrfs) snapshotSubvolume(path string, dest string, recursion bool) (rev
 			return err
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			// Don't delete recursive since there already is a revert hook
 			// for each subvolume that got created.
 			_ = d.deleteSubvolume(dest, false)
@@ -230,8 +230,8 @@ func (d *btrfs) snapshotSubvolume(path string, dest string, recursion bool) (rev
 		}
 	}
 
-	cleanup := revert.Clone().Fail
-	revert.Success()
+	cleanup := reverter.Clone().Fail
+	reverter.Success()
 	return cleanup, nil
 }
 

--- a/internal/server/storage/drivers/driver_ceph.go
+++ b/internal/server/storage/drivers/driver_ceph.go
@@ -124,8 +124,8 @@ func (d *ceph) FillConfig() error {
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
 func (d *ceph) Create() error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	d.config["volatile.initial_source"] = d.config["source"]
 
@@ -175,7 +175,7 @@ func (d *ceph) Create() error {
 			return err
 		}
 
-		revert.Add(func() { _ = d.osdDeletePool() })
+		reverter.Add(func() { _ = d.osdDeletePool() })
 
 		// Initialize the pool. This is not necessary but allows the pool to be monitored.
 		_, err = subprocess.TryRunCommand("rbd",
@@ -249,7 +249,7 @@ func (d *ceph) Create() error {
 		d.config["ceph.osd.pg_num"] = msg
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }

--- a/internal/server/storage/drivers/driver_cephfs.go
+++ b/internal/server/storage/drivers/driver_cephfs.go
@@ -115,8 +115,8 @@ func (d *cephfs) FillConfig() error {
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
 func (d *cephfs) Create() error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	err := d.FillConfig()
 	if err != nil {
@@ -191,7 +191,7 @@ func (d *cephfs) Create() error {
 					return fmt.Errorf("Failed to create ceph OSD pool %q: %w", pool, err)
 				}
 
-				revert.Add(func() {
+				reverter.Add(func() {
 					// Delete the OSD pool.
 					_, _ = subprocess.RunCommand("ceph",
 						"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
@@ -221,7 +221,7 @@ func (d *cephfs) Create() error {
 			return fmt.Errorf("Failed to create CephFS %q: %w", fsName, err)
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			// Set the FS to fail so that we can remove it.
 			_, _ = subprocess.RunCommand("ceph",
 				"--name", fmt.Sprintf("client.%s", d.config["cephfs.user.name"]),
@@ -310,7 +310,7 @@ func (d *cephfs) Create() error {
 		return fmt.Errorf("Only empty CephFS paths can be used as a storage pool")
 	}
 
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }

--- a/internal/server/storage/drivers/driver_dir_utils.go
+++ b/internal/server/storage/drivers/driver_dir_utils.go
@@ -34,12 +34,12 @@ func (d *dir) setupInitialQuota(vol Volume) (revert.Hook, error) {
 		return nil, err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Define a function to revert the quota being setup.
 	revertFunc := func() { _ = d.deleteQuota(volPath, volID) }
-	revert.Add(revertFunc)
+	reverter.Add(revertFunc)
 
 	// Initialize the volume's project using the volume ID and set the quota.
 	sizeBytes, err := units.ParseByteSizeString(vol.ConfigSize())
@@ -52,7 +52,7 @@ func (d *dir) setupInitialQuota(vol Volume) (revert.Hook, error) {
 		return nil, err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return revertFunc, nil
 }
 

--- a/internal/server/storage/drivers/driver_dir_volumes.go
+++ b/internal/server/storage/drivers/driver_dir_volumes.go
@@ -27,8 +27,8 @@ import (
 func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
 	volPath := vol.MountPath()
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if util.PathExists(vol.MountPath()) {
 		return fmt.Errorf("Volume path %q already exists", vol.MountPath())
@@ -40,7 +40,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		return err
 	}
 
-	revert.Add(func() { _ = os.RemoveAll(volPath) })
+	reverter.Add(func() { _ = os.RemoveAll(volPath) })
 
 	// Get path to disk volume if volume is block or iso.
 	rootBlockPath := ""
@@ -58,7 +58,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		if revertFunc != nil {
-			revert.Add(revertFunc)
+			reverter.Add(revertFunc)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -117,17 +117,17 @@ func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 				return err
 			}
 
-			revert := revert.New()
-			defer revert.Fail()
+			reverter := revert.New()
+			defer reverter.Fail()
 
 			revertQuota, err := d.setupInitialQuota(vol)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(revertQuota)
+			reverter.Add(revertQuota)
 
-			revert.Success()
+			reverter.Success()
 			return nil
 		}
 
@@ -434,11 +434,11 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		return err
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	snapPath := snapVol.MountPath()
-	revert.Add(func() { _ = os.RemoveAll(snapPath) })
+	reverter.Add(func() { _ = os.RemoveAll(snapPath) })
 
 	if snapVol.contentType != ContentTypeBlock || snapVol.volType != VolumeTypeCustom {
 		var rsyncArgs []string
@@ -483,7 +483,7 @@ func (d *dir) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -461,8 +461,8 @@ func (d *lvm) createLogicalVolumeSnapshot(vgName string, srcVol Volume, snapVol 
 		args = append(args, "-prw")
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// If clustered, we need to acquire exclusive write access for this operation.
 	if d.clustered && !makeThinLv {
@@ -484,13 +484,13 @@ func (d *lvm) createLogicalVolumeSnapshot(vgName string, srcVol Volume, snapVol 
 
 	d.logger.Debug("Logical volume snapshot created", logCtx)
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = d.removeLogicalVolume(d.lvmDevPath(vgName, snapVol.volType, snapVol.contentType, snapVol.name))
 	})
 
 	targetVolDevPath := d.lvmDevPath(vgName, snapVol.volType, snapVol.contentType, snapVol.name)
 
-	revert.Success()
+	reverter.Success()
 	return targetVolDevPath, nil
 }
 
@@ -591,8 +591,8 @@ func (d *lvm) resizeLogicalVolume(lvPath string, sizeBytes int64) error {
 
 // copyThinpoolVolume makes an optimised copy of a thinpool volume by using thinpool snapshots.
 func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refresh bool) error {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	removeVols := []string{}
 
@@ -624,7 +624,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 				return err
 			}
 
-			revert.Add(func() { _ = os.RemoveAll(newSnapVolPath) })
+			reverter.Add(func() { _ = os.RemoveAll(newSnapVolPath) })
 
 			// We do not modify the original snapshot so as to avoid damaging if it is corrupted for
 			// some reason. If the filesystem needs to have a unique UUID generated in order to mount
@@ -634,7 +634,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 				return fmt.Errorf("Error creating LVM logical volume snapshot: %w", err)
 			}
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				_ = d.removeLogicalVolume(d.lvmDevPath(d.config["lvm.vg_name"], newSnapVol.volType, newSnapVol.contentType, newSnapVol.name))
 			})
 		}
@@ -661,7 +661,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 			// Record this volume to be removed at the very end.
 			removeVols = append(removeVols, tmpVolName)
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				// Rename the original volume back to the original name.
 				_ = d.renameLogicalVolume(tmpVolDevPath, newVolDevPath)
 			})
@@ -675,7 +675,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 			return err
 		}
 
-		revert.Add(func() { _ = os.RemoveAll(volPath) })
+		reverter.Add(func() { _ = os.RemoveAll(volPath) })
 	}
 
 	// Create snapshot of source volume as new volume.
@@ -686,7 +686,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = d.removeLogicalVolume(volDevPath)
 	})
 
@@ -731,7 +731,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/storage/drivers/driver_zfs.go
+++ b/internal/server/storage/drivers/driver_zfs.go
@@ -454,10 +454,10 @@ func (d *zfs) Create() error {
 	}
 
 	// Setup revert in case of problems
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() { _ = d.Delete(nil) })
+	reverter.Add(func() { _ = d.Delete(nil) })
 
 	// Apply our default configuration.
 	err = d.ensureInitialDatasets(false)
@@ -465,7 +465,7 @@ func (d *zfs) Create() error {
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -42,8 +42,8 @@ import (
 // filler function.
 func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
 	// Revert handling
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if vol.contentType == ContentTypeFS {
 		// Create mountpoint.
@@ -52,7 +52,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			return err
 		}
 
-		revert.Add(func() { _ = os.Remove(vol.MountPath()) })
+		reverter.Add(func() { _ = os.Remove(vol.MountPath()) })
 	}
 
 	// Look for previously deleted images.
@@ -131,7 +131,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				}
 
 				// We now have a restored image, so setup revert.
-				revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+				reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 
 				if vol.IsVMBlock() {
 					fsVol := vol.NewVMBlockFilesystemVolume()
@@ -144,7 +144,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 					// No need to revert.add since we have already succeeded.
 				}
 
-				revert.Success()
+				reverter.Success()
 				return nil
 			}
 		}
@@ -158,7 +158,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		// After this point we have a filesystem, so setup revert.
-		revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+		reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 
 		// Apply the size limit.
 		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
@@ -232,7 +232,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		// After this point we'll have a volume, so setup revert.
-		revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+		reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 
 		if vol.contentType == ContentTypeFS {
 			// Wait up to 30 seconds for the device to appear.
@@ -266,7 +266,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		reverter.Add(func() { _ = d.DeleteVolume(fsVol, op) })
 	}
 
 	err := vol.MountTask(func(mountPath string, op *operations.Operation) error {
@@ -354,7 +354,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }
@@ -375,8 +375,8 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		return nil, nil, fmt.Errorf("Cannot restore volume, already exists on target")
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Define a revert function that will be used both to revert if an error occurs inside this
 	// function but also return it for use from the calling functions if no error internally.
@@ -392,7 +392,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 	}
 
 	// Only execute the revert function if we have had an error internally.
-	revert.Add(revertHook)
+	reverter.Add(revertHook)
 
 	// Define function to unpack a volume from a backup tarball file.
 	unpackVolume := func(v Volume, r io.ReadSeeker, unpacker []string, srcFile string, target string) error {
@@ -554,7 +554,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 				return nil, nil, err
 			}
 
-			revert.Add(func() { _, _ = d.UnmountVolume(v, false, op) })
+			reverter.Add(func() { _, _ = d.UnmountVolume(v, false, op) })
 
 			postHook = func(postVol Volume) error {
 				_, err := d.UnmountVolume(postVol, false, op)
@@ -563,8 +563,8 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		}
 	}
 
-	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
-	revert.Success()
+	cleanup := reverter.Clone().Fail // Clone before calling reverter.Success() so we can return the Fail func.
+	reverter.Success()
 	return postHook, cleanup, nil
 }
 
@@ -573,8 +573,8 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	var err error
 
 	// Revert handling
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if vol.contentType == ContentTypeFS {
 		// Create mountpoint.
@@ -583,7 +583,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			return err
 		}
 
-		revert.Add(func() { _ = os.Remove(vol.MountPath()) })
+		reverter.Add(func() { _ = os.Remove(vol.MountPath()) })
 	}
 
 	// For VMs, also copy the filesystem dataset.
@@ -598,7 +598,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		}
 
 		// Delete on revert.
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		reverter.Add(func() { _ = d.DeleteVolume(fsVol, op) })
 	}
 
 	// Retrieve snapshots on the source.
@@ -621,7 +621,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			return err
 		}
 
-		revert.Add(func() { _ = unfreezeFS() })
+		reverter.Add(func() { _ = unfreezeFS() })
 	}
 
 	var srcSnapshot string
@@ -650,7 +650,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			}()
 		} else {
 			// Delete the snapshot on revert.
-			revert.Add(func() {
+			reverter.Add(func() {
 				// Delete snapshot (or mark for deferred deletion if cannot be deleted currently).
 				_, err := subprocess.RunCommand("zfs", "destroy", "-r", "-d", srcSnapshot)
 				if err != nil {
@@ -666,7 +666,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	}
 
 	// Delete the volume created on failure.
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 
 	// If zfs.clone_copy is disabled or source volume has snapshots, then use full copy mode.
 	if util.IsFalse(d.config["zfs.clone_copy"]) || len(snapshots) > 0 {
@@ -900,7 +900,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -1086,8 +1086,8 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 		}
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Handle zfs send/receive migration.
 	if len(volTargetArgs.Snapshots) > 0 {
@@ -1116,14 +1116,14 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 				return fmt.Errorf("Failed receiving snapshot volume %q: %w", snapVol.Name(), err)
 			}
 
-			revert.Add(func() {
+			reverter.Add(func() {
 				_ = d.DeleteVolumeSnapshot(snapVol, op)
 			})
 		}
 	}
 
 	if !volTargetArgs.Refresh {
-		revert.Add(func() {
+		reverter.Add(func() {
 			_ = d.DeleteVolume(vol, op)
 		})
 	}
@@ -1245,7 +1245,7 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -2238,8 +2238,8 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 
 	defer unlock()
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	dataset := d.dataset(vol, false)
 	mountPath := vol.MountPath()
@@ -2292,7 +2292,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 		}
 
 		if activated {
-			revert.Add(func() { _, _ = d.deactivateVolume(vol) })
+			reverter.Add(func() { _, _ = d.deactivateVolume(vol) })
 		}
 
 		if !IsContentBlock(vol.contentType) && d.isBlockBacked(vol) && !linux.IsMountPoint(mountPath) {
@@ -2327,7 +2327,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 	}
 
 	vol.MountRefCountIncrement() // From here on it is up to caller to call UnmountVolume() when done.
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -2414,8 +2414,8 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, newVolName, vol.config, vol.poolConfig)
 
 	// Revert handling.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// First rename the VFS paths.
 	err := genericVFSRenameVolume(d, vol, newVolName, op)
@@ -2423,7 +2423,7 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 		return err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = genericVFSRenameVolume(d, newVol, vol.name, op)
 	})
 
@@ -2433,7 +2433,7 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 		return err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_, _ = subprocess.RunCommand("zfs", "rename", d.dataset(newVol, false), d.dataset(vol, false))
 	})
 
@@ -2453,14 +2453,14 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 			return err
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			newFsVol := NewVolume(d, d.name, newVol.volType, ContentTypeFS, newVol.name, newVol.config, newVol.poolConfig)
 			_ = d.RenameVolume(newFsVol, vol.name, op)
 		})
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }
@@ -2728,8 +2728,8 @@ func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrc
 }
 
 func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	poolPath := GetPoolMountPath(d.name)
 	tmpDir, err := os.MkdirTemp(poolPath, "backup.")
@@ -2737,7 +2737,7 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 		return "", nil, err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = os.RemoveAll(tmpDir)
 	})
 
@@ -2761,7 +2761,7 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 		return "", nil, err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		// Delete snapshot (or mark for deferred deletion if cannot be deleted currently).
 		_, err := subprocess.RunCommand("zfs", "destroy", "-r", "-d", snapshotDataset)
 		if err != nil {
@@ -2774,10 +2774,10 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 		return "", nil, err
 	}
 
-	revert.Add(hook)
+	reverter.Add(hook)
 
-	cleanup := revert.Clone().Fail
-	revert.Success()
+	cleanup := reverter.Clone().Fail
+	reverter.Success()
 	return tmpDir, cleanup, nil
 }
 
@@ -2951,8 +2951,8 @@ func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
 	parentName, _, _ := api.GetParentAndSnapshotName(vol.name)
 
 	// Revert handling.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the parent directory.
 	err := createParentSnapshotDirIfMissing(d.name, vol.volType, parentName)
@@ -2972,7 +2972,7 @@ func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
 		return err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolumeSnapshot(vol, op) })
+	reverter.Add(func() { _ = d.DeleteVolumeSnapshot(vol, op) })
 
 	// For VM images, create a filesystem volume too.
 	if vol.IsVMBlock() {
@@ -2982,11 +2982,11 @@ func (d *zfs) CreateVolumeSnapshot(vol Volume, op *operations.Operation) error {
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
+		reverter.Add(func() { _ = d.DeleteVolumeSnapshot(fsVol, op) })
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }
@@ -3058,8 +3058,8 @@ func (d *zfs) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) erro
 }
 
 func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountPath string, op *operations.Operation) (revert.Hook, error) {
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Check if filesystem volume already mounted.
 	if snapVol.contentType == ContentTypeFS && !d.isBlockBacked(snapVol) {
@@ -3088,7 +3088,7 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 			return nil, err
 		}
 
-		revert.Add(func() { _, _ = d.UnmountVolume(parentVol, false, op) })
+		reverter.Add(func() { _, _ = d.UnmountVolume(parentVol, false, op) })
 
 		parentDataset := d.dataset(parentVol, false)
 
@@ -3156,7 +3156,7 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 				}
 
 				// Delete on revert.
-				revert.Add(func() { _ = d.deleteDatasetRecursive(dataset) })
+				reverter.Add(func() { _ = d.deleteDatasetRecursive(dataset) })
 
 				err := d.setDatasetProperties(dataset, "volmode=dev")
 				if err != nil {
@@ -3229,7 +3229,7 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 
 	d.logger.Debug("Mounted ZFS snapshot dataset", logger.Ctx{"dev": snapshotDataset, "path": mountPath})
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_, err := forceUnmount(mountPath)
 		if err != nil {
 			return
@@ -3238,8 +3238,8 @@ func (d *zfs) mountVolumeSnapshot(snapVol Volume, snapshotDataset string, mountP
 		d.logger.Debug("Unmounted ZFS snapshot dataset", logger.Ctx{"dev": snapshotDataset, "path": mountPath})
 	})
 
-	cleanup := revert.Clone().Fail
-	revert.Success()
+	cleanup := reverter.Clone().Fail
+	reverter.Success()
 	return cleanup, nil
 }
 
@@ -3472,8 +3472,8 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, fmt.Sprintf("%s/%s", parentName, newSnapshotName), vol.config, vol.poolConfig)
 
 	// Revert handling.
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// First rename the VFS paths.
 	err := genericVFSRenameVolumeSnapshot(d, vol, newSnapshotName, op)
@@ -3481,7 +3481,7 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 		return err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = genericVFSRenameVolumeSnapshot(d, newVol, vol.name, op)
 	})
 
@@ -3491,7 +3491,7 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 		return err
 	}
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_, _ = subprocess.RunCommand("zfs", "rename", d.dataset(newVol, false), d.dataset(vol, false))
 	})
 
@@ -3503,14 +3503,14 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 			return err
 		}
 
-		revert.Add(func() {
+		reverter.Add(func() {
 			newFsVol := NewVolume(d, d.name, newVol.volType, ContentTypeFS, newVol.name, newVol.config, newVol.poolConfig)
 			_ = d.RenameVolumeSnapshot(newFsVol, vol.name, op)
 		})
 	}
 
 	// All done.
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -67,8 +67,8 @@ func genericVFSRenameVolume(d Driver, vol Volume, newVolName string, op *operati
 		return fmt.Errorf("Volume must not be a snapshot")
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Rename the volume itself.
 	srcVolumePath := GetVolumeMountPath(d.Name(), vol.volType, vol.name)
@@ -80,7 +80,7 @@ func genericVFSRenameVolume(d Driver, vol Volume, newVolName string, op *operati
 			return fmt.Errorf("Failed to rename %q to %q: %w", srcVolumePath, dstVolumePath, err)
 		}
 
-		revert.Add(func() { _ = os.Rename(dstVolumePath, srcVolumePath) })
+		reverter.Add(func() { _ = os.Rename(dstVolumePath, srcVolumePath) })
 	}
 
 	// And if present, the snapshots too.
@@ -93,10 +93,10 @@ func genericVFSRenameVolume(d Driver, vol Volume, newVolName string, op *operati
 			return fmt.Errorf("Failed to rename %q to %q: %w", srcSnapshotDir, dstSnapshotDir, err)
 		}
 
-		revert.Add(func() { _ = os.Rename(dstSnapshotDir, srcSnapshotDir) })
+		reverter.Add(func() { _ = os.Rename(dstSnapshotDir, srcSnapshotDir) })
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -295,8 +295,8 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		return ErrNotSupported
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the main volume if not refreshing.
 	if !volTargetArgs.Refresh {
@@ -305,7 +305,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+		reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 	}
 
 	recvFSVol := func(volName string, conn io.ReadWriteCloser, path string) error {
@@ -424,7 +424,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 			}
 
 			// Setup the revert.
-			revert.Add(func() {
+			reverter.Add(func() {
 				_ = d.DeleteVolumeSnapshot(snapVol, op)
 			})
 		}
@@ -485,7 +485,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 
@@ -854,8 +854,8 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		return nil
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Find the compression algorithm used for backup source data.
 	_, err := srcData.Seek(0, io.SeekStart)
@@ -883,7 +883,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		return nil, nil, err
 	}
 
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 
 	if len(snapshots) > 0 {
 		// Create new snapshots directory.
@@ -920,7 +920,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 			return nil, nil, err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
+		reverter.Add(func() { _ = d.DeleteVolumeSnapshot(snapVol, op) })
 	}
 
 	err = d.MountVolume(vol, op)
@@ -928,7 +928,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		return nil, nil, err
 	}
 
-	revert.Add(func() { _, _ = d.UnmountVolume(vol, false, op) })
+	reverter.Add(func() { _, _ = d.UnmountVolume(vol, false, op) })
 
 	backupPrefix := "backup/container"
 	if vol.IsVMBlock() {
@@ -950,8 +950,8 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 		return nil, nil, err
 	}
 
-	cleanup := revert.Clone().Fail // Clone before calling revert.Success() so we can return the Fail func.
-	revert.Success()
+	cleanup := reverter.Clone().Fail // Clone before calling reverter.Success() so we can return the Fail func.
+	reverter.Success()
 
 	var postHook VolumePostHook
 	if vol.volType != VolumeTypeCustom {
@@ -992,8 +992,8 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 		rsyncArgs = append(rsyncArgs, "--exclude", genericVolumeDiskFile)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create the main volume if not refreshing.
 	if !refresh {
@@ -1002,7 +1002,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 			return err
 		}
 
-		revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+		reverter.Add(func() { _ = d.DeleteVolume(vol, op) })
 	}
 
 	// Define function to send a filesystem volume.
@@ -1082,7 +1082,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 				}
 
 				// Setup the revert.
-				revert.Add(func() {
+				reverter.Add(func() {
 					_ = d.DeleteVolumeSnapshot(snapVol, op)
 				})
 			}
@@ -1131,7 +1131,7 @@ func genericVFSCopyVolume(d Driver, initVolume func(vol Volume) (revert.Hook, er
 		return err
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/storage/drivers/volume.go
+++ b/internal/server/storage/drivers/volume.go
@@ -212,8 +212,8 @@ func (v Volume) MountInUse() bool {
 func (v Volume) EnsureMountPath() error {
 	volPath := v.MountPath()
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	// Create volume's mount path if missing, with any created directories set to 0711.
 	if !util.PathExists(volPath) {
@@ -231,7 +231,7 @@ func (v Volume) EnsureMountPath() error {
 			return fmt.Errorf("Failed to create mount directory %q: %w", volPath, err)
 		}
 
-		revert.Add(func() { _ = os.Remove(volPath) })
+		reverter.Add(func() { _ = os.Remove(volPath) })
 	}
 
 	mode := os.FileMode(0o711)
@@ -298,7 +298,7 @@ func (v Volume) EnsureMountPath() error {
 		}
 	}
 
-	revert.Success()
+	reverter.Success()
 	return nil
 }
 

--- a/internal/server/syslog/listener.go
+++ b/internal/server/syslog/listener.go
@@ -35,10 +35,10 @@ func Listen(ctx context.Context, eventServer *events.Server) error {
 		return fmt.Errorf("Failed listening on syslog socket: %w", err)
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
+	reverter := revert.New()
+	defer reverter.Fail()
 
-	revert.Add(func() {
+	reverter.Add(func() {
 		_ = conn.Close()
 		_ = os.Remove(sockFile)
 	})
@@ -140,7 +140,7 @@ func Listen(ctx context.Context, eventServer *events.Server) error {
 		}
 	}()
 
-	revert.Success()
+	reverter.Success()
 
 	return nil
 }


### PR DESCRIPTION
A lot of the reverters were named `revert` which conflicts with the package name, while others were called `reverter`. I decided to unify the naming to `reverter` so that they are all named the same and do not conflict with the package name anymore.

I dont know how to name the commit, since it covers a lot of code parts. 