### PR TITLE
Rename result of `mux.NewRouter()` so they dont collide with the mux package

### DIFF
--- a/cmd/incus-agent/dev_incus.go
+++ b/cmd/incus-agent/dev_incus.go
@@ -251,14 +251,14 @@ func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devIncusRespo
 }
 
 func devIncusAPI(d *Daemon) http.Handler {
-	m := mux.NewRouter()
-	m.UseEncodedPath() // Allow encoded values in path segments.
+	router := mux.NewRouter()
+	router.UseEncodedPath() // Allow encoded values in path segments.
 
 	for _, handler := range handlers {
-		m.HandleFunc(handler.path, hoistReq(handler.f, d))
+		router.HandleFunc(handler.path, hoistReq(handler.f, d))
 	}
 
-	return m
+	return router
 }
 
 // Create a new net.Listener bound to the unix socket of the DevIncus endpoint.

--- a/cmd/incus-agent/server.go
+++ b/cmd/incus-agent/server.go
@@ -17,20 +17,20 @@ import (
 )
 
 func restServer(tlsConfig *tls.Config, cert *x509.Certificate, debug bool, d *Daemon) *http.Server {
-	mux := mux.NewRouter()
-	mux.StrictSlash(false) // Don't redirect to URL with trailing slash.
-	mux.UseEncodedPath()   // Allow encoded values in path segments.
+	router := mux.NewRouter()
+	router.StrictSlash(false) // Don't redirect to URL with trailing slash.
+	router.UseEncodedPath()   // Allow encoded values in path segments.
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
 	})
 
 	for _, c := range api10 {
-		createCmd(mux, "1.0", c, cert, debug, d)
+		createCmd(router, "1.0", c, cert, debug, d)
 	}
 
-	return &http.Server{Handler: mux, TLSConfig: tlsConfig}
+	return &http.Server{Handler: router, TLSConfig: tlsConfig}
 }
 
 func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Certificate, debug bool, d *Daemon) {

--- a/cmd/incusd/dev_incus.go
+++ b/cmd/incusd/dev_incus.go
@@ -309,14 +309,14 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 }
 
 func devIncusAPI(d *Daemon, f hoistFunc) http.Handler {
-	m := mux.NewRouter()
-	m.UseEncodedPath() // Allow encoded values in path segments.
+	router := mux.NewRouter()
+	router.UseEncodedPath() // Allow encoded values in path segments.
 
 	for _, handler := range handlers {
-		m.HandleFunc(handler.path, f(handler.f, d))
+		router.HandleFunc(handler.path, f(handler.f, d))
 	}
 
-	return m
+	return router
 }
 
 /*


### PR DESCRIPTION
This PR renames the result of calling `mux.newRouter()` from `mux` (which collides with the package name `mux`) to `router` which should fit with the method name. 
This PR also renames other variables that used to called `m` to `router`, so that they are the same.

If desired i can also just rename them all to `m`.