### PR TITLE
incus/internal/server/nic_sriov: add hwspoofchk to disable hardware spoofcheck support

### DIFF
--- a/internal/server/device/nic.go
+++ b/internal/server/device/nic.go
@@ -33,6 +33,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"security.ipv4_filtering":              validate.IsAny,
 		"security.ipv6_filtering":              validate.IsAny,
 		"security.port_isolation":              validate.Optional(validate.IsBool),
+		"hwspoofchk":				validate.Optional(validate.IsBool),
 		"ipv4.address":                         validate.Optional(validate.IsNetworkAddressV4),
 		"ipv6.address":                         validate.Optional(validate.IsNetworkAddressV6),
 		"ipv4.routes":                          validate.Optional(validate.IsListOf(validate.IsNetworkV4)),

--- a/internal/server/device/nic_sriov.go
+++ b/internal/server/device/nic_sriov.go
@@ -97,6 +97,15 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		//  shortdesc: Prevent the instance from spoofing another instance's MAC address
 		"security.mac_filtering",
 
+		// gendoc:generate(entity=devices, group=nic_sriov, key=hwspoofchk)
+		//
+		// ---
+		//  type: bool
+		//  default: true
+		//  managed: no
+		//  shortdesc: Enable hardware spoofchecking for use with security.mac_filtering
+		"hwspoofchk",
+		
 		// gendoc:generate(entity=devices, group=nic_sriov, key=boot.priority)
 		//
 		// ---
@@ -217,7 +226,7 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Claim the SR-IOV virtual function (VF) on the parent (PF) and get the PCI information.
-	vfPCIDev, pciIOMMUGroup, err := networkSRIOVSetupVF(d.deviceCommon, d.config["parent"], vfDev, vfID, true, saveData)
+	vfPCIDev, pciIOMMUGroup, err := networkSRIOVSetupVF(d.deviceCommon, d.config["parent"], vfDev, vfID, util.IsTrueOrEmpty(d.config["hwspoofchk"]), saveData)
 	if err != nil {
 		network.SRIOVVirtualFunctionMutex.Unlock()
 		return nil, err

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1528,6 +1528,15 @@
 						}
 					},
 					{
+						"hwspoofchk": {
+							"default": "true",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Enable hardware spoofchecking for use with security.mac_filtering",
+							"type": "bool"
+						}
+					},
+					{
 						"vlan": {
 							"longdesc": "",
 							"managed": "no",


### PR DESCRIPTION
I've added a `hwspoofchk` flag to the SRIOV nic device, because not all NICs support hardware spoof checking. 

In my case I'm running this on Bluefield 3 VFs which only return "Operation not supported" when using the `spoofchk` flag. 

This makes the option in `networkSRIOVSetupVF` configurable through a setting in the profile. 

The default is enabled, to keep with existing setups. 

Signed-off-by: Falk Stern <falk@fourecks.de>