### PR TITLE
Rename vars using builtin names

### DIFF
--- a/client/util.go
+++ b/client/util.go
@@ -164,22 +164,22 @@ type remoteOperationResult struct {
 	Error error
 }
 
-func remoteOperationError(msg string, errors []remoteOperationResult) error {
+func remoteOperationError(msg string, errorOperationResults []remoteOperationResult) error {
 	// Check if empty
-	if len(errors) == 0 {
+	if len(errorOperationResults) == 0 {
 		return nil
 	}
 
 	// Check if all identical
 	var err error
-	for _, entry := range errors {
+	for _, entry := range errorOperationResults {
 		if err != nil && entry.Error.Error() != err.Error() {
-			errorStrs := make([]string, 0, len(errors))
-			for _, error := range errors {
-				errorStrs = append(errorStrs, fmt.Sprintf("%s: %v", error.URL, error.Error))
+			errorStrings := make([]string, 0, len(errorOperationResults))
+			for _, operationResult := range errorOperationResults {
+				errorStrings = append(errorStrings, fmt.Sprintf("%s: %v", operationResult.URL, operationResult.Error))
 			}
 
-			return fmt.Errorf("%s:\n - %s", msg, strings.Join(errorStrs, "\n - "))
+			return fmt.Errorf("%s:\n - %s", msg, strings.Join(errorStrings, "\n - "))
 		}
 
 		err = entry.Error

--- a/cmd/incusd/devices.go
+++ b/cmd/incusd/devices.go
@@ -378,7 +378,7 @@ func fillFixedInstances(fixedInstances map[int64][]instance.Instance, inst insta
 //
 // Overall, this function ensures that the CPU resources of the host are utilized effectively amongst all the containers running on it.
 func deviceTaskBalance(s *state.State) {
-	min := func(x, y int) int {
+	minFunc := func(x, y int) int {
 		if x < y {
 			return x
 		}
@@ -510,7 +510,7 @@ func deviceTaskBalance(s *state.State) {
 		count, err := strconv.Atoi(cpulimit)
 		if err == nil {
 			// Load-balance
-			count = min(count, len(cpus))
+			count = minFunc(count, len(cpus))
 			if len(numaCpus) > 0 {
 				fillFixedInstances(fixedInstances, c, cpus, numaCpus, count, true)
 			} else {

--- a/cmd/incusd/main_cluster.go
+++ b/cmd/incusd/main_cluster.go
@@ -65,8 +65,8 @@ func (c *cmdCluster) Command() *cobra.Command {
 	cmd.AddCommand(listDatabase.Command())
 
 	// Recover
-	recover := cmdClusterRecoverFromQuorumLoss{global: c.global}
-	cmd.AddCommand(recover.Command())
+	recoverFromQuorumLoss := cmdClusterRecoverFromQuorumLoss{global: c.global}
+	cmd.AddCommand(recoverFromQuorumLoss.Command())
 
 	// Remove a raft node.
 	removeRaftNode := cmdClusterRemoveRaftNode{global: c.global}

--- a/internal/server/config/safe.go
+++ b/internal/server/config/safe.go
@@ -17,9 +17,9 @@ func SafeLoad(schema Schema, values map[string]string) (Map, error) {
 			return m, err
 		}
 
-		for _, error := range errors {
-			message := fmt.Sprintf("Invalid configuration key: %s", error.Reason)
-			logger.Error(message, logger.Ctx{"key": error.Name})
+		for _, e := range errors {
+			message := fmt.Sprintf("Invalid configuration key: %s", e.Reason)
+			logger.Error(message, logger.Ctx{"key": e.Name})
 		}
 	}
 

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -529,17 +529,17 @@ func qemuCPU(opts *qemuCPUOpts, pinning bool) []cfg.Section {
 		}
 
 		// Cap the max number of CPUs to 64 unless directly assigned more.
-		max := 64
-		if int(cpu.Total) < max {
-			max = int(cpu.Total)
-		} else if opts.cpuRequested > max {
-			max = opts.cpuRequested
-		} else if opts.cpuCount > max {
-			max = opts.cpuCount
+		maxCpus := 64
+		if int(cpu.Total) < maxCpus {
+			maxCpus = int(cpu.Total)
+		} else if opts.cpuRequested > maxCpus {
+			maxCpus = opts.cpuRequested
+		} else if opts.cpuCount > maxCpus {
+			maxCpus = opts.cpuCount
 		}
 
 		entries = append(entries, cfg.Entry{
-			Key: "maxcpus", Value: fmt.Sprintf("%d", max),
+			Key: "maxcpus", Value: fmt.Sprintf("%d", maxCpus),
 		})
 	}
 

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -1334,14 +1334,14 @@ func ParseIPCIDRToNet(ipAddressCIDR string) (*net.IPNet, error) {
 
 // IPToNet converts an IP to a single host IPNet.
 func IPToNet(ip net.IP) net.IPNet {
-	len := 32
+	bits := 32
 	if ip.To4() == nil {
-		len = 128
+		bits = 128
 	}
 
 	return net.IPNet{
 		IP:   ip,
-		Mask: net.CIDRMask(len, len),
+		Mask: net.CIDRMask(bits, bits),
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -22,12 +22,12 @@ func NewDottedVersion(versionString string) (*DottedVersion, error) {
 		return nil, formatError
 	}
 
-	maj, err := strconv.Atoi(split[0])
+	major, err := strconv.Atoi(split[0])
 	if err != nil {
 		return nil, formatError
 	}
 
-	min, err := strconv.Atoi(split[1])
+	minor, err := strconv.Atoi(split[1])
 	if err != nil {
 		return nil, formatError
 	}
@@ -41,8 +41,8 @@ func NewDottedVersion(versionString string) (*DottedVersion, error) {
 	}
 
 	return &DottedVersion{
-		Major: maj,
-		Minor: min,
+		Major: major,
+		Minor: minor,
 		Patch: patch,
 	}, nil
 }


### PR DESCRIPTION
Renames some variables that were shadowing builtin go functions or interfaces.
I did not rename all the variables i found, since some are a bit harder to understand.