### PR TITLE
Port ovn network documentation to gendoc 

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -3380,6 +3380,224 @@ User keys can be used in search.
 ```
 
 <!-- config group network_load_balancer-common end -->
+<!-- config group network_ovn-common start -->
+```{config:option} bridge.external_interfaces network_ovn-common
+:shortdesc: "Comma-separated list of unconfigured network interfaces to include in the bridge"
+:type: "string"
+
+```
+
+```{config:option} bridge.hwaddr network_ovn-common
+:shortdesc: "MAC address for the virtual bridge interface"
+:type: "string"
+
+```
+
+```{config:option} bridge.mtu network_ovn-common
+:default: "`1442`"
+:shortdesc: "Bridge MTU (default allows host to host Geneve tunnels)"
+:type: "integer"
+
+```
+
+```{config:option} dns.domain network_ovn-common
+:default: "`incus`"
+:shortdesc: "Domain to advertise to DHCP clients and use for DNS resolution"
+:type: "string"
+
+```
+
+```{config:option} dns.nameservers network_ovn-common
+:default: "Uplink DNS servers (IPv4 and IPv6 address if no uplink is configured)"
+:shortdesc: "DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and the first IPv6 address is also advertised as RDNSS via RA."
+:type: "string"
+
+```
+
+```{config:option} dns.search network_ovn-common
+:shortdesc: "Full comma-separated domain search list, defaulting to `dns.domain` value"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.forward network_ovn-common
+:shortdesc: "Comma-separated list of DNS zone names for forward DNS records"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.reverse.ipv4 network_ovn-common
+:shortdesc: "DNS zone name for IPv4 reverse DNS records"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.reverse.ipv6 network_ovn-common
+:shortdesc: "DNS zone name for IPv6 reverse DNS records"
+:type: "string"
+
+```
+
+```{config:option} ipv4.address network_ovn-common
+:condition: "standard mode"
+:default: "(initial value on creation: `auto`)"
+:shortdesc: "IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp network_ovn-common
+:condition: "IPv4 address"
+:default: "`true`"
+:shortdesc: "Whether to allocate addresses using DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.dhcp.expiry network_ovn-common
+:condition: "IPv4 DHCP"
+:default: "`1h`"
+:shortdesc: "When to expire DHCP leases"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.ranges network_ovn-common
+:condition: "IPv4 DHCP"
+:default: "all addresses"
+:shortdesc: "Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.routes network_ovn-common
+:condition: "IPv4 DHCP"
+:shortdesc: "Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq and OVN)"
+:type: "string"
+
+```
+
+```{config:option} ipv4.l3only network_ovn-common
+:condition: "IPv4 address"
+:default: "`false`"
+:shortdesc: "Whether to enable layer 3 only mode."
+:type: "bool"
+
+```
+
+```{config:option} ipv4.nat network_ovn-common
+:condition: "IPv4 address"
+:default: "`false` initial value on creation if `ipv4.address` is set to `auto: true`)"
+:shortdesc: "Whether to NAT"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.nat.address network_ovn-common
+:condition: "IPv4 address"
+:shortdesc: "The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)"
+:type: "string"
+
+```
+
+```{config:option} ipv6.address network_ovn-common
+:condition: "standard mode"
+:default: "(initial value on creation: `auto`)"
+:shortdesc: "IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)"
+:type: "string"
+
+```
+
+```{config:option} ipv6.dhcp network_ovn-common
+:condition: "IPv6 address"
+:default: "`true`"
+:shortdesc: "Whether to provide additional network configuration over DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.dhcp.stateful network_ovn-common
+:condition: "IPv6 DHCP"
+:default: "`false`"
+:shortdesc: "Whether to allocate addresses using DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.l3only network_ovn-common
+:condition: "IPv6 DHCP stateful"
+:default: "`false`"
+:shortdesc: "Whether to enable layer 3 only mode."
+:type: "bool"
+
+```
+
+```{config:option} ipv6.nat network_ovn-common
+:condition: "IPv6 address"
+:default: "`false` (initial value on creation if `ipv6.address` is set to `auto: true`)"
+:shortdesc: "Whether to NAT"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.nat.address network_ovn-common
+:condition: "IPv6 address"
+:shortdesc: "The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)"
+:type: "string"
+
+```
+
+```{config:option} network network_ovn-common
+:shortdesc: "Uplink network to use for external network access or `none` to keep isolated"
+:type: "string"
+
+```
+
+```{config:option} security.acls network_ovn-common
+:shortdesc: "Comma-separated list of Network ACLs to apply to NICs connected to this network"
+:type: "string"
+
+```
+
+```{config:option} security.acls.default.egress.action network_ovn-common
+:condition: "`security.acls`"
+:default: "`reject`"
+:shortdesc: "Action to use for egress traffic that doesn't match any ACL rule"
+:type: "string"
+
+```
+
+```{config:option} security.acls.default.egress.logged network_ovn-common
+:condition: "`security.acls`"
+:default: "`false`"
+:shortdesc: "Whether to log egress traffic that doesn't match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} security.acls.default.ingress.action network_ovn-common
+:condition: "`security.acls`"
+:default: "`reject`"
+:shortdesc: "Action to use for ingress traffic that doesn't match any ACL rule"
+:type: "string"
+
+```
+
+```{config:option} security.acls.default.ingress.logged network_ovn-common
+:condition: "`security.acls`"
+:default: "`false`"
+:shortdesc: "Whether to log ingress traffic that doesn't match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} user.* network_ovn-common
+:shortdesc: "User-provided free-form key/value pairs"
+:type: "string"
+
+```
+
+<!-- config group network_ovn-common end -->
 <!-- config group network_zone-common start -->
 ```{config:option} dns.nameservers network_zone-common
 :required: "no"

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -39,37 +39,11 @@ The following configuration key namespaces are currently supported for the `ovn`
 
 The following configuration options are available for the `ovn` network type:
 
-Key                                  | Type      | Condition             | Default                   | Description
-:--                                  | :--       | :--                   | :--                       | :--
-`network`                            | string    | -                     | -                         | Uplink network to use for external network access or `none` to keep isolated
-`bridge.external_interfaces`         | string    | -                     | -                         | Comma-separated list of unconfigured network interfaces to include in the bridge
-`bridge.hwaddr`                      | string    | -                     | -                         | MAC address for the bridge
-`bridge.mtu`                         | integer   | -                     | `1442`                    | Bridge MTU (default allows host to host Geneve tunnels)
-`dns.nameservers`                    | string    | -                     | Uplink DNS servers (IPv4 and IPv6 address if no uplink is configured) | DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and the first IPv6 address is also advertised as RDNSS via RA.
-`dns.domain`                         | string    | -                     | `incus`                   | Domain to advertise to DHCP clients and use for DNS resolution
-`dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value
-`dns.zone.forward`                   | string    | -                     | -                         | Comma-separated list of DNS zone names for forward DNS records
-`dns.zone.reverse.ipv4`              | string    | -                     | -                         | DNS zone name for IPv4 reverse DNS records
-`dns.zone.reverse.ipv6`              | string    | -                     | -                         | DNS zone name for IPv6 reverse DNS records
-`ipv4.address`                       | string    | standard mode         | - (initial value on creation: `auto`) | IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)
-`ipv4.dhcp`                          | bool      | IPv4 address          | `true`                    | Whether to allocate addresses using DHCP
-`ipv4.dhcp.expiry`                   | string    | IPv4 DHCP             | `1h`                      | When to expire DHCP leases
-`ipv4.dhcp.routes`                   | string    | IPv4 DHCP             | -                         | Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq and OVN)
-`ipv4.l3only`                        | bool      | IPv4 address          | `false`                   | Whether to enable layer 3 only mode.
-`ipv4.nat`                           | bool      | IPv4 address          | `false` (initial value on creation if `ipv4.address` is set to `auto`: `true`) | Whether to NAT
-`ipv4.nat.address`                   | string    | IPv4 address          | -                         | The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
-`ipv6.address`                       | string    | standard mode         | - (initial value on creation: `auto`) | IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)
-`ipv6.dhcp`                          | bool      | IPv6 address          | `true`                    | Whether to provide additional network configuration over DHCP
-`ipv6.dhcp.stateful`                 | bool      | IPv6 DHCP             | `false`                   | Whether to allocate addresses using DHCP
-`ipv6.l3only`                        | bool      | IPv6 DHCP stateful    | `false`                   | Whether to enable layer 3 only mode.
-`ipv6.nat`                           | bool      | IPv6 address          | `false` (initial value on creation if `ipv6.address` is set to `auto`: `true`) | Whether to NAT
-`ipv6.nat.address`                   | string    | IPv6 address          | -                         | The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
-`security.acls`                      | string    | -                     | -                         | Comma-separated list of Network ACLs to apply to NICs connected to this network
-`security.acls.default.egress.action`| string    | `security.acls`       | `reject`                  | Action to use for egress traffic that doesn't match any ACL rule
-`security.acls.default.egress.logged`| bool      | `security.acls`       | `false`                   | Whether to log egress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.action` | string  | `security.acls`       | `reject`                  | Action to use for ingress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.logged` | bool    | `security.acls`       | `false`                   | Whether to log ingress traffic that doesn't match any ACL rule
-`user.*`                             | string    | -                     | -                         | User-provided free-form key/value pairs
+% Include content from [config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group network_ovn-common start -->
+    :end-before: <!-- config group network_ovn-common end -->
+```
 
 (network-ovn-features)=
 ## Supported features

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -3824,6 +3824,258 @@
 				]
 			}
 		},
+		"network_ovn": {
+			"common": {
+				"keys": [
+					{
+						"bridge.external_interfaces": {
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of unconfigured network interfaces to include in the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.hwaddr": {
+							"longdesc": "",
+							"shortdesc": "MAC address for the virtual bridge interface",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.mtu": {
+							"default": "`1442`",
+							"longdesc": "",
+							"shortdesc": "Bridge MTU (default allows host to host Geneve tunnels)",
+							"type": "integer"
+						}
+					},
+					{
+						"dns.domain": {
+							"default": "`incus`",
+							"longdesc": "",
+							"shortdesc": "Domain to advertise to DHCP clients and use for DNS resolution",
+							"type": "string"
+						}
+					},
+					{
+						"dns.nameservers": {
+							"default": "Uplink DNS servers (IPv4 and IPv6 address if no uplink is configured)",
+							"longdesc": "",
+							"shortdesc": "DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and the first IPv6 address is also advertised as RDNSS via RA.",
+							"type": "string"
+						}
+					},
+					{
+						"dns.search": {
+							"longdesc": "",
+							"shortdesc": "Full comma-separated domain search list, defaulting to `dns.domain` value",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.forward": {
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of DNS zone names for forward DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.reverse.ipv4": {
+							"longdesc": "",
+							"shortdesc": "DNS zone name for IPv4 reverse DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.reverse.ipv6": {
+							"longdesc": "",
+							"shortdesc": "DNS zone name for IPv6 reverse DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"condition": "standard mode",
+							"default": "(initial value on creation: `auto`)",
+							"longdesc": "",
+							"shortdesc": "IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp": {
+							"condition": "IPv4 address",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to allocate addresses using DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.dhcp.expiry": {
+							"condition": "IPv4 DHCP",
+							"default": "`1h`",
+							"longdesc": "",
+							"shortdesc": "When to expire DHCP leases",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.ranges": {
+							"condition": "IPv4 DHCP",
+							"default": "all addresses",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.routes": {
+							"condition": "IPv4 DHCP",
+							"longdesc": "",
+							"shortdesc": "Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq and OVN)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.l3only": {
+							"condition": "IPv4 address",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to enable layer 3 only mode.",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.nat": {
+							"condition": "IPv4 address",
+							"default": "`false` initial value on creation if `ipv4.address` is set to `auto: true`)",
+							"longdesc": "",
+							"shortdesc": "Whether to NAT",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.nat.address": {
+							"condition": "IPv4 address",
+							"longdesc": "",
+							"shortdesc": "The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.address": {
+							"condition": "standard mode",
+							"default": "(initial value on creation: `auto`)",
+							"longdesc": "",
+							"shortdesc": "IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp": {
+							"condition": "IPv6 address",
+							"default": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to provide additional network configuration over DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.dhcp.stateful": {
+							"condition": "IPv6 DHCP",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to allocate addresses using DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.l3only": {
+							"condition": "IPv6 DHCP stateful",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to enable layer 3 only mode.",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.nat": {
+							"condition": "IPv6 address",
+							"default": "`false` (initial value on creation if `ipv6.address` is set to `auto: true`)",
+							"longdesc": "",
+							"shortdesc": "Whether to NAT",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.nat.address": {
+							"condition": "IPv6 address",
+							"longdesc": "",
+							"shortdesc": "The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)",
+							"type": "string"
+						}
+					},
+					{
+						"network": {
+							"longdesc": "",
+							"shortdesc": "Uplink network to use for external network access or `none` to keep isolated",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls": {
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of Network ACLs to apply to NICs connected to this network",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.action": {
+							"condition": "`security.acls`",
+							"default": "`reject`",
+							"longdesc": "",
+							"shortdesc": "Action to use for egress traffic that doesn't match any ACL rule",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.logged": {
+							"condition": "`security.acls`",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to log egress traffic that doesn't match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"security.acls.default.ingress.action": {
+							"condition": "`security.acls`",
+							"default": "`reject`",
+							"longdesc": "",
+							"shortdesc": "Action to use for ingress traffic that doesn't match any ACL rule",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.ingress.logged": {
+							"condition": "`security.acls`",
+							"default": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to log ingress traffic that doesn't match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"user.*": {
+							"longdesc": "",
+							"shortdesc": "User-provided free-form key/value pairs",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"network_zone": {
 			"common": {
 				"keys": [

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -393,10 +393,42 @@ func (n *ovn) getExternalSubnetInUse(uplinkNetworkName string) ([]externalSubnet
 // Validate network config.
 func (n *ovn) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
+		// gendoc:generate(entity=network_ovn, group=common, key=network)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Uplink network to use for external network access or `none` to keep isolated
 		"network":                    validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=bridge.hwaddr)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: MAC address for the virtual bridge interface
+
 		"bridge.hwaddr":              validate.Optional(validate.IsNetworkMAC),
+		// gendoc:generate(entity=network_ovn, group=common, key=bridge.mtu)
+		//
+		// ---
+		//  type: integer
+		//  shortdesc: Bridge MTU (default allows host to host Geneve tunnels)
+		//  default: `1442`
+
 		"bridge.mtu":                 validate.Optional(validate.IsNetworkMTU),
+		// gendoc:generate(entity=network_ovn, group=common, key=bridge.external_interfaces)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Comma-separated list of unconfigured network interfaces to include in the bridge
+
 		"bridge.external_interfaces": validate.Optional(validateExternalInterfaces),
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.address)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)
+		//  condition: standard mode
+		//  default: (initial value on creation: `auto`)
 		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -404,13 +436,52 @@ func (n *ovn) Validate(config map[string]string) error {
 
 			return validate.IsNetworkAddressCIDRV4(value)
 		}),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.dhcp)
+		//
+		// ---
+		//  type: bool
+		//  shortdesc: Whether to allocate addresses using DHCP
+		//  condition: IPv4 address
+		//  default: `true`
 		"ipv4.dhcp": validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.dhcp.expiry)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: When to expire DHCP leases
+		//  condition: IPv4 DHCP
+		//  default: `1h`
 		"ipv4.dhcp.expiry": validate.Optional(func(value string) error {
 			_, err := time.ParseDuration(value)
 			return err
 		}),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.dhcp.ranges)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 DHCP
+		//  default: all addresses
+		//  shortdesc: Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)
 		"ipv4.dhcp.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.dhcp.routes)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 DHCP
+		//  shortdesc: Static routes to provide via DHCP option 121, as a comma-separated list of alternating subnets (CIDR) and gateway addresses (same syntax as dnsmasq and OVN)
 		"ipv4.dhcp.routes": validate.Optional(validate.IsDHCPRouteList),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.address)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)
+		//  condition: standard mode
+		//  default: (initial value on creation: `auto`)
 		"ipv6.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -418,25 +489,169 @@ func (n *ovn) Validate(config map[string]string) error {
 
 			return validate.IsNetworkAddressCIDRV6(value)
 		}),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.dhcp)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 address
+		//  shortdesc: Whether to provide additional network configuration over DHCP
+		//  default: `true`
 		"ipv6.dhcp":                            validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.dhcp.stateful)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 DHCP
+		//  shortdesc: Whether to allocate addresses using DHCP
+		//  default: `false`
 		"ipv6.dhcp.stateful":                   validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.nat)
+		//
+		// ---
+		//  type: bool
+		//  shortdesc: Whether to NAT
+		//  condition: IPv4 address
+		//  default: `false` initial value on creation if `ipv4.address` is set to `auto: true`)
 		"ipv4.nat":                             validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.nat.address)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
+		//  condition: IPv4 address
 		"ipv4.nat.address":                     validate.Optional(validate.IsNetworkAddressV4),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.nat)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 address
+		//  shortdesc: Whether to NAT
+		//  default: `false` (initial value on creation if `ipv6.address` is set to `auto: true`)
 		"ipv6.nat":                             validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.nat.address)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv6 address
+		//  shortdesc: The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
 		"ipv6.nat.address":                     validate.Optional(validate.IsNetworkAddressV6),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv4.l3only)
+		//
+		// ---
+		//  type: bool
+		//  shortdesc: Whether to enable layer 3 only mode.
+		//  condition: IPv4 address
+		//  default: `false`
 		"ipv4.l3only":                          validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=ipv6.l3only)
+		//
+		// ---
+		//  type: bool
+		//  condition: IPv6 DHCP stateful
+		//  shortdesc: Whether to enable layer 3 only mode.
+		//  default: `false`
 		"ipv6.l3only":                          validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=dns.nameservers)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: DNS server IPs to advertise to DHCP clients and via Router Advertisements. Both IPv4 and IPv6 addresses get pushed via DHCP, and the first IPv6 address is also advertised as RDNSS via RA.
+		//  default: Uplink DNS servers (IPv4 and IPv6 address if no uplink is configured)
 		"dns.nameservers":                      validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=dns.domain)
+		//
+		// ---
+		//  type: string
+		//  default: `incus`
+		//  shortdesc: Domain to advertise to DHCP clients and use for DNS resolution
 		"dns.domain":                           validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=dns.search)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Full comma-separated domain search list, defaulting to `dns.domain` value
 		"dns.search":                           validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=dns.zone.forward)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Comma-separated list of DNS zone names for forward DNS records
 		"dns.zone.forward":                     validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=dns.zone.reverse.ipv4)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: DNS zone name for IPv4 reverse DNS records
 		"dns.zone.reverse.ipv4":                validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=dns.zone.reverse.ipv6)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: DNS zone name for IPv6 reverse DNS records
 		"dns.zone.reverse.ipv6":                validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=security.acls)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Comma-separated list of Network ACLs to apply to NICs connected to this network
 		"security.acls":                        validate.IsAny,
+
+		// gendoc:generate(entity=network_ovn, group=common, key=security.acls.default.ingress.action)
+		//
+		// ---
+		//  type: string
+		//  condition: `security.acls`
+		//  shortdesc: Action to use for ingress traffic that doesn't match any ACL rule
+		//  default: `reject`
 		"security.acls.default.ingress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=security.acls.default.egress.action)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Action to use for egress traffic that doesn't match any ACL rule
+		//  default: `reject`
+		//  condition: `security.acls`
 		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=security.acls.default.ingress.logged)
+		//
+		// ---
+		//  type: bool
+		//  condition: `security.acls`
+		//  shortdesc: Whether to log ingress traffic that doesn't match any ACL rule
+		//  default: `false`
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=security.acls.default.egress.logged)
+		//
+		// ---
+		//  type: bool
+		//  shortdesc: Whether to log egress traffic that doesn't match any ACL rule
+		//  default: `false`
+		//  condition: `security.acls`
 		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
+
+		// gendoc:generate(entity=network_ovn, group=common, key=user.*)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: User-provided free-form key/value pairs
 
 		// Volatile keys populated automatically as needed.
 		ovnVolatileUplinkIPv4: validate.Optional(validate.IsNetworkAddressV4),


### PR DESCRIPTION
This PR closes #1794. Automated table towards OVN network documentation by utilizing config metadata. 