### PR TITLE
incusd/network/ovn: Wait up to 10s for OVN northd to allocate an IP

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -4177,7 +4177,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		var dynamicIPs []net.IP
 
 		// Retry a few times in case port has not yet allocated dynamic IPs.
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 40; i++ {
 			dynamicIPs, err = n.ovnnb.GetLogicalSwitchPortDynamicIPs(context.TODO(), instancePortName)
 			if err == nil {
 				if len(dynamicIPs) > 0 {


### PR DESCRIPTION
In some busy environments, the 2.5s timeout wasn't quite enough.


Sponsored-by: Luizalabs (https://luizalabs.com)