### PR TITLE
Add server-side filtering for `incus project list`

### DIFF
--- a/client/incus_projects.go
+++ b/client/incus_projects.go
@@ -44,6 +44,26 @@ func (r *ProtocolIncus) GetProjects() ([]api.Project, error) {
 	return projects, nil
 }
 
+// GetProjectsWithFilter returns a filtered list of projects as Project structs.
+func (r *ProtocolIncus) GetProjectsWithFilter(filters []string) ([]api.Project, error) {
+	if !r.HasExtension("projects") {
+		return nil, fmt.Errorf("The server is missing the required \"projects\" API extension")
+	}
+
+	projects := []api.Project{}
+
+	v := url.Values{}
+	v.Set("recursion", "1")
+	v.Set("filter", parseFilters(filters))
+
+	_, err := r.queryStruct("GET", fmt.Sprintf("/projects?%s", v.Encode()), nil, "", &projects)
+	if err != nil {
+		return nil, err
+	}
+
+	return projects, nil
+}
+
 // GetProject returns a Project entry for the provided name.
 func (r *ProtocolIncus) GetProject(name string) (*api.Project, string, error) {
 	if !r.HasExtension("projects") {

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -305,6 +305,7 @@ type InstanceServer interface {
 	// Project functions
 	GetProjectNames() (names []string, err error)
 	GetProjects() (projects []api.Project, err error)
+	GetProjectsWithFilter(filters []string) (projects []api.Project, err error)
 	GetProject(name string) (project *api.Project, ETag string, err error)
 	GetProjectState(name string) (project *api.ProjectState, err error)
 	GetProjectAccess(name string) (access api.Access, err error)


### PR DESCRIPTION
Resolves #1911

Adds server-side filtering for `incus project list`. Filters are either a string to filter by exact name of projects or a list of  <key>=<value> pairs separated by commas to filter by properties.