### PR TITLE
Handle parent=none for physical networks

### DIFF
--- a/cmd/incusd/networks.go
+++ b/cmd/incusd/networks.go
@@ -459,6 +459,11 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		// A targetNode was specified, let's just define the node's network without actually creating it.
 		// Check that only NodeSpecificNetworkConfig keys are specified.
 		for key := range req.Config {
+			// Special-case: allow "parent=none". Used to indicate that this node should not act as a gateway chassis.
+			if key == "parent" && req.Config[key] == "none" {
+				continue
+			}
+
 			if !slices.Contains(db.NodeSpecificNetworkConfig, key) {
 				return response.BadRequest(fmt.Errorf("Config key %q may not be used as member-specific key", key))
 			}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -3399,6 +3399,11 @@ func (n *ovn) Rename(newName string) error {
 // chassisEnabled checks the cluster config to see if this particular
 // member should act as an OVN chassis.
 func (n *ovn) chassisEnabled(ctx context.Context, tx *db.ClusterTx) (bool, error) {
+	// If parent is "none", this network is standalone and should not act as a chassis.
+	if n.config["parent"] == "none" {
+		return false, nil
+	}
+
 	// Get the member info.
 	memberID := tx.GetNodeID()
 	members, err := tx.GetNodes(ctx)
@@ -3445,6 +3450,13 @@ func (n *ovn) Start() error {
 	var err error
 
 	reverter.Add(func() { n.setUnavailable() })
+
+	// Skip full start logic if parent=none.
+	if n.config["parent"] == "none" {
+		n.logger.Info("Skipping OVN Start due to parent=none", logger.Ctx{"project": n.project, "name": n.name})
+		n.setAvailable()
+		return nil
+	}
 
 	// Check that uplink network is available.
 	if n.config["network"] != "" && n.config["network"] != "none" && !IsAvailable(api.ProjectDefaultName, n.config["network"]) {


### PR DESCRIPTION
These are the following steps I took to handle the issue. Please let me know if there are any problems or changes I should implement. Thank you!

Part (1): Skip uplink IP allocation when parent == "none"
* File: internal/server/network/network_ovn.go
* Function: setupUplinkPort()
* Change:
    * Added a continue to skip uplinkAllocateIP logic if parent == "none".
    * Ensures we don't try to allocate uplink IPs when the uplink network is intentionally disabled.
Part (2): Avoid startUplinkPort() when parent == "none"
* File: internal/server/network/network_ovn.go
* Function: Start()
* Change:
    * Early return (return nil) if n.config["parent"] == "none" before calling startUplinkPort() and BGP logic.
    * Prevents unnecessary OVN uplink initialization when there's no external network.
Part (3): Avoid joining chassis group when parent == "none"
* File: internal/server/network/network_ovn.go
* Function: chassisEnabled()
* Change:
    * Added conditional check: if n.config["parent"] == "none", return false.
    * Ensures we don't participate in OVN chassis groups in this disabled uplink mode.