### PR TITLE
Add server-side filtering for `incus config trust list`

### DIFF
--- a/client/incus_certificates.go
+++ b/client/incus_certificates.go
@@ -36,6 +36,23 @@ func (r *ProtocolIncus) GetCertificates() ([]api.Certificate, error) {
 	return certificates, nil
 }
 
+// GetCertificatesWithFilter returns a filtered list of certificates.
+func (r *ProtocolIncus) GetCertificatesWithFilter(filters []string) ([]api.Certificate, error) {
+	certificates := []api.Certificate{}
+
+	v := url.Values{}
+	v.Set("recursion", "1")
+	v.Set("filter", parseFilters(filters))
+
+	// Fetch the raw value
+	_, err := r.queryStruct("GET", fmt.Sprintf("/certificates?%s", v.Encode()), nil, "", &certificates)
+	if err != nil {
+		return nil, err
+	}
+
+	return certificates, nil
+}
+
 // GetCertificate returns the certificate entry for the provided fingerprint.
 func (r *ProtocolIncus) GetCertificate(fingerprint string) (*api.Certificate, string, error) {
 	certificate := api.Certificate{}

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -89,6 +89,7 @@ type InstanceServer interface {
 	// Certificate functions
 	GetCertificateFingerprints() (fingerprints []string, err error)
 	GetCertificates() (certificates []api.Certificate, err error)
+	GetCertificatesWithFilter(filters []string) ([]api.Certificate, error)
 	GetCertificate(fingerprint string) (certificate *api.Certificate, ETag string, err error)
 	CreateCertificate(certificate api.CertificatesPost) (err error)
 	UpdateCertificate(fingerprint string, certificate api.CertificatePut, ETag string) (err error)

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -547,8 +547,16 @@ func (c *cmdConfigTrustList) Run(cmd *cobra.Command, args []string) error {
 
 	resource := resources[0]
 
+	// Process the filters
+	filters := []string{}
+	if len(args) > 1 {
+		filters = append(filters, args[1:]...)
+	}
+
+	filters = prepareCertificatesFilters(filters)
+
 	// List trust relationships
-	trust, err := resource.server.GetCertificates()
+	trust, err := resource.server.GetCertificatesWithFilter(filters)
 	if err != nil {
 		return err
 	}
@@ -928,4 +936,28 @@ func (c *cmdConfigTrustShow) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s", data)
 
 	return nil
+}
+
+// prepareCertificatesFilters processes and formats filter criteria
+// for storage buckets, ensuring they are in a format that the server can interpret.
+func prepareCertificatesFilters(filters []string) []string {
+	formatedFilters := []string{}
+
+	for _, filter := range filters {
+		membs := strings.SplitN(filter, "=", 2)
+		key := membs[0]
+
+		if len(membs) == 1 {
+			regexpValue := key
+			if !strings.Contains(key, "^") && !strings.Contains(key, "$") {
+				regexpValue = "^" + regexpValue + "$"
+			}
+
+			filter = fmt.Sprintf("name=(%s|^%s.*)", regexpValue, key)
+		}
+
+		formatedFilters = append(formatedFilters, filter)
+	}
+
+	return formatedFilters
 }

--- a/internal/server/network/driver_macvlan.go
+++ b/internal/server/network/driver_macvlan.go
@@ -38,7 +38,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		//  type: int
 		//  condition: -
 		//  shortdesc: The MTU of the new interface
-		"mtu":    validate.Optional(validate.IsNetworkMTU),
+		"mtu": validate.Optional(validate.IsNetworkMTU),
 
 		// gendoc:generate(entity=network_macvlan, group=common, key=vlan)
 		//
@@ -46,7 +46,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		//  type: int
 		//  condition: -
 		//  shortdesc: The VLAN ID to attach to
-		"vlan":   validate.Optional(validate.IsNetworkVLAN),
+		"vlan": validate.Optional(validate.IsNetworkVLAN),
 
 		// gendoc:generate(entity=network_macvlan, group=common, key=gvrp)
 		//
@@ -55,7 +55,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		//  condition: -
 		//  default: `false`
 		//  shortdesc: Register VLAN using GARP VLAN Registration Protocol
-		"gvrp":   validate.Optional(validate.IsBool),
+		"gvrp": validate.Optional(validate.IsBool),
 
 		// gendoc:generate(entity=network_macvlan, group=common, key=user.*)
 		//


### PR DESCRIPTION
Resolves #1908.

Adds server-side filtering for the `incus config trust list` command. Updated CLI List to use `GetCertificatesWithFilter`. Did not update CLI List to use a `GetAllProjectCertificatesWithFilter` function because there is not an existing `GetCertificatesAllProjects` function. 
