### PR TITLE
incusd/firewall/nftables: disable UDP checksum validation for packets on bridged network

### DIFF
--- a/internal/server/firewall/drivers/drivers_nftables_templates.go
+++ b/internal/server/firewall/drivers/drivers_nftables_templates.go
@@ -51,6 +51,7 @@ chain in{{.chainSeparator}}{{.networkName}} {
 	{{ if eq . "ip" }}
 	iifname "{{$.networkName}}" icmp type {3, 11, 12} accept
 	iifname "{{$.networkName}}" udp dport 67 accept
+	iifname "{{$.networkName}}" ip protocol udp udp checksum set 0
 	{{ else }}
 	iifname "{{$.networkName}}" icmpv6 type {1, 2, 3, 4, 133, 135, 136, 143} accept
 	iifname "{{$.networkName}}" udp dport 547 accept
@@ -68,6 +69,7 @@ chain out{{.chainSeparator}}{{.networkName}} {
 	{{ if eq . "ip" }}
 	oifname "{{$.networkName}}" icmp type {3, 11, 12} accept
 	oifname "{{$.networkName}}" udp sport 67 accept
+	oifname "{{$.networkName}}" ip protocol udp udp checksum set 0
 	{{ else }}
 	oifname "{{$.networkName}}" icmpv6 type {1, 2, 3, 4, 128, 134, 135, 136, 143} accept
 	oifname "{{$.networkName}}" udp sport 547 accept


### PR DESCRIPTION
Before:
```
sudo nft list ruleset
table inet incus {
...................
        chain in.incusbr0 {
                type filter hook input priority filter; policy accept;
                iifname "incusbr0" tcp dport 53 accept
                iifname "incusbr0" udp dport 53 accept
                iifname "incusbr0" icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
                iifname "incusbr0" udp dport 67 accept
                iifname "incusbr0" icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-solicit, nd-neighbor-solicit, nd-neighbor-advert, mld2-listener-report } accept
                iifname "incusbr0" udp dport 547 accept
        }

        chain out.incusbr0 {
                type filter hook output priority filter; policy accept;
                oifname "incusbr0" tcp sport 53 accept
                oifname "incusbr0" udp sport 53 accept
                oifname "incusbr0" icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
                oifname "incusbr0" udp sport 67 accept
                oifname "incusbr0" icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, mld2-listener-report } accept
                oifname "incusbr0" udp sport 547 accept
        }
}
```
After:
```
sudo nft list ruleset # check if rule exists

table inet incus {
...................
        chain in.incusbr0 {
                type filter hook input priority filter; policy accept;
                iifname "incusbr0" tcp dport 53 accept
                iifname "incusbr0" udp dport 53 accept
                iifname "incusbr0" icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
                iifname "incusbr0" udp dport 67 accept
                iifname "incusbr0" ip protocol udp udp checksum set 0
                iifname "incusbr0" icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, nd-router-solicit, nd-neighbor-solicit, nd-neighbor-advert, mld2-listener-report } accept
                iifname "incusbr0" udp dport 547 accept
        }

        chain out.incusbr0 {
                type filter hook output priority filter; policy accept;
                oifname "incusbr0" tcp sport 53 accept
                oifname "incusbr0" udp sport 53 accept
                oifname "incusbr0" icmp type { destination-unreachable, time-exceeded, parameter-problem } accept
                oifname "incusbr0" udp sport 67 accept
                oifname "incusbr0" ip protocol udp udp checksum set 0
                oifname "incusbr0" icmpv6 type { destination-unreachable, packet-too-big, time-exceeded, parameter-problem, echo-request, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, mld2-listener-report } accept
                oifname "incusbr0" udp sport 547 accept
        }
}
```

**What was changed?**
- Following guidance from https://github.com/lxc/incus/issues/1997 with an additional change to disable checksum validation for both input and output.
- For `nftables`, we're calling networkSetupICMPDHCPDNSAccess which then runs the nftablesNetICMPDHCPDNS template.
- Hence, we extended this template to add the recommended rule in the IPv4 case.
- To recap, suggested rule from issue: `nft insert rule inet incus out.incusbr0 index 0 oifname "incusbr0" ip protocol udp udp checksum set 0;`

**Tests Done**
- build complete fine
- Applied `incusd` on test system and confirmed that new rule was put in place