### PR TITLE
Rename instances of sha256.New() so they dont collide with the package name

### DIFF
--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -279,7 +279,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 	}
 
 	// Hashing
-	hashSHA256 := sha256.New()
+	hash256 := sha256.New()
 
 	// Deal with split images
 	if ctype == "multipart/form-data" {
@@ -300,7 +300,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 			return nil, fmt.Errorf("Invalid multipart image")
 		}
 
-		size, err := io.Copy(io.MultiWriter(req.MetaFile, hashSHA256), part)
+		size, err := io.Copy(io.MultiWriter(req.MetaFile, hash256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 			return nil, fmt.Errorf("Invalid multipart image")
 		}
 
-		size, err = io.Copy(io.MultiWriter(req.RootfsFile, hashSHA256), part)
+		size, err = io.Copy(io.MultiWriter(req.RootfsFile, hash256), part)
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +327,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 		resp.RootfsName = part.FileName()
 
 		// Check the hash
-		hash := fmt.Sprintf("%x", hashSHA256.Sum(nil))
+		hash := fmt.Sprintf("%x", hash256.Sum(nil))
 		if imageType != "oci" && !strings.HasPrefix(hash, fingerprint) {
 			return nil, fmt.Errorf("Image fingerprint doesn't match. Got %s expected %s", hash, fingerprint)
 		}
@@ -346,7 +346,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 		return nil, fmt.Errorf("No filename in Content-Disposition header")
 	}
 
-	size, err := io.Copy(io.MultiWriter(req.MetaFile, hashSHA256), body)
+	size, err := io.Copy(io.MultiWriter(req.MetaFile, hash256), body)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func incusDownloadImage(fingerprint string, uri string, userAgent string, do fun
 	resp.MetaName = filename
 
 	// Check the hash
-	hash := fmt.Sprintf("%x", hashSHA256.Sum(nil))
+	hash := fmt.Sprintf("%x", hash256.Sum(nil))
 	if imageType != "oci" && !strings.HasPrefix(hash, fingerprint) {
 		return nil, fmt.Errorf("Image fingerprint doesn't match. Got %s expected %s", hash, fingerprint)
 	}

--- a/cmd/incusd/daemon_images.go
+++ b/cmd/incusd/daemon_images.go
@@ -500,17 +500,17 @@ func ImageDownload(ctx context.Context, r *http.Request, s *state.State, op *ope
 		defer func() { _ = f.Close() }()
 
 		// Hashing
-		sha256 := sha256.New()
+		hash256 := sha256.New()
 
 		// Download the image
-		writer := internalIO.NewQuotaWriter(io.MultiWriter(f, sha256), args.Budget)
+		writer := internalIO.NewQuotaWriter(io.MultiWriter(f, hash256), args.Budget)
 		size, err := io.Copy(writer, body)
 		if err != nil {
 			return nil, false, err
 		}
 
 		// Validate hash
-		result := fmt.Sprintf("%x", sha256.Sum(nil))
+		result := fmt.Sprintf("%x", hash256.Sum(nil))
 		if result != fp {
 			return nil, false, fmt.Errorf("Hash mismatch for %q: %s != %s", args.Server, result, fp)
 		}

--- a/internal/server/apparmor/apparmor.go
+++ b/internal/server/apparmor/apparmor.go
@@ -241,9 +241,9 @@ func profileName(prefix string, name string) string {
 
 	// Max length in AppArmor is 253 chars.
 	if len(name)+len(prefix)+3+separators >= 253 {
-		hash := sha256.New()
-		_, _ = io.WriteString(hash, name)
-		name = fmt.Sprintf("%x", hash.Sum(nil))
+		hash256 := sha256.New()
+		_, _ = io.WriteString(hash256, name)
+		name = fmt.Sprintf("%x", hash256.Sum(nil))
 	}
 
 	if len(prefix) > 0 {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -9483,9 +9483,9 @@ func (d *qemu) blockNodeName(name string) string {
 		// If the name is too long, hash it as SHA-256 (32 bytes).
 		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 25 chars.
 		// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow.
-		hash := sha256.New()
-		hash.Write([]byte(name))
-		binaryHash := hash.Sum(nil)
+		hash256 := sha256.New()
+		hash256.Write([]byte(name))
+		binaryHash := hash256.Sum(nil)
 		name = base64.RawURLEncoding.EncodeToString(binaryHash)
 		name = name[0:25]
 	}

--- a/internal/server/util/http.go
+++ b/internal/server/util/http.go
@@ -65,13 +65,13 @@ func WriteJSON(w http.ResponseWriter, body any, debugLogger logger.Logger) error
 
 // EtagHash hashes the provided data and returns the sha256.
 func EtagHash(data any) (string, error) {
-	etag := sha256.New()
-	err := json.NewEncoder(etag).Encode(data)
+	hash256 := sha256.New()
+	err := json.NewEncoder(hash256).Encode(data)
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", etag.Sum(nil)), nil
+	return fmt.Sprintf("%x", hash256.Sum(nil)), nil
 }
 
 // EtagCheck validates the hash of the current state with the hash


### PR DESCRIPTION
This PR renames all instances of `sha256.New()` to `hash256` so that they do not collide with the package name `sha256` anymore. I chose this variable name since that was already used a bunch in other places. I am willing to use a different name of course, but i thought, i'd use what was already there.