### PR TITLE
Allow for direct S3 push of instance and custom volume backups

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2821,3 +2821,7 @@ network forward.
 ## `network_physical_gateway_hwaddr`
 
 Allows setting the MAC address of the IPv4 and IPv6 gateways when used with OVN.
+
+## `backup_s3_upload`
+
+Adds support for immediately uploading instance or volume backups to an S3 compatible endpoint.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -25,6 +25,41 @@ definitions:
         title: AccessEntry represents an entity having access to the resource.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
+    BackupTarget:
+        properties:
+            access_key:
+                description: AccessKey is the S3 API access key
+                example: GOOG1234
+                type: string
+                x-go-name: AccessKey
+            bucket_name:
+                description: BucketName is the name of the S3 bucket.
+                example: my_bucket
+                type: string
+                x-go-name: BucketName
+            path:
+                description: Path is the target path.
+                example: foo/test.tar
+                type: string
+                x-go-name: Path
+            protocol:
+                description: Protocol is the upload protocol.
+                example: S3
+                type: string
+                x-go-name: Protocol
+            secret_key:
+                description: SecretKey is the S3 API access key
+                example: secret123
+                type: string
+                x-go-name: SecretKey
+            url:
+                description: URL is the HTTPS URL for the backup
+                example: https://storage.googleapis.com
+                type: string
+                x-go-name: URL
+        title: BackupTarget represents the target storage server for an instance or volume backup.
+        type: object
+        x-go-package: github.com/lxc/incus/v6/shared/api
     Certificate:
         description: Certificate represents a certificate
         properties:
@@ -1619,6 +1654,8 @@ definitions:
                 example: true
                 type: boolean
                 x-go-name: OptimizedStorage
+            target:
+                $ref: '#/definitions/BackupTarget'
         title: InstanceBackupsPost represents the fields available for a new instance backup.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
@@ -6550,6 +6587,8 @@ definitions:
                 example: true
                 type: boolean
                 x-go-name: OptimizedStorage
+            target:
+                $ref: '#/definitions/BackupTarget'
             volume_only:
                 description: Whether to ignore snapshots
                 example: false

--- a/internal/server/backup/backup_common.go
+++ b/internal/server/backup/backup_common.go
@@ -1,9 +1,19 @@
 package backup
 
 import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
 	"time"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+
 	"github.com/lxc/incus/v6/internal/server/state"
+	"github.com/lxc/incus/v6/shared/api"
 )
 
 // WorkingDirPrefix is used when temporary working directories are needed.
@@ -39,4 +49,54 @@ func (b *CommonBackup) SetCompressionAlgorithm(compression string) {
 // optimization supported by the storage driver.
 func (b *CommonBackup) OptimizedStorage() bool {
 	return b.optimizedStorage
+}
+
+// upload handles backup uploads.
+func (b *CommonBackup) upload(filePath string, req *api.BackupTarget) error {
+	if req.Protocol != "s3" {
+		return fmt.Errorf("Unsupported backup target protocol %q", req.Protocol)
+	}
+
+	// Set up an S3 client.
+	uri, err := url.Parse(req.URL)
+	if err != nil {
+		return err
+	}
+
+	creds := credentials.NewStaticV4(req.AccessKey, req.SecretKey, "")
+
+	ts := &http.Transport{
+		MaxIdleConns:       10,
+		IdleConnTimeout:    30 * time.Second,
+		DisableCompression: true,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+		},
+	}
+
+	client, err := minio.New(uri.Host, &minio.Options{
+		BucketLookup: minio.BucketLookupPath,
+		Creds:        creds,
+		Secure:       uri.Scheme == "https",
+		Transport:    ts,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Upload the object.
+	tr, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer tr.Close()
+
+	_, err = client.PutObject(context.Background(), req.BucketName, req.Path, tr, -1, minio.PutObjectOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/server/backup/backup_instance.go
+++ b/internal/server/backup/backup_instance.go
@@ -153,3 +153,9 @@ func (b *InstanceBackup) Render() *api.InstanceBackup {
 		OptimizedStorage: b.optimizedStorage,
 	}
 }
+
+// Upload pushes the backup to external storage.
+func (b *InstanceBackup) Upload(req *api.BackupTarget) error {
+	backupPath := internalUtil.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, b.name))
+	return b.upload(backupPath, req)
+}

--- a/internal/server/backup/backup_volume.go
+++ b/internal/server/backup/backup_volume.go
@@ -148,3 +148,9 @@ func (b *VolumeBackup) Render() *api.StorageVolumeBackup {
 		OptimizedStorage: b.optimizedStorage,
 	}
 }
+
+// Upload pushes the backup to external storage.
+func (b *VolumeBackup) Upload(req *api.BackupTarget) error {
+	backupPath := internalUtil.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
+	return b.upload(backupPath, req)
+}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -486,6 +486,7 @@ var APIExtensions = []string{
 	"custom_volume_sftp",
 	"network_ovn_external_nic_address",
 	"network_physical_gateway_hwaddr",
+	"backup_s3_upload",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/api/instance_backup.go
+++ b/shared/api/instance_backup.go
@@ -4,6 +4,37 @@ import (
 	"time"
 )
 
+// BackupTarget represents the target storage server for an instance or volume backup.
+//
+// swagger:model
+//
+// API extension: backup_s3_upload.
+type BackupTarget struct {
+	// Protocol is the upload protocol.
+	// Example: S3
+	Protocol string `json:"protocol" yaml:"protocol"`
+
+	// URL is the HTTPS URL for the backup
+	// Example: https://storage.googleapis.com
+	URL string `json:"url" yaml:"url"`
+
+	// BucketName is the name of the S3 bucket.
+	// Example: my_bucket
+	BucketName string `json:"bucket_name" yaml:"bucket_name"`
+
+	// Path is the target path.
+	// Example: foo/test.tar
+	Path string `json:"path" yaml:"path"`
+
+	// AccessKey is the S3 API access key
+	// Example: GOOG1234
+	AccessKey string `json:"access_key" yaml:"access_key"`
+
+	// SecretKey is the S3 API access key
+	// Example: secret123
+	SecretKey string `json:"secret_key" yaml:"secret_key"`
+}
+
 // InstanceBackupsPost represents the fields available for a new instance backup.
 //
 // swagger:model
@@ -31,6 +62,12 @@ type InstanceBackupsPost struct {
 	//
 	// API extension: backup_compression_algorithm
 	CompressionAlgorithm string `json:"compression_algorithm" yaml:"compression_algorithm"`
+
+	// External upload target
+	// The backup will be uploaded and then deleted from local storage.
+	//
+	// API extension: backup_s3_upload
+	Target *BackupTarget `json:"target" yaml:"target"`
 }
 
 // InstanceBackup represents an instance backup.

--- a/shared/api/storage_pool_volume_backup.go
+++ b/shared/api/storage_pool_volume_backup.go
@@ -56,6 +56,12 @@ type StorageVolumeBackupsPost struct {
 	// What compression algorithm to use
 	// Example: gzip
 	CompressionAlgorithm string `json:"compression_algorithm" yaml:"compression_algorithm"`
+
+	// External upload target
+	// The backup will be uploaded and then deleted from local storage.
+	//
+	// API extension: backup_s3_upload
+	Target *BackupTarget `json:"target" yaml:"target"`
 }
 
 // StorageVolumeBackupPost represents the fields available for the renaming of a volume backup


### PR DESCRIPTION
Extended backup APIs to support uploading instance and custom volume backups to an S3 bucket, deleting the local backup afterwards.