### PR TITLE
incusd/instance/qemu: Don't allow QEMU RSS to exceed memory limit

### DIFF
--- a/internal/server/instance/drivers/driver_qemu_metrics.go
+++ b/internal/server/instance/drivers/driver_qemu_metrics.go
@@ -155,6 +155,11 @@ func (d *qemu) getQemuMemoryMetrics(monitor *qmp.Monitor) (metrics.MemoryMetrics
 		return out, err
 	}
 
+	// Handle host usage being larger than limit.
+	if memRSS > memTotalBytes {
+		memRSS = memTotalBytes
+	}
+
 	// Prepare struct.
 	out = metrics.MemoryMetrics{
 		MemAvailableBytes: uint64(memTotalBytes - memRSS),


### PR DESCRIPTION
This prevents a metrics overflow as QEMU may be reporting slightly higher memory usage than the user configured limit (due to QEMU's own consumption).

Closes #1686