### PR TITLE
Missing case statements for iota constants

### DIFF
--- a/cmd/incus-migrate/main_migrate.go
+++ b/cmd/incus-migrate/main_migrate.go
@@ -283,6 +283,9 @@ func (c *cmdMigrate) askServer() (incus.InstanceServer, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
+
+	case authMethodTLSTemporaryCertificate:
+		// Intentionally ignored
 	}
 
 	var authType string

--- a/internal/filter/value.go
+++ b/internal/filter/value.go
@@ -41,7 +41,9 @@ func ValueOf(obj any, field string) any {
 					return v
 				}
 			}
+
 			return m[field]
+
 		case reflect.Map:
 			for _, entry := range value.MapKeys() {
 				if entry.Interface() != key {
@@ -51,8 +53,12 @@ func ValueOf(obj any, field string) any {
 				m := value.MapIndex(entry)
 				return ValueOf(m.Interface(), rest)
 			}
+
+			return nil
+
+		default:
+			return nil
 		}
-		return nil
 	}
 
 	for i := 0; i < value.NumField(); i++ {

--- a/internal/server/db/operationtype/operation_type.go
+++ b/internal/server/db/operationtype/operation_type.go
@@ -300,7 +300,8 @@ func (t Type) Permission() (auth.ObjectType, auth.Entitlement) {
 		return auth.ObjectTypeStorageVolume, auth.EntitlementCanManageBackups
 	case BucketBackupRestore:
 		return auth.ObjectTypeStorageVolume, auth.EntitlementCanEdit
-	}
 
-	return "", ""
+	default:
+		return "", ""
+	}
 }

--- a/internal/server/scriptlet/marshal/marshal.go
+++ b/internal/server/scriptlet/marshal/marshal.go
@@ -195,9 +195,8 @@ func starlarkMarshal(input any, parent *starlark.Dict) (starlark.Value, error) {
 				return nil, err
 			}
 		}
-	}
 
-	if sv == nil {
+	default:
 		return nil, fmt.Errorf("Unrecognised type %v for value %+v", v.Type(), v.Interface())
 	}
 


### PR DESCRIPTION
This PR ensures that switch statements on iota constants cover all cases internally either by internalizing the external return statement as a default case or by commenting explicitely that a certain case is ignored. The file `vdpa.go` is ignored in this PR, since that looks like it needs special taking care of.