### PR TITLE
incusd: refactor process kill error being ignored

### DIFF
--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -1823,7 +1823,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		if err != nil {
 			// Kill Process if started, but could not save the file.
 			err2 := p.Stop()
-			if err != nil {
+			if err2 != nil {
 				return fmt.Errorf("Could not kill subprocess while handling saving error: %s: %s", err, err2)
 			}
 


### PR DESCRIPTION
Refactors a wrong err check where err was checked but err2 should have been checked.