### PR TITLE
client: Fix required extension for GetNetworkAddressSetsAllProjects

### DIFF
--- a/client/incus_network_address_sets.go
+++ b/client/incus_network_address_sets.go
@@ -44,8 +44,8 @@ func (r *ProtocolIncus) GetNetworkAddressSets() ([]api.NetworkAddressSet, error)
 
 // GetNetworkAddressSetsAllProjects returns a list of network address set structs across all projects.
 func (r *ProtocolIncus) GetNetworkAddressSetsAllProjects() ([]api.NetworkAddressSet, error) {
-	if !r.HasExtension("network_address_sets_all_projects") {
-		return nil, fmt.Errorf(`The server is missing the required "network_address_sets_all_projects" API extension`)
+	if !r.HasExtension("network_address_set") {
+		return nil, fmt.Errorf(`The server is missing the required "network_address_set" API extension`)
 	}
 
 	addressSets := []api.NetworkAddressSet{}


### PR DESCRIPTION
There is no extension with the name `network_address_sets_all_projects` defined. Since all the methods have been added together in the same version, there is no reason to distinguish between `network_address_sets_all_projects` and `network_address_set`.