### PR TITLE
incusd: rename instanceActionToOptype to instanceActionToOpType

### DIFF
--- a/cmd/incusd/instance_state.go
+++ b/cmd/incusd/instance_state.go
@@ -180,7 +180,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Actually perform the change.
-	opType, err := instanceActionToOptype(req.Action)
+	opType, err := instanceActionToOpType(req.Action)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -201,7 +201,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	return operations.OperationResponse(op)
 }
 
-func instanceActionToOptype(action string) (operationtype.Type, error) {
+func instanceActionToOpType(action string) (operationtype.Type, error) {
 	switch internalInstance.InstanceAction(action) {
 	case internalInstance.Start:
 		return operationtype.InstanceStart, nil
@@ -213,9 +213,9 @@ func instanceActionToOptype(action string) (operationtype.Type, error) {
 		return operationtype.InstanceFreeze, nil
 	case internalInstance.Unfreeze:
 		return operationtype.InstanceUnfreeze, nil
+	default:
+		return operationtype.Unknown, fmt.Errorf("Unknown action: '%s'", action)
 	}
-
-	return operationtype.Unknown, fmt.Errorf("Unknown action: '%s'", action)
 }
 
 func doInstanceStatePut(inst instance.Instance, req api.InstanceStatePut) error {

--- a/cmd/incusd/instances_put.go
+++ b/cmd/incusd/instances_put.go
@@ -146,7 +146,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Determine operation type.
-	opType, err := instanceActionToOptype(req.State.Action)
+	opType, err := instanceActionToOpType(req.State.Action)
 	if err != nil {
 		return response.BadRequest(err)
 	}


### PR DESCRIPTION
Renames the function instanceActionToOptype to fix a typo. Also move the default case into the switch.