### PR TITLE
Implement stateful DHCPv6

### DIFF
--- a/cmd/incusd/main_forknet.go
+++ b/cmd/incusd/main_forknet.go
@@ -479,6 +479,9 @@ func (c *cmdForknet) dhcpRunV4(errorChannel chan error, iface string, hostname s
 }
 
 func (c *cmdForknet) dhcpRunV6(errorChannel chan error, iface string, hostname string, logger *logrus.Logger) {
+	// Wait a couple of seconds for IPv6 link-local.
+	time.Sleep(2 * time.Second)
+
 	// Get a new DHCPv6 client.
 	client, err := nclient6.New(iface)
 	if err != nil {

--- a/cmd/incusd/main_forknet.go
+++ b/cmd/incusd/main_forknet.go
@@ -219,10 +219,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
+	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/dhcpv6/nclient6"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -235,6 +238,11 @@ import (
 
 type cmdForknet struct {
 	global *cmdGlobal
+
+	applyDNSMu      sync.Mutex
+	dhcpv4Lease     *nclient4.Lease
+	dhcpv6Lease     *dhcpv6.Message
+	instNetworkPath string
 }
 
 func (c *cmdForknet) command() *cobra.Command {
@@ -294,10 +302,12 @@ func (c *cmdForknet) runInfo(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-// RunDHCP runs a one time DHCPv4 client and applies address, route and DNS configuration.
+// RunDHCP spawns the DHCP client(s) and applies address, route and DNS configuration.
 func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 	logger := logrus.New()
 	logger.Level = logrus.DebugLevel
+
+	c.instNetworkPath = args[0]
 
 	if C.forknet_dhcp_logfile >= 0 {
 		logger.SetOutput(os.NewFile(uintptr(C.forknet_dhcp_logfile), "incus-dhcp-logfile"))
@@ -321,18 +331,48 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 	}
 
 	// Read the hostname.
-	bb, err := os.ReadFile(filepath.Join(args[0], "hostname"))
+	bb, err := os.ReadFile(filepath.Join(c.instNetworkPath, "hostname"))
 	if err != nil {
 		logger.WithError(err).Error("Unable to read hostname file")
 	}
 
 	hostname := strings.TrimSpace(string(bb))
 
+	// Create PID file.
+	err = os.WriteFile(filepath.Join(c.instNetworkPath, "dhcp.pid"), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644)
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCP, couldn't write PID file")
+		return err
+	}
+
+	errorChannel := make(chan error, 2)
+	go c.dhcpRunV4(errorChannel, iface, hostname, logger)
+	go c.dhcpRunV6(errorChannel, iface, hostname, logger)
+
+	err1 := <-errorChannel
+	if err1 != nil {
+		logger.WithError(err1).Error("DHCP client failed")
+	}
+
+	err2 := <-errorChannel
+	if err2 != nil {
+		logger.WithError(err2).Error("DHCP client failed")
+	}
+
+	if err1 == nil && err2 == nil {
+		return nil
+	}
+
+	return fmt.Errorf("DHCP failure, client1=%v client2=%v", err1, err2)
+}
+
+func (c *cmdForknet) dhcpRunV4(errorChannel chan error, iface string, hostname string, logger *logrus.Logger) {
 	// Try to get a lease.
 	client, err := nclient4.New(iface)
 	if err != nil {
-		logger.WithError(err).Error("Giving up on DHCP, couldn't set up client")
-		return nil
+		logger.WithError(err).Error("Giving up on DHCPv4, couldn't set up client")
+		errorChannel <- err
+		return
 	}
 
 	defer func() { _ = client.Close() }()
@@ -340,55 +380,34 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 	lease, err := client.Request(context.Background(), dhcpv4.WithOption(dhcpv4.OptHostName(hostname)))
 	if err != nil {
 		logger.WithError(err).WithField("hostname", hostname).
-			Error("Giving up on DHCP, couldn't get a lease")
-		return nil
+			Error("Giving up on DHCPv4, couldn't get a lease")
+		errorChannel <- err
+		return
 	}
 
 	// Parse the response.
 	if lease.Offer == nil {
 		logger.WithField("hostname", hostname).
-			Error("Giving up on DHCP, couldn't get a lease after 5s")
-		return nil
+			Error("Giving up on DHCPv4, couldn't get a lease after 5s")
+		errorChannel <- err
+		return
 	}
 
 	if lease.Offer.YourIPAddr == nil || lease.Offer.YourIPAddr.Equal(net.IPv4zero) || lease.Offer.SubnetMask() == nil || len(lease.Offer.Router()) != 1 {
-		logger.Error("Giving up on DHCP, lease didn't contain required fields")
-		return nil
+		logger.Error("Giving up on DHCPv4, lease didn't contain required fields")
+		errorChannel <- fmt.Errorf("Giving up on DHCPv4, lease didn't contain required fields")
+		return
 	}
 
-	if len(lease.Offer.DNS()) > 0 {
-		// DNS configuration.
-		f, err := os.Create(filepath.Join(args[0], "resolv.conf"))
-		if err != nil {
-			logger.WithError(err).Error("Giving up on DHCP, couldn't create resolv.conf")
-			return nil
-		}
+	c.applyDNSMu.Lock()
+	c.dhcpv4Lease = lease
+	c.applyDNSMu.Unlock()
 
-		defer f.Close()
-
-		for _, nameserver := range lease.Offer.DNS() {
-			_, err = fmt.Fprintf(f, "nameserver %s\n", nameserver)
-			if err != nil {
-				logger.WithError(err).Error("Giving up on DHCP, couldn't prepare resolv.conf")
-				return nil
-			}
-		}
-
-		if lease.Offer.DomainName() != "" {
-			_, err = fmt.Fprintf(f, "domain %s\n", lease.Offer.DomainName())
-			if err != nil {
-				logger.WithError(err).Error("Giving up on DHCP, couldn't prepare resolv.conf")
-				return nil
-			}
-		}
-
-		if lease.Offer.DomainSearch() != nil && len(lease.Offer.DomainSearch().Labels) > 0 {
-			_, err = fmt.Fprintf(f, "search %s\n", strings.Join(lease.Offer.DomainSearch().Labels, ", "))
-			if err != nil {
-				logger.WithError(err).Error("Giving up on DHCP, couldn't prepare resolv.conf")
-				return nil
-			}
-		}
+	err = c.dhcpApplyDNS(logger)
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCPv4, error applying DNS")
+		errorChannel <- err
+		return
 	}
 
 	// Network configuration.
@@ -402,8 +421,9 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 
 	err = addr.Add()
 	if err != nil {
-		logger.WithError(err).Error("Giving up on DHCP, couldn't add IP")
-		return nil
+		logger.WithError(err).Error("Giving up on DHCPv4, couldn't add IP")
+		errorChannel <- err
+		return
 	}
 
 	if lease.Offer.Options.Has(dhcpv4.OptionClasslessStaticRoute) {
@@ -420,8 +440,9 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 
 			err = route.Add()
 			if err != nil {
-				logger.WithError(err).Error("Giving up on DHCP, couldn't add classless static route")
-				return nil
+				logger.WithError(err).Error("Giving up on DHCPv4, couldn't add classless static route")
+				errorChannel <- err
+				return
 			}
 		}
 	} else {
@@ -434,16 +455,10 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 
 		err = route.Add()
 		if err != nil {
-			logger.WithError(err).Error("Giving up on DHCP, couldn't add default route")
-			return nil
+			logger.WithError(err).Error("Giving up on DHCPv4, couldn't add default route")
+			errorChannel <- err
+			return
 		}
-	}
-
-	// Create PID file.
-	err = os.WriteFile(filepath.Join(args[0], "dhcp.pid"), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644)
-	if err != nil {
-		logger.WithError(err).Error("Giving up on DHCP, couldn't write PID file")
-		return nil
 	}
 
 	// Handle DHCP renewal.
@@ -454,12 +469,175 @@ func (c *cmdForknet) runDHCP(_ *cobra.Command, args []string) error {
 		// Renew the lease.
 		newLease, err := client.Renew(context.Background(), lease, dhcpv4.WithOption(dhcpv4.OptHostName(hostname)))
 		if err != nil {
-			logger.WithError(err).Error("Giving up on DHCP, couldn't renew the lease")
-			return nil
+			logger.WithError(err).Error("Giving up on DHCPv4, couldn't renew the lease")
+			errorChannel <- err
+			return
 		}
 
 		lease = newLease
 	}
+}
+
+func (c *cmdForknet) dhcpRunV6(errorChannel chan error, iface string, hostname string, logger *logrus.Logger) {
+	// Get a new DHCPv6 client.
+	client, err := nclient6.New(iface)
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCPv6, couldn't set up client")
+		errorChannel <- err
+		return
+	}
+
+	defer func() { _ = client.Close() }()
+
+	// Try to get a lease.
+	advertisement, err := client.Solicit(context.Background(), dhcpv6.WithFQDN(0, hostname))
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCPv6, error during DHCPv6 Solicit")
+		errorChannel <- err
+		return
+	}
+
+	reply, err := client.Request(context.Background(), advertisement, dhcpv6.WithFQDN(0, hostname))
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCPv6, error during DHCPv6 Request")
+		errorChannel <- err
+		return
+	}
+
+	c.applyDNSMu.Lock()
+	c.dhcpv6Lease = reply
+	c.applyDNSMu.Unlock()
+
+	err = c.dhcpApplyDNS(logger)
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCPv6, error applying DNS")
+		errorChannel <- err
+		return
+	}
+
+	// Network configuration.
+	ia := reply.Options.OneIANA()
+	if ia == nil {
+		logger.Error("Giving up on DHCPv6 renewal, reply missing IANA")
+		errorChannel <- fmt.Errorf("Giving up on DHCPv6 renewal, reply missing IANA")
+		return
+	}
+
+	for _, iaaddr := range ia.Options.Addresses() {
+		addr := &ip.Addr{
+			DevName: iface,
+			Address: fmt.Sprintf("%s/64", iaaddr.IPv6Addr),
+			Family:  ip.FamilyV6,
+		}
+
+		err = addr.Add()
+		if err != nil {
+			logger.WithError(err).Error("Giving up on DHCPv6, couldn't add IP")
+			errorChannel <- err
+			return
+		}
+	}
+
+	// Handle DHCP Renewal.
+	for {
+		// Wait until it's renewal time.
+		t1 := ia.T1
+		time.Sleep(t1)
+
+		// Renew the lease.
+		var optIAAddrs []dhcpv6.OptIAAddress
+		for _, optIAAddr := range ia.Options.Addresses() {
+			optIAAddrs = append(optIAAddrs, *optIAAddr)
+		}
+
+		modifiers := []dhcpv6.Modifier{
+			dhcpv6.WithClientID(reply.Options.ClientID()),
+			dhcpv6.WithServerID(reply.Options.ServerID()),
+			dhcpv6.WithIAID(ia.IaId),
+			dhcpv6.WithIANA(optIAAddrs...),
+		}
+
+		renew, err := dhcpv6.NewMessage(modifiers...)
+		if err != nil {
+			logger.WithError(err).Error("Giving up on DHCv6, couldn't create renew message")
+			errorChannel <- err
+			return
+		}
+
+		renew.MessageType = dhcpv6.MessageTypeRenew
+
+		newReply, err := dhcpv6.NewReplyFromMessage(renew, dhcpv6.WithFQDN(0, hostname))
+		if err != nil {
+			logger.WithError(err).Error("Giving up on DHCPv6, couldn't renew the lease")
+			errorChannel <- err
+			return
+		}
+
+		reply = newReply
+	}
+}
+
+func (c *cmdForknet) dhcpApplyDNS(logger *logrus.Logger) error {
+	c.applyDNSMu.Lock()
+	defer c.applyDNSMu.Unlock()
+
+	f, err := os.Create(filepath.Join(c.instNetworkPath, "resolv.conf"))
+	if err != nil {
+		logger.WithError(err).Error("Giving up on DHCP, couldn't create resolv.conf")
+		return err
+	}
+
+	defer f.Close()
+
+	if c.dhcpv4Lease != nil {
+		if len(c.dhcpv4Lease.Offer.DNS()) > 0 {
+			for _, nameserver := range c.dhcpv4Lease.Offer.DNS() {
+				_, err = fmt.Fprintf(f, "nameserver %s\n", nameserver)
+				if err != nil {
+					logger.WithError(err).Error("Giving up on DHCPv4, couldn't prepare resolv.conf")
+					return err
+				}
+			}
+
+			if c.dhcpv4Lease.Offer.DomainName() != "" {
+				_, err = fmt.Fprintf(f, "domain %s\n", c.dhcpv4Lease.Offer.DomainName())
+				if err != nil {
+					logger.WithError(err).Error("Giving up on DHCPv4, couldn't prepare resolv.conf")
+					return err
+				}
+			}
+
+			if c.dhcpv4Lease.Offer.DomainSearch() != nil && len(c.dhcpv4Lease.Offer.DomainSearch().Labels) > 0 {
+				_, err = fmt.Fprintf(f, "search %s\n", strings.Join(c.dhcpv4Lease.Offer.DomainSearch().Labels, ", "))
+				if err != nil {
+					logger.WithError(err).Error("Giving up on DHCPv4, couldn't prepare resolv.conf")
+					return err
+				}
+			}
+		}
+	}
+
+	if c.dhcpv6Lease != nil {
+		if len(c.dhcpv6Lease.Options.DNS()) > 0 {
+			for _, nameserver := range c.dhcpv6Lease.Options.DNS() {
+				_, err = fmt.Fprintf(f, "nameserver %s\n", nameserver)
+				if err != nil {
+					logger.WithError(err).Error("Giving up on DHCPv6, couldn't prepare resolv.conf")
+					return err
+				}
+			}
+
+			if c.dhcpv6Lease.Options.DomainSearchList() != nil && len(c.dhcpv6Lease.Options.DomainSearchList().Labels) > 0 {
+				_, err = fmt.Fprintf(f, "search %s\n", strings.Join(c.dhcpv6Lease.Options.DomainSearchList().Labels, ", "))
+				if err != nil {
+					logger.WithError(err).Error("Giving up on DHCPv6, couldn't prepare resolv.conf")
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *cmdForknet) runDetach(_ *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR addresses #1869

The main differences between nclient4 and nclient6 is that:
- nclient6 does not have a Lease struct, but rather works with dhcpv6.Message (the final Reply in the Solicit -> Advertisement -> Request -> Reply conversation)
- It doesn't seem like router information is provided in the Reply, so that's not added in the network configuration
- There is no Renew() function in nclient6 like there is in nclient4, so a Renew message is manually created and sent