### PR TITLE
incusd: Refactor error list

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -644,7 +644,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		return err
 	})
 	if err != nil {
-		var errorList config.ErrorList
+		var errorList *config.ErrorList
 		switch {
 		case errors.As(err, &errorList):
 			return response.BadRequest(err)
@@ -708,7 +708,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		return err
 	})
 	if err != nil {
-		var errorList config.ErrorList
+		var errorList *config.ErrorList
 		switch {
 		case errors.As(err, &errorList):
 			return response.BadRequest(err)

--- a/internal/server/config/errors.go
+++ b/internal/server/config/errors.go
@@ -25,18 +25,20 @@ func (e Error) Error() string {
 
 // ErrorList is a list of configuration Errors occurred during Load() or
 // Map.Change().
-type ErrorList []*Error
+type ErrorList struct {
+	errors []Error
+}
 
 // ErrorList implements the error interface.
-func (l ErrorList) Error() string {
-	errorCount := len(l)
+func (l *ErrorList) Error() string {
+	errorCount := l.Len()
 	if errorCount == 0 {
 		return "no errors"
 	}
 
 	errorMessage := strings.Builder{}
 
-	firstError := l[0].Error()
+	firstError := l.errors[0].Error()
 	errorMessage.WriteString(firstError)
 
 	if errorCount > 1 {
@@ -46,15 +48,19 @@ func (l ErrorList) Error() string {
 	return errorMessage.String()
 }
 
-// ErrorList implements the sort Interface.
-func (l ErrorList) Len() int           { return len(l) }
-func (l ErrorList) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-func (l ErrorList) Less(i, j int) bool { return l[i].Name < l[j].Name }
+// Len returns the amount of errors contained in the list. This is needed to implement the sort Interface.
+func (l *ErrorList) Len() int { return len(l.errors) }
+
+// Swap swaps two errors at two indices. This is needed to implement the sort Interface.
+func (l *ErrorList) Swap(i, j int) { l.errors[i], l.errors[j] = l.errors[j], l.errors[i] }
+
+// Less defines an ordering of errors inside the error list. This is needed to implement the sort Interface.
+func (l *ErrorList) Less(i, j int) bool { return l.errors[i].Name < l.errors[j].Name }
 
 // Sort sorts an ErrorList. *Error entries are sorted by key name.
-func (l ErrorList) sort() { sort.Sort(l) }
+func (l *ErrorList) sort() { sort.Sort(l) }
 
 // Add adds an Error with given key name, value and reason.
 func (l *ErrorList) add(name string, value any, reason string) {
-	*l = append(*l, &Error{name, value, reason})
+	l.errors = append(l.errors, Error{name, value, reason})
 }

--- a/internal/server/config/errors.go
+++ b/internal/server/config/errors.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // Error generated when trying to set a certain config key to certain value.
@@ -28,14 +29,21 @@ type ErrorList []*Error
 
 // ErrorList implements the error interface.
 func (l ErrorList) Error() string {
-	switch len(l) {
-	case 0:
+	errorCount := len(l)
+	if errorCount == 0 {
 		return "no errors"
-	case 1:
-		return l[0].Error()
 	}
 
-	return fmt.Sprintf("%s (and %d more errors)", l[0], len(l)-1)
+	errorMessage := strings.Builder{}
+
+	firstError := l[0].Error()
+	errorMessage.WriteString(firstError)
+
+	if errorCount > 1 {
+		errorMessage.WriteString(fmt.Sprintf(" (and %d more errors)", errorCount-1))
+	}
+
+	return errorMessage.String()
 }
 
 // ErrorList implements the sort Interface.

--- a/internal/server/config/errors.go
+++ b/internal/server/config/errors.go
@@ -6,27 +6,26 @@ import (
 	"strings"
 )
 
-// Error generated when trying to set a certain config key to certain value.
-type Error struct {
-	Name   string // The name of the key this error is associated with.
-	Value  any    // The value that the key was tried to be set to.
-	Reason string // Human-readable reason of the error.
+// configurationError is generated when trying to set a config key to an erroneous value.
+type configurationError struct {
+	configKey      string
+	erroneousValue any
+	reason         string
 }
 
-// Error implements the error interface.
-func (e Error) Error() string {
-	message := fmt.Sprintf("cannot set '%s'", e.Name)
-	if e.Value != nil {
-		message += fmt.Sprintf(" to '%v'", e.Value)
+// ConfigurationError implements the error interface.
+func (e configurationError) Error() string {
+	message := fmt.Sprintf("cannot set '%s'", e.configKey)
+	if e.erroneousValue != nil {
+		message += fmt.Sprintf(" to '%v'", e.erroneousValue)
 	}
 
-	return message + fmt.Sprintf(": %s", e.Reason)
+	return message + fmt.Sprintf(": %s", e.reason)
 }
 
-// ErrorList is a list of configuration Errors occurred during Load() or
-// Map.Change().
+// ErrorList is a list of configuration Errors occurred during Load() or Map.Change().
 type ErrorList struct {
-	errors []Error
+	errors []configurationError
 }
 
 // ErrorList implements the error interface.
@@ -55,12 +54,12 @@ func (l *ErrorList) Len() int { return len(l.errors) }
 func (l *ErrorList) Swap(i, j int) { l.errors[i], l.errors[j] = l.errors[j], l.errors[i] }
 
 // Less defines an ordering of errors inside the error list. This is needed to implement the sort Interface.
-func (l *ErrorList) Less(i, j int) bool { return l.errors[i].Name < l.errors[j].Name }
+func (l *ErrorList) Less(i, j int) bool { return l.errors[i].configKey < l.errors[j].configKey }
 
-// Sort sorts an ErrorList. *Error entries are sorted by key name.
+// sort sorts an ErrorList. *ConfigurationError entries are sorted by key name.
 func (l *ErrorList) sort() { sort.Sort(l) }
 
-// Add adds an Error with given key name, value and reason.
-func (l *ErrorList) add(name string, value any, reason string) {
-	l.errors = append(l.errors, Error{name, value, reason})
+// add adds an ConfigurationError with given key name, value and reason.
+func (l *ErrorList) add(configKey string, erroneousValue any, errorReason string) {
+	l.errors = append(l.errors, configurationError{configKey, erroneousValue, errorReason})
 }

--- a/internal/server/config/errors_internal_test.go
+++ b/internal/server/config/errors_internal_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_ErrorList_Error_NoErrors(t *testing.T) {
 	// arrange
-	errors := ErrorList{}
+	errors := &ErrorList{}
 
 	// assert
 	assert.EqualError(t, errors, "no errors")
@@ -16,7 +16,7 @@ func Test_ErrorList_Error_NoErrors(t *testing.T) {
 
 func Test_ErrorList_Error_OneError(t *testing.T) {
 	// arrange
-	errors := ErrorList{}
+	errors := &ErrorList{}
 	errors.add("qux", "zzz", "bean")
 
 	// assert
@@ -25,7 +25,7 @@ func Test_ErrorList_Error_OneError(t *testing.T) {
 
 func Test_ErrorList_Error_TwoErrorsSorted(t *testing.T) {
 	// arrange
-	errors := ErrorList{}
+	errors := &ErrorList{}
 	errors.add("foo", "xxx", "boom")
 	errors.add("bar", "yyy", "ugh")
 
@@ -38,7 +38,7 @@ func Test_ErrorList_Error_TwoErrorsSorted(t *testing.T) {
 
 func Test_ErrorList_Error_TwoErrorsUnsorted(t *testing.T) {
 	// arrange
-	errors := ErrorList{}
+	errors := &ErrorList{}
 	errors.add("foo", "xxx", "boom")
 	errors.add("bar", "yyy", "ugh")
 
@@ -48,7 +48,7 @@ func Test_ErrorList_Error_TwoErrorsUnsorted(t *testing.T) {
 
 func Test_ErrorList_Error_MoreThanTwoErrorsUnsorted(t *testing.T) {
 	// arrange
-	errors := ErrorList{}
+	errors := &ErrorList{}
 	errors.add("foo", "xxx", "boom")
 	errors.add("bar", "yyy", "ugh")
 	errors.add("qux", "zzz", "bean")

--- a/internal/server/config/errors_internal_test.go
+++ b/internal/server/config/errors_internal_test.go
@@ -6,12 +6,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Errors can be sorted by key name, and the global error message mentions the
-// first of them.
-func TestErrorList_Error(t *testing.T) {
+func Test_ErrorList_Error_NoErrors(t *testing.T) {
+	// arrange
+	errors := ErrorList{}
+
+	// assert
+	assert.EqualError(t, errors, "no errors")
+}
+
+func Test_ErrorList_Error_OneError(t *testing.T) {
+	// arrange
+	errors := ErrorList{}
+	errors.add("qux", "zzz", "bean")
+
+	// assert
+	assert.EqualError(t, errors, "cannot set 'qux' to 'zzz': bean")
+}
+
+func Test_ErrorList_Error_TwoErrorsSorted(t *testing.T) {
+	// arrange
 	errors := ErrorList{}
 	errors.add("foo", "xxx", "boom")
 	errors.add("bar", "yyy", "ugh")
+
+	// act
 	errors.sort()
+
+	// assert
 	assert.EqualError(t, errors, "cannot set 'bar' to 'yyy': ugh (and 1 more errors)")
+}
+
+func Test_ErrorList_Error_TwoErrorsUnsorted(t *testing.T) {
+	// arrange
+	errors := ErrorList{}
+	errors.add("foo", "xxx", "boom")
+	errors.add("bar", "yyy", "ugh")
+
+	// assert
+	assert.EqualError(t, errors, "cannot set 'foo' to 'xxx': boom (and 1 more errors)")
+}
+
+func Test_ErrorList_Error_MoreThanTwoErrorsUnsorted(t *testing.T) {
+	// arrange
+	errors := ErrorList{}
+	errors.add("foo", "xxx", "boom")
+	errors.add("bar", "yyy", "ugh")
+	errors.add("qux", "zzz", "bean")
+
+	// assert
+	assert.EqualError(t, errors, "cannot set 'foo' to 'xxx': boom (and 2 more errors)")
 }

--- a/internal/server/config/map.go
+++ b/internal/server/config/map.go
@@ -43,7 +43,7 @@ func Load(schema Schema, values map[string]string) (Map, error) {
 func (m *Map) Change(changes map[string]string) (map[string]string, error) {
 	values := make(map[string]string, len(m.schema))
 
-	errors := ErrorList{}
+	errors := &ErrorList{}
 	for name, change := range changes {
 		// Ensure that we were actually passed a string.
 		s := reflect.ValueOf(change)
@@ -173,7 +173,7 @@ func (m *Map) update(values map[string]string) ([]string, error) {
 
 	// Update our keys with the values from the given map, and keep track
 	// of which keys actually changed their value.
-	errors := ErrorList{}
+	errors := &ErrorList{}
 	names := []string{}
 	for name, value := range values {
 		changed, err := m.set(name, value, initial)

--- a/internal/server/config/safe.go
+++ b/internal/server/config/safe.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/lxc/incus/v6/shared/logger"
@@ -12,12 +13,13 @@ import (
 func SafeLoad(schema Schema, values map[string]string) (Map, error) {
 	m, err := Load(schema, values)
 	if err != nil {
-		errors, ok := err.(ErrorList)
+		var errs *ErrorList
+		ok := errors.As(err, &errs)
 		if !ok {
 			return m, err
 		}
 
-		for _, e := range errors {
+		for _, e := range errs.errors {
 			message := fmt.Sprintf("Invalid configuration key: %s", e.Reason)
 			logger.Error(message, logger.Ctx{"key": e.Name})
 		}

--- a/internal/server/config/safe.go
+++ b/internal/server/config/safe.go
@@ -20,8 +20,8 @@ func SafeLoad(schema Schema, values map[string]string) (Map, error) {
 		}
 
 		for _, e := range errs.errors {
-			message := fmt.Sprintf("Invalid configuration key: %s", e.Reason)
-			logger.Error(message, logger.Ctx{"key": e.Name})
+			message := fmt.Sprintf("Invalid configuration key: %s", e.reason)
+			logger.Error(message, logger.Ctx{"key": e.configKey})
 		}
 	}
 


### PR DESCRIPTION
This PR refactors the ErrorList struct and the Error struct in internal/server/config/errors.go so that the Error struct is now private and all functions declared on ErrorList have the same type of receiver.
Also refactors the implementation of the error interface on ErrorList and adds a bunch of new tests for it.