### PR TITLE
Rework QEMU config override logic

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3918,7 +3918,16 @@ func (d *qemu) generateQemuConfig(machineDefinition string, cpuInfo *cpuTopology
 	}
 
 	// process any user-specified overrides
-	d.conf = qemuRawCfgOverride(conf, d.expandedConfig)
+	confOverride, ok := d.expandedConfig["raw.qemu.conf"]
+	if ok {
+		d.conf, err = qemuRawCfgOverride(conf, confOverride)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		d.conf = conf
+	}
+
 	return monHooks, nil
 }
 

--- a/internal/server/instance/drivers/driver_qemu_config_override.go
+++ b/internal/server/instance/drivers/driver_qemu_config_override.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -13,218 +12,148 @@ const pattern = `\s*(?m:(?:\[([^\]]+)\](?:\[(\d+)\])?)|(?:([^=]+)[ \t]*=[ \t]*(?
 
 var parser = regexp.MustCompile(pattern)
 
-type rawConfigKey struct {
-	sectionName string
-	index       uint
-	entryKey    string
+// sectionContent represents the content of a section, without its name.
+type sectionContent struct {
+	comment string
+	entries map[string]string
 }
 
-type configMap map[rawConfigKey]string
+// section represents a section pointing to its content.
+type section struct {
+	name    string
+	content *sectionContent
+}
 
-func parseConfOverride(confOverride string) configMap {
-	s := confOverride
-	rv := configMap{}
-	currentSectionName := ""
-	var currentIndex uint
-	currentEntryCount := 0
+// qemuRawCfgOverride generates a new QEMU configuration from an original one and an override entry.
+func qemuRawCfgOverride(conf []cfg.Section, expandedConfig map[string]string) []cfg.Section {
+	confOverride, ok := expandedConfig["raw.qemu.conf"]
+	if !ok {
+		// If we don’t have an override, we can return the original configuration.
+		return conf
+	}
 
+	// We define a data structure optimized for lookup and insertion…
+	indexedSections := map[string]map[int]*sectionContent{}
+	// … and another one keeping insertion order. This saves us a few cycles at the expense of a few
+	// bytes of RAM.
+	orderedSections := []section{}
+
+	// We first iterate over the original config to populate both our data structures.
+	for _, sec := range conf {
+		indexedSection, ok := indexedSections[sec.Name]
+		if !ok {
+			indexedSection = map[int]*sectionContent{}
+			indexedSections[sec.Name] = indexedSection
+		}
+
+		// We perform a copy of the map to avoid modifying the original one
+		entries := make(map[string]string, len(sec.Entries))
+		for k, v := range sec.Entries {
+			entries[k] = v
+		}
+
+		content := &sectionContent{
+			comment: sec.Comment,
+			entries: entries,
+		}
+
+		indexedSection[len(indexedSection)] = content
+		orderedSections = append(orderedSections, section{
+			name:    sec.Name,
+			content: content,
+		})
+	}
+
+	var currentIndexedSection map[int]*sectionContent
+	var currentIndex int
+	// We set the changed flag to true for our first iteration.
+	changed := true
+
+	// Then, we parse the override string.
 	for {
-		loc := parser.FindStringSubmatchIndex(s)
+		loc := parser.FindStringSubmatchIndex(confOverride)
 		if loc == nil {
 			break
 		}
 
 		if loc[2] > 0 {
-			if currentSectionName != "" && currentEntryCount == 0 {
-				// new section started and previous section ended without entries
-				k := rawConfigKey{
-					sectionName: currentSectionName,
-					index:       currentIndex,
-					entryKey:    "",
-				}
-
-				rv[k] = ""
+			// If a section is defined in the override but has no key, remove its entries.
+			if !changed {
+				(*currentIndexedSection[currentIndex]).entries = make(map[string]string)
 			}
 
-			currentEntryCount = 0
-			currentSectionName = strings.TrimSpace(s[loc[2]:loc[3]])
+			changed = false
+			currentSectionName := strings.TrimSpace(confOverride[loc[2]:loc[3]])
+
 			if loc[4] > 0 {
-				i, err := strconv.Atoi(s[loc[4]:loc[5]])
+				i, err := strconv.Atoi(confOverride[loc[4]:loc[5]])
 				if err != nil || i < 0 {
 					panic("failed to parse index")
 				}
 
-				currentIndex = uint(i)
+				currentIndex = i
 			} else {
 				currentIndex = 0
 			}
+
+			var ok bool
+			currentIndexedSection, ok = indexedSections[currentSectionName]
+			if !ok {
+				// If there is no section with this name, we are creating a new section.
+				currentIndexedSection = map[int]*sectionContent{}
+				indexedSections[currentSectionName] = currentIndexedSection
+			}
+
+			_, ok = currentIndexedSection[currentIndex]
+			if !ok {
+				// If there is no section with this index, we are creating a new section.
+				emptyContent := &sectionContent{entries: make(map[string]string)}
+				currentIndexedSection[currentIndex] = emptyContent
+				indexedSections[currentSectionName] = currentIndexedSection
+				orderedSections = append(orderedSections, section{
+					name:    currentSectionName,
+					content: emptyContent,
+				})
+			}
 		} else {
-			entryKey := strings.TrimSpace(s[loc[6]:loc[7]])
+			entryKey := strings.TrimSpace(confOverride[loc[6]:loc[7]])
 			var value string
 
 			if loc[8] > 0 {
 				// quoted value
-				value = s[loc[8]:loc[9]]
+				value = confOverride[loc[8]:loc[9]]
 			} else {
 				// unquoted value
-				value = strings.TrimSpace(s[loc[10]:loc[11]])
+				value = strings.TrimSpace(confOverride[loc[10]:loc[11]])
 			}
 
-			k := rawConfigKey{
-				sectionName: currentSectionName,
-				index:       currentIndex,
-				entryKey:    entryKey,
-			}
-
-			rv[k] = value
-			currentEntryCount++
-		}
-
-		s = s[loc[1]:]
-	}
-
-	if currentSectionName != "" && currentEntryCount == 0 {
-		// previous section ended without entries
-		k := rawConfigKey{
-			sectionName: currentSectionName,
-			index:       currentIndex,
-			entryKey:    "",
-		}
-
-		rv[k] = ""
-	}
-
-	return rv
-}
-
-func updateEntries(entries map[string]string, sk rawConfigKey, confMap configMap) map[string]string {
-	rv := make(map[string]string)
-
-	for key, value := range entries {
-		ek := rawConfigKey{sk.sectionName, sk.index, key}
-		val, ok := confMap[ek]
-		if ok {
-			// override
-			delete(confMap, ek)
-			value = val
-		}
-
-		rv[key] = value
-	}
-
-	return rv
-}
-
-func appendEntries(entries map[string]string, sk rawConfigKey, confMap configMap) map[string]string {
-	// processed all modifications for the current section, now
-	// handle new entries
-	for rawKey, value := range confMap {
-		if rawKey.sectionName != sk.sectionName || rawKey.index != sk.index {
-			continue
-		}
-
-		entries[rawKey.entryKey] = value
-		delete(confMap, rawKey)
-	}
-
-	return entries
-}
-
-func updateSections(conf []cfg.Section, confMap configMap) []cfg.Section {
-	newConf := []cfg.Section{}
-	sectionCounts := map[string]uint{}
-
-	for _, section := range conf {
-		count, ok := sectionCounts[section.Name]
-
-		if ok {
-			sectionCounts[section.Name] = count + 1
-		} else {
-			sectionCounts[section.Name] = 1
-		}
-
-		index := sectionCounts[section.Name] - 1
-		sk := rawConfigKey{section.Name, index, ""}
-
-		val, ok := confMap[sk]
-		if ok {
-			if val == "" {
-				// deleted section
-				delete(confMap, sk)
-				continue
+			changed = true
+			if value == "" {
+				// If the value associated to this key is empty, delete the key.
+				delete((*currentIndexedSection[currentIndex]).entries, entryKey)
+			} else {
+				(*currentIndexedSection[currentIndex]).entries[entryKey] = value
 			}
 		}
 
-		newSection := cfg.Section{
-			Name:    section.Name,
-			Comment: section.Comment,
+		confOverride = confOverride[loc[1]:]
+	}
+
+	// Same as above, if a section is defined in the override but has no key, remove its entries.
+	if !changed {
+		(*currentIndexedSection[currentIndex]).entries = make(map[string]string)
+	}
+
+	res := []cfg.Section{}
+	for _, orderedSection := range orderedSections {
+		if len((*orderedSection.content).entries) > 0 {
+			res = append(res, cfg.Section{
+				Name:    orderedSection.name,
+				Comment: (*orderedSection.content).comment,
+				Entries: (*orderedSection.content).entries,
+			})
 		}
-
-		newSection.Entries = updateEntries(section.Entries, sk, confMap)
-		newSection.Entries = appendEntries(newSection.Entries, sk, confMap)
-
-		newConf = append(newConf, newSection)
 	}
 
-	return newConf
-}
-
-func appendSections(newConf []cfg.Section, confMap configMap) []cfg.Section {
-	tmp := map[rawConfigKey]cfg.Section{}
-
-	for k, value := range confMap {
-		if k.entryKey == "" {
-			// makes no sense to process section deletions (the only case where
-			// entryKey == "") since we are only adding new sections now
-			continue
-		}
-
-		sectionKey := rawConfigKey{k.sectionName, k.index, ""}
-		section, found := tmp[sectionKey]
-		if !found {
-			section = cfg.Section{
-				Name:    k.sectionName,
-				Entries: make(map[string]string),
-			}
-		}
-
-		section.Entries[k.entryKey] = value
-		tmp[sectionKey] = section
-	}
-
-	rawSections := []rawConfigKey{}
-	for rawSection := range tmp {
-		rawSections = append(rawSections, rawSection)
-	}
-
-	// Sort to have deterministic output in the appended sections
-	sort.SliceStable(rawSections, func(i, j int) bool {
-		return rawSections[i].sectionName < rawSections[j].sectionName ||
-			rawSections[i].index < rawSections[j].index
-	})
-
-	for _, rawSection := range rawSections {
-		newConf = append(newConf, tmp[rawSection])
-	}
-
-	return newConf
-}
-
-func qemuRawCfgOverride(conf []cfg.Section, expandedConfig map[string]string) []cfg.Section {
-	confOverride, ok := expandedConfig["raw.qemu.conf"]
-	if !ok {
-		return conf
-	}
-
-	confMap := parseConfOverride(confOverride)
-
-	if len(confMap) == 0 {
-		// If no keys are found, we return the conf unmodified.
-		return conf
-	}
-
-	newConf := updateSections(conf, confMap)
-	newConf = appendSections(newConf, confMap)
-
-	return newConf
+	return res
 }

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -1122,45 +1122,16 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}}
 		testCases := []struct {
 			cfg       []cfg.Section
-			overrides map[string]string
+			overrides string
 			expected  string
 		}{{
-			// unmodified
-			conf,
-			map[string]string{},
-			`[global]
-			driver = "ICH9-LPC"
-			property = "disable_s3"
-			value = "1"
-
-			[global]
-			driver = "ICH9-LPC"
-			property = "disable_s4"
-			value = "0"
-
-			[memory]
-			size = "1024M"
-
-			[device "qemu_gpu"]
-			addr = "00.0"
-			bus = "qemu_pci3"
-			driver = "virtio-gpu-pci"
-
-			[device "qemu_keyboard"]
-			addr = "00.1"
-			bus = "qemu_pci2"
-			driver = "virtio-keyboard-pci"`,
-		}, {
 			// override some keys
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[memory]
-						size = "4096M"
+			`[memory]
+			size = "4096M"
 
-						[device "qemu_gpu"]
-						driver = "qxl-vga"`,
-			},
+			[device "qemu_gpu"]
+			driver = "qxl-vga"`,
 			`[global]
 			driver = "ICH9-LPC"
 			property = "disable_s3"
@@ -1186,14 +1157,11 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// delete some keys
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[device "qemu_keyboard"]
-						driver = ""
+			`[device "qemu_keyboard"]
+			driver = ""
 
-						[device "qemu_gpu"]
-						addr = ""`,
-			},
+			[device "qemu_gpu"]
+			addr = ""`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1217,20 +1185,17 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// add some keys to existing sections
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[memory]
-						somekey = "somevalue"
-						somekey2 =             "somevalue2"
-						somekey3 =   "somevalue3"
-						somekey4="somevalue4"
+			`[memory]
+			somekey = "somevalue"
+			somekey2 =             "somevalue2"
+			somekey3 =   "somevalue3"
+			somekey4="somevalue4"
 
-						[device "qemu_keyboard"]
-						multifunction="off"
+			[device "qemu_keyboard"]
+			multifunction="off"
 
-						[device "qemu_gpu"]
-						multifunction=      "on"`,
-			},
+			[device "qemu_gpu"]
+			multifunction=      "on"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1262,16 +1227,13 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// edit/add/remove
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[memory]
-						size = "2048M"
-						[device "qemu_gpu"]
-						multifunction = "on"
-						[device "qemu_keyboard"]
-						addr = ""
-						bus = ""`,
-			},
+			`[memory]
+			size = "2048M"
+			[device "qemu_gpu"]
+			multifunction = "on"
+			[device "qemu_keyboard"]
+			addr = ""
+			bus = ""`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1296,12 +1258,9 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// delete sections
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[memory]
-						[device "qemu_keyboard"]
-						[global][1]`,
-			},
+			`[memory]
+			[device "qemu_keyboard"]
+			[global][1]`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1314,23 +1273,20 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// add sections
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[object1]
-						key1     = "value1"
-						key2     = "value2"
+			`[object1]
+			key1     = "value1"
+			key2     = "value2"
 
-						[object "2"]
-						key3  = "value3"
-						[object "3"]
-						key4  = "value4"
+			[object "2"]
+			key3  = "value3"
+			[object "3"]
+			key4  = "value4"
 
-						[object "2"]
-						key5  = "value5"
+			[object "2"]
+			key5  = "value5"
 
-						[object1]
-						key6     = "value6"`,
-			},
+			[object1]
+			key6     = "value6"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1368,16 +1324,13 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// add/remove sections
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[device "qemu_gpu"]
-						[object "2"]
-						key3  = "value3"
-						[object "3"]
-						key4  = "value4"
-						[object "2"]
-						key5  = "value5"`,
-			},
+			`[device "qemu_gpu"]
+			[object "2"]
+			key3  = "value3"
+			[object "3"]
+			key4  = "value4"
+			[object "2"]
+			key5  = "value5"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1405,19 +1358,16 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// edit keys of repeated sections
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[global][1]
-						property ="disable_s1"
-						[global]
-						property ="disable_s5"
-						[global][1]
-						value = ""
-						[global][0]
-						somekey ="somevalue"
-						[global][1]
-						anotherkey = "anothervalue"`,
-			},
+			`[global][1]
+			property ="disable_s1"
+			[global]
+			property ="disable_s5"
+			[global][1]
+			value = ""
+			[global][0]
+			somekey ="somevalue"
+			[global][1]
+			anotherkey = "anothervalue"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s5"
@@ -1446,23 +1396,20 @@ func TestQemuConfigTemplates(t *testing.T) {
 			conf,
 			// note that for appending new sections, all that matters is that
 			// the index is higher than the existing indexes
-			map[string]string{
-				"raw.qemu.conf": `
-						[global][2]
-						property =  "new section"
-						[global][2]
-						value =     "new value"
-						[object][3]
-						k1 =        "v1"
-						[object][3]
-						k2 =        "v2"
-						[object][4]
-						k3 =        "v1"
-						[object][4]
-						k2 =        "v2"
-						[object][11]
-						k11 =  "v11"`,
-			},
+			`[global][2]
+			property =  "new section"
+			[global][2]
+			value =     "new value"
+			[object][3]
+			k1 =        "v1"
+			[object][3]
+			k2 =        "v2"
+			[object][4]
+			k3 =        "v1"
+			[object][4]
+			k2 =        "v2"
+			[object][11]
+			k11 =  "v11"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1503,17 +1450,14 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// create multiple sections with same name, with decreasing indices
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[object][3]
-						k1 =        "v1"
-						[object][3]
-						k2 =        "v2"
-						[object][2]
-						k3 =        "v1"
-						[object][2]
-						k2 =        "v2"`,
-			},
+			`[object][3]
+			k1 =        "v1"
+			[object][3]
+			k2 =        "v2"
+			[object][2]
+			k3 =        "v1"
+			[object][2]
+			k2 =        "v2"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1547,21 +1491,18 @@ func TestQemuConfigTemplates(t *testing.T) {
 		}, {
 			// mix all operations
 			conf,
-			map[string]string{
-				"raw.qemu.conf": `
-						[memory]
-						size = "8192M"
-						[device "qemu_keyboard"]
-						multifunction=on
-						bus =
-						[device "qemu_gpu"]
-						[object "3"]
-						key4 = " value4 "
-						[object "2"]
-						key3 =   value3
-						[object "3"]
-						key5 = "value5"`,
-			},
+			`[memory]
+			size = "8192M"
+			[device "qemu_keyboard"]
+			multifunction=on
+			bus =
+			[device "qemu_gpu"]
+			[object "3"]
+			key4 = " value4 "
+			[object "2"]
+			key3 =   value3
+			[object "3"]
+			key5 = "value5"`,
 			`[global]
 				driver = "ICH9-LPC"
 				property = "disable_s3"
@@ -1588,7 +1529,12 @@ func TestQemuConfigTemplates(t *testing.T) {
 				key3 = "value3"`,
 		}}
 		for _, tc := range testCases {
-			runTest(tc.expected, qemuRawCfgOverride(tc.cfg, tc.overrides))
+			overridden, err := qemuRawCfgOverride(tc.cfg, tc.overrides)
+			if err != nil {
+				t.Error(err)
+			}
+
+			runTest(tc.expected, overridden)
 		}
 	})
 }


### PR DESCRIPTION
This PR rewrites the old QEMU config override logic to save some CPU cycles and to be a little easier to review. This breaks the previous behavior in the following way: new config sections are inserted in the final config in the order in which they are seen, not in the order in which they are last updated. I feel like it’s actually the intended behavior (as it’s the one for already-defined sections, not new ones).