### PR TITLE
incusd/instance: fix device finding logic

### DIFF
--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -1287,7 +1287,7 @@ func (m *Monitor) RingbufRead(device string) (string, error) {
 		return "", err
 	}
 
-	deviceFound := true
+	deviceFound := false
 	for _, qemuDevice := range queryResp.Return {
 		if qemuDevice.Label == device {
 			deviceFound = true


### PR DESCRIPTION
Refactors a wrong for loop where a qemu device is being looked up. The loop started by setting `deviceFound` to true instead of false.