### PR TITLE
incusd/server/device/nic_routed: Added host_tables

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2795,3 +2795,7 @@ This is limited to bridged networks as OVN doesn't support flexible enough SNAT 
 ## `memory_hotplug`
 
 This adds memory hotplugging for VMs, allowing them to add memory at runtime without rebooting.
+
+## `instance_nic_routed_host_tables`
+
+This adds support for specifying host-routing tables on `nic` devices that use the routed mode.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1164,8 +1164,16 @@ For file systems (shared directories or custom volumes), this is one of:
 ```
 
 ```{config:option} ipv4.host_table devices-nic_routed
-:shortdesc: "The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)"
+:shortdesc: "Deprecated: Use `ipv4.host_tables` instead"
 :type: "integer"
+The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)
+
+```
+
+```{config:option} ipv4.host_tables devices-nic_routed
+:default: "254"
+:shortdesc: "Comma-delimited list of routing tables IDs to add IPv4 static routes to"
+:type: "string"
 
 ```
 
@@ -1203,8 +1211,16 @@ For file systems (shared directories or custom volumes), this is one of:
 ```
 
 ```{config:option} ipv6.host_table devices-nic_routed
-:shortdesc: "The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)"
+:shortdesc: "Deprecated: Use `ipv6.host_tables` instead"
 :type: "integer"
+The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
+
+```
+
+```{config:option} ipv6.host_tables devices-nic_routed
+:default: "254"
+:shortdesc: "Comma-delimited list of routing tables IDs to add IPv6 static routes to"
+:type: "string"
 
 ```
 

--- a/internal/server/device/nic_routed.go
+++ b/internal/server/device/nic_routed.go
@@ -139,76 +139,76 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		// ---
 		//  type: integer
 		//  shortdesc: The priority for outgoing traffic, to be used by the kernel queuing discipline to prioritize network packets
-
 		"limits.priority",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.gateway)
 		//
 		// ---
 		//  type: string
 		//  default: auto
 		//  shortdesc: Whether to add an automatic default IPv4 gateway (can be `auto` or `none`)
-
 		"ipv4.gateway",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv6.gateway)
 		//
 		// ---
 		//  type: string
 		//  default: auto
 		//  shortdesc: Whether to add an automatic default IPv6 gateway (can be `auto` or `none`)
-
 		"ipv6.gateway",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.routes)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Comma-delimited list of IPv4 static routes to add on host to NIC (without L2 ARP/NDP proxy)
-
 		"ipv4.routes",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv6.routes)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Comma-delimited list of IPv6 static routes to add on host to NIC (without L2 ARP/NDP proxy)
-
 		"ipv6.routes",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.host_address)
 		//
 		// ---
 		//  type: string
 		//  default: `169.254.0.1`
 		//  shortdesc: The IPv4 address to add to the host-side `veth` interface
-
 		"ipv4.host_address",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv6.host_address)
 		//
 		// ---
 		//  type: string
 		//  default: `fe80::1`
 		//  shortdesc: The IPv6 address to add to the host-side `veth` interface
-
 		"ipv6.host_address",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.host_table)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)
-
 		"ipv4.host_table",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv6.host_table)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
-
 		"ipv6.host_table",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=gvrp)
 		//
 		// ---
 		//  type: bool
 		//  default: false
 		//  shortdesc: Register VLAN using GARP VLAN Registration Protocol
-
 		"gvrp",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=vrf)
 		//
 		// ---

--- a/internal/server/device/nic_routed.go
+++ b/internal/server/device/nic_routed.go
@@ -189,16 +189,20 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.host_table)
 		//
+		// The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)
+		//
 		// ---
 		//  type: integer
-		//  shortdesc: The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)
+		//  shortdesc: Deprecated: Use `ipv4.host_tables` instead
 		"ipv4.host_table",
 
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv6.host_table)
 		//
+		// The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
+		//
 		// ---
 		//  type: integer
-		//  shortdesc: The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
+		//  shortdesc: Deprecated: Use `ipv6.host_tables` instead
 		"ipv6.host_table",
 
 		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.host_tables)

--- a/internal/server/device/nic_routed.go
+++ b/internal/server/device/nic_routed.go
@@ -201,6 +201,22 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		//  shortdesc: The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
 		"ipv6.host_table",
 
+		// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.host_tables)
+		//
+		// ---
+		//  type: string
+		//  default: 254
+		//  shortdesc: Comma-delimited list of routing tables IDs to add IPv4 static routes to
+		"ipv4.host_tables",
+
+		// gendoc:generate(entity=devices, group=nic_routed, key=ipv6.host_tables)
+		//
+		// ---
+		//  type: string
+		//  default: 254
+		//  shortdesc: Comma-delimited list of routing tables IDs to add IPv6 static routes to
+		"ipv6.host_tables",
+
 		// gendoc:generate(entity=devices, group=nic_routed, key=gvrp)
 		//
 		// ---
@@ -241,8 +257,6 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 	//  shortdesc: Comma-delimited list of IPv6 static addresses to add to the instance
 	rules["ipv6.address"] = validate.Optional(validate.IsListOf(validate.IsNetworkAddressV6))
 
-	rules["gvrp"] = validate.Optional(validate.IsBool)
-
 	// gendoc:generate(entity=devices, group=nic_routed, key=ipv4.neighbor_probe)
 	//
 	// ---
@@ -259,6 +273,9 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 	//  shortdesc: Whether to probe the parent network for IP address availability
 	rules["ipv6.neighbor_probe"] = validate.Optional(validate.IsBool)
 
+	rules["ipv4.host_tables"] = validate.Optional(validate.IsListOf(validate.IsInRange(0, 255)))
+	rules["ipv6.host_tables"] = validate.Optional(validate.IsListOf(validate.IsInRange(0, 255)))
+	rules["gvrp"] = validate.Optional(validate.IsBool)
 	rules["vrf"] = validate.Optional(validate.IsAny)
 
 	err = d.config.Validate(rules)
@@ -584,36 +601,55 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 			}
 		}
 
-		table := "main"
-		if d.config["vrf"] != "" {
-			table = ""
+		getTables := func() []string {
+			// New plural form – honour exactly what the user gives.
+			v := d.config[fmt.Sprintf("%s.host_tables", keyPrefix)]
+			if v != "" {
+				return util.SplitNTrimSpace(v, ",", -1, true)
+			}
+
+			// Legacy – single key: include it plus 254.
+			v = d.config[fmt.Sprintf("%s.host_table", keyPrefix)]
+			if v != "" {
+				if v == "254" {
+					return []string{"254"} // user asked for main only
+				}
+
+				return []string{v, "254"} // custom + main
+			}
+
+			// Default – main only.
+			return []string{"254"}
 		}
+
+		tables := getTables()
 
 		// Perform per-address host-side configuration (static routes and neighbour proxy entries).
 		for _, addrStr := range addresses {
 			// Apply host-side static routes to main routing table or VRF.
-			r := ip.Route{
-				DevName: saveData["host_name"],
-				Route:   fmt.Sprintf("%s/%d", addrStr, subnetSize),
-				Table:   table,
-				Family:  ipFamilyArg,
-				VRF:     d.config["vrf"],
-			}
 
-			err = r.Add()
-			if err != nil {
-				return nil, fmt.Errorf("Failed adding host route %q: %w", r.Route, err)
-			}
-
-			// Add host-side static routes to instance IPs to custom routing table if specified.
-			// This is in addition to the static route added to the main routing table, which is still
-			// critical to ensure that reverse path filtering doesn't kick in blocking traffic from
-			// the instance.
-			if d.config[fmt.Sprintf("%s.host_table", keyPrefix)] != "" {
+			// If a VRF is set we still add a route into the VRF's own table (empty Table value).
+			if d.config["vrf"] != "" {
 				r := ip.Route{
 					DevName: saveData["host_name"],
 					Route:   fmt.Sprintf("%s/%d", addrStr, subnetSize),
-					Table:   d.config[fmt.Sprintf("%s.host_table", keyPrefix)],
+					Table:   "",
+					Family:  ipFamilyArg,
+					VRF:     d.config["vrf"],
+				}
+
+				err = r.Add()
+				if err != nil {
+					return nil, fmt.Errorf("Failed adding host route %q: %w", r.Route, err)
+				}
+			}
+
+			// Add routes to all requested tables.
+			for _, tbl := range tables {
+				r := ip.Route{
+					DevName: saveData["host_name"],
+					Route:   fmt.Sprintf("%s/%d", addrStr, subnetSize),
+					Table:   tbl,
 					Family:  ipFamilyArg,
 				}
 
@@ -645,21 +681,40 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 			if len(addresses) == 0 {
 				return nil, fmt.Errorf("%s.routes requires %s.address to be set", keyPrefix, keyPrefix)
 			}
+
 			// Add routes
 			for _, routeStr := range routes {
-				// Apply host-side static routes to main routing table or VRF.
-				r := ip.Route{
-					DevName: saveData["host_name"],
-					Route:   routeStr,
-					Table:   table,
-					Family:  ipFamilyArg,
-					Via:     addresses[0],
-					VRF:     d.config["vrf"],
+				// If a VRF is set we still add a route into the VRF's own table (empty Table value).
+				if d.config["vrf"] != "" {
+					r := ip.Route{
+						DevName: saveData["host_name"],
+						Route:   routeStr,
+						Table:   "",
+						Family:  ipFamilyArg,
+						Via:     addresses[0],
+						VRF:     d.config["vrf"],
+					}
+
+					err = r.Add()
+					if err != nil {
+						return nil, fmt.Errorf("Failed adding route %q: %w", r.Route, err)
+					}
 				}
 
-				err = r.Add()
-				if err != nil {
-					return nil, fmt.Errorf("Failed adding route %q: %w", r.Route, err)
+				// Add routes to all requested tables.
+				for _, tbl := range tables {
+					r := ip.Route{
+						DevName: saveData["host_name"],
+						Route:   routeStr,
+						Table:   tbl,
+						Family:  ipFamilyArg,
+						Via:     addresses[0],
+					}
+
+					err = r.Add()
+					if err != nil {
+						return nil, fmt.Errorf("Failed adding route %q to table %q: %w", r.Route, r.Table, err)
+					}
 				}
 			}
 		}

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1326,9 +1326,17 @@
 					},
 					{
 						"ipv4.host_table": {
-							"longdesc": "",
-							"shortdesc": "The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)",
+							"longdesc": "The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)\n",
+							"shortdesc": "Deprecated: Use `ipv4.host_tables` instead",
 							"type": "integer"
+						}
+					},
+					{
+						"ipv4.host_tables": {
+							"default": "254",
+							"longdesc": "",
+							"shortdesc": "Comma-delimited list of routing tables IDs to add IPv4 static routes to",
+							"type": "string"
 						}
 					},
 					{
@@ -1371,9 +1379,17 @@
 					},
 					{
 						"ipv6.host_table": {
-							"longdesc": "",
-							"shortdesc": "The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)",
+							"longdesc": "The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)\n",
+							"shortdesc": "Deprecated: Use `ipv6.host_tables` instead",
 							"type": "integer"
+						}
+					},
+					{
+						"ipv6.host_tables": {
+							"default": "254",
+							"longdesc": "",
+							"shortdesc": "Comma-delimited list of routing tables IDs to add IPv6 static routes to",
+							"type": "string"
 						}
 					},
 					{

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -398,7 +398,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Uplink network to use for external network access or `none` to keep isolated
-		"network":                    validate.IsAny,
+		"network": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=bridge.hwaddr)
 		//
@@ -406,7 +406,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  shortdesc: MAC address for the virtual bridge interface
 
-		"bridge.hwaddr":              validate.Optional(validate.IsNetworkMAC),
+		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
 		// gendoc:generate(entity=network_ovn, group=common, key=bridge.mtu)
 		//
 		// ---
@@ -414,7 +414,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  shortdesc: Bridge MTU (default allows host to host Geneve tunnels)
 		//  default: `1442`
 
-		"bridge.mtu":                 validate.Optional(validate.IsNetworkMTU),
+		"bridge.mtu": validate.Optional(validate.IsNetworkMTU),
 		// gendoc:generate(entity=network_ovn, group=common, key=bridge.external_interfaces)
 		//
 		// ---
@@ -497,7 +497,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  shortdesc: Whether to provide additional network configuration over DHCP
 		//  default: `true`
-		"ipv6.dhcp":                            validate.Optional(validate.IsBool),
+		"ipv6.dhcp": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.dhcp.stateful)
 		//
@@ -506,7 +506,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  condition: IPv6 DHCP
 		//  shortdesc: Whether to allocate addresses using DHCP
 		//  default: `false`
-		"ipv6.dhcp.stateful":                   validate.Optional(validate.IsBool),
+		"ipv6.dhcp.stateful": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.nat)
 		//
@@ -515,7 +515,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  shortdesc: Whether to NAT
 		//  condition: IPv4 address
 		//  default: `false` initial value on creation if `ipv4.address` is set to `auto: true`)
-		"ipv4.nat":                             validate.Optional(validate.IsBool),
+		"ipv4.nat": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.nat.address)
 		//
@@ -523,7 +523,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  shortdesc: The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
 		//  condition: IPv4 address
-		"ipv4.nat.address":                     validate.Optional(validate.IsNetworkAddressV4),
+		"ipv4.nat.address": validate.Optional(validate.IsNetworkAddressV4),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.nat)
 		//
@@ -532,7 +532,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  shortdesc: Whether to NAT
 		//  default: `false` (initial value on creation if `ipv6.address` is set to `auto: true`)
-		"ipv6.nat":                             validate.Optional(validate.IsBool),
+		"ipv6.nat": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.nat.address)
 		//
@@ -540,7 +540,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv6 address
 		//  shortdesc: The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
-		"ipv6.nat.address":                     validate.Optional(validate.IsNetworkAddressV6),
+		"ipv6.nat.address": validate.Optional(validate.IsNetworkAddressV6),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.l3only)
 		//
@@ -549,7 +549,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  shortdesc: Whether to enable layer 3 only mode.
 		//  condition: IPv4 address
 		//  default: `false`
-		"ipv4.l3only":                          validate.Optional(validate.IsBool),
+		"ipv4.l3only": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.l3only)
 		//
@@ -558,7 +558,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  condition: IPv6 DHCP stateful
 		//  shortdesc: Whether to enable layer 3 only mode.
 		//  default: `false`
-		"ipv6.l3only":                          validate.Optional(validate.IsBool),
+		"ipv6.l3only": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=dns.nameservers)
 		//
@@ -566,7 +566,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  shortdesc: DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and the first IPv6 address is also advertised as RDNSS via RA.
 		//  default: Uplink DNS servers (IPv4 and IPv6 address if no uplink is configured)
-		"dns.nameservers":                      validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
+		"dns.nameservers": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=dns.domain)
 		//
@@ -574,42 +574,42 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  default: `incus`
 		//  shortdesc: Domain to advertise to DHCP clients and use for DNS resolution
-		"dns.domain":                           validate.IsAny,
+		"dns.domain": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=dns.search)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Full comma-separated domain search list, defaulting to `dns.domain` value
-		"dns.search":                           validate.IsAny,
+		"dns.search": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=dns.zone.forward)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Comma-separated list of DNS zone names for forward DNS records
-		"dns.zone.forward":                     validate.IsAny,
+		"dns.zone.forward": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=dns.zone.reverse.ipv4)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: DNS zone name for IPv4 reverse DNS records
-		"dns.zone.reverse.ipv4":                validate.IsAny,
+		"dns.zone.reverse.ipv4": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=dns.zone.reverse.ipv6)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: DNS zone name for IPv6 reverse DNS records
-		"dns.zone.reverse.ipv6":                validate.IsAny,
+		"dns.zone.reverse.ipv6": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=security.acls)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Comma-separated list of Network ACLs to apply to NICs connected to this network
-		"security.acls":                        validate.IsAny,
+		"security.acls": validate.IsAny,
 
 		// gendoc:generate(entity=network_ovn, group=common, key=security.acls.default.ingress.action)
 		//
@@ -627,7 +627,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  shortdesc: Action to use for egress traffic that doesn't match any ACL rule
 		//  default: `reject`
 		//  condition: `security.acls`
-		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+		"security.acls.default.egress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=security.acls.default.ingress.logged)
 		//
@@ -645,7 +645,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  shortdesc: Whether to log egress traffic that doesn't match any ACL rule
 		//  default: `false`
 		//  condition: `security.acls`
-		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
+		"security.acls.default.egress.logged": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_ovn, group=common, key=user.*)
 		//

--- a/internal/server/network/driver_physical.go
+++ b/internal/server/network/driver_physical.go
@@ -38,7 +38,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: -
 		// shortdesc: Existing interface to use for network
-		"parent":                      validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
+		"parent": validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 
 		// gendoc:generate(entity=network_physical, group=common, key=mtu)
 		//
@@ -46,7 +46,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: integer
 		// condition: -
 		// shortdesc: The MTU of the new interface
-		"mtu":                         validate.Optional(validate.IsNetworkMTU),
+		"mtu": validate.Optional(validate.IsNetworkMTU),
 
 		// gendoc:generate(entity=network_physical, group=common, key=vlan)
 		//
@@ -54,7 +54,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: integer
 		// condition: -
 		// shortdesc: The VLAN ID to attach to
-		"vlan":                        validate.Optional(validate.IsNetworkVLAN),
+		"vlan": validate.Optional(validate.IsNetworkVLAN),
 
 		// gendoc:generate(entity=network_physical, group=common, key=gvrp)
 		//
@@ -63,7 +63,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// condition: -
 		// defaultdesc: 'false'
 		// shortdesc: Register VLAN using GARP VLAN Registration Protocol
-		"gvrp":                        validate.Optional(validate.IsBool),
+		"gvrp": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_physical, group=ipv4, key=ipv4.gateway)
 		//
@@ -71,7 +71,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: standard mode
 		// shortdesc: IPv4 address for the gateway and network (CIDR)
-		"ipv4.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV4),
+		"ipv4.gateway": validate.Optional(validate.IsNetworkAddressCIDRV4),
 
 		// gendoc:generate(entity=network_physical, group=ipv6, key=ipv6.gateway)
 		//
@@ -79,7 +79,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: standard mode
 		// shortdesc: IPv6 address for the gateway and network (CIDR)
-		"ipv6.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV6),
+		"ipv6.gateway": validate.Optional(validate.IsNetworkAddressCIDRV6),
 
 		// gendoc:generate(entity=network_physical, group=ipv4, key=ipv4.ovn.ranges)
 		//
@@ -87,7 +87,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: -
 		// shortdesc: Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
-		"ipv4.ovn.ranges":             validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
+		"ipv4.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
 
 		// gendoc:generate(entity=network_physical, group=ipv6, key=ipv6.ovn.ranges)
 		//
@@ -95,7 +95,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: -
 		// shortdesc: Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
-		"ipv6.ovn.ranges":             validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
+		"ipv6.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
 
 		// gendoc:generate(entity=network_physical, group=ipv4, key=ipv4.routes)
 		//
@@ -103,7 +103,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: IPv4 address
 		// shortdesc: Comma-separated list of additional IPv4 CIDR subnets that can be used with child OVN networks `ipv4.routes.external` setting
-		"ipv4.routes":                 validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
+		"ipv4.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
 
 		// gendoc:generate(entity=network_physical, group=ipv4, key=ipv4.routes.anycast)
 		//
@@ -112,7 +112,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// condition: IPv4 address
 		// defaultdesc: 'false'
 		// shortdesc: Allow the overlapping routes to be used on multiple networks/NIC at the same time
-		"ipv4.routes.anycast":         validate.Optional(validate.IsBool),
+		"ipv4.routes.anycast": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_physical, group=ipv6, key=ipv6.routes)
 		//
@@ -120,7 +120,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: IPv6 address
 		// shortdesc: Comma-separated list of additional IPv6 CIDR subnets that can be used with child OVN networks `ipv6.routes.external` setting
-		"ipv6.routes":                 validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
+		"ipv6.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
 
 		// gendoc:generate(entity=network_physical, group=ipv6, key=ipv6.routes.anycast)
 		//
@@ -129,7 +129,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// condition: IPv6 address
 		// defaultdesc: 'false'
 		// shortdesc: Allow the overlapping routes to be used on multiple networks/NIC at the same time
-		"ipv6.routes.anycast":         validate.Optional(validate.IsBool),
+		"ipv6.routes.anycast": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_physical, group=dns, key=dns.nameservers)
 		//
@@ -137,7 +137,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// type: string
 		// condition: standard mode
 		// shortdesc: List of DNS server IPs on `physical` network
-		"dns.nameservers":             validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
+		"dns.nameservers": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
 
 		// gendoc:generate(entity=network_physical, group=ovn, key=ovn.ingress_mode)
 		//
@@ -146,7 +146,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// condition: standard mode
 		// defaultdesc: `l2proxy`
 		// shortdesc: Sets the method how OVN NIC external IPs will be advertised on uplink network: `l2proxy` (proxy ARP/NDP) or `routed`
-		"ovn.ingress_mode":            validate.Optional(validate.IsOneOf("l2proxy", "routed")),
+		"ovn.ingress_mode": validate.Optional(validate.IsOneOf("l2proxy", "routed")),
 
 		"volatile.last_state.created": validate.Optional(validate.IsBool),
 	}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -480,6 +480,7 @@ var APIExtensions = []string{
 	"server_logging",
 	"network_forward_snat",
 	"memory_hotplug",
+	"instance_nic_routed_host_tables",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
We closed our old PR (https://github.com/lxc/incus/pull/1964) and are opening a new one due to it being pretty outdated compared to the codebase. We added our changes to nic_routed.go and wanted to know where else we need to edit. We assume the documentation we need to add would be through gendoc and we would mark the ipv4.host_table and ipv6.host_table as deprecated there.

Issue #1559 
